### PR TITLE
Form element height fixes.

### DIFF
--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -20,7 +20,7 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
       >
         <Icon
           name={icon}
-          size="md"
+          size="sm"
         />
       </Button>
     );

--- a/src/components/SplitButton/SplitButton.tsx
+++ b/src/components/SplitButton/SplitButton.tsx
@@ -95,7 +95,10 @@ export const SplitButton = ({
           data-testid="split-button-dropdown"
         >
           <span>
-            <Icon name="chevron-down" />
+            <Icon
+              name="chevron-down"
+              size="sm"
+            />
           </span>
         </SecondaryButton>
       </SplitButtonTrigger>

--- a/src/styles/types.ts
+++ b/src/styles/types.ts
@@ -476,6 +476,23 @@
             "text": {
               "default": string
             }
+          },
+          "ghost": {
+            "background": {
+              "default": string,
+              "hover": string,
+              "active": string
+            },
+            "stroke": {
+              "default": string,
+              "hover": string,
+              "active": string
+            },
+            "text": {
+              "default": string,
+              "hover": string,
+              "active": string
+            }
           }
         }
       },
@@ -538,10 +555,26 @@
           }
         }
       },
-      "button-group": {
+      "group": {
         "radii": {
           "center": string,
           "end": string
+        },
+        "color": {
+          "background": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "panel": string
+          },
+          "text": {
+            "default": string,
+            "hover": string,
+            "active": string
+          },
+          "stroke": {
+            "panel": string
+          }
         }
       },
       "alignLeft": {
@@ -568,24 +601,6 @@
               "hover": string,
               "active": string
             }
-          }
-        }
-      },
-      "group": {
-        "color": {
-          "background": {
-            "default": string,
-            "hover": string,
-            "active": string,
-            "panel": string
-          },
-          "text": {
-            "default": string,
-            "hover": string,
-            "active": string
-          },
-          "stroke": {
-            "panel": string
           }
         }
       },
@@ -1425,22 +1440,6 @@
               "height": string,
               "width": string
             }
-          },
-          "color": {
-            "background": {
-              "active": string,
-              "hover": string,
-              "default": string
-            },
-            "text": {
-              "default": string,
-              "hover": string,
-              "active": string,
-              "muted": string
-            },
-            "icon": {
-              "default": string
-            }
           }
         },
         "title": {
@@ -1449,11 +1448,6 @@
             "hover": string,
             "active": string,
             "disabled": string
-          },
-          "color": {
-            "default": string,
-            "hover": string,
-            "active": string
           }
         },
         "subItem": {
@@ -1485,27 +1479,12 @@
             "hover": string,
             "active": string,
             "disabled": string
-          },
-          "color": {
-            "text": {
-              "default": string,
-              "hover": string,
-              "active": string
-            },
-            "background": {
-              "default": string,
-              "hover": string,
-              "active": string
-            }
           }
         },
         "dragControl": {
           "separator": {
             "size": {
               "height": string
-            },
-            "color": {
-              "default": string
             }
           }
         }
@@ -1522,6 +1501,54 @@
           "stroke": {
             "default": string
           }
+        },
+        "navigation": {
+          "item": {
+            "color": {
+              "background": {
+                "active": string,
+                "hover": string,
+                "default": string
+              },
+              "text": {
+                "default": string,
+                "hover": string,
+                "active": string,
+                "muted": string
+              },
+              "icon": {
+                "default": string
+              }
+            }
+          },
+          "title": {
+            "color": {
+              "default": string,
+              "hover": string,
+              "active": string
+            }
+          },
+          "subItem": {
+            "color": {
+              "text": {
+                "default": string,
+                "hover": string,
+                "active": string
+              },
+              "background": {
+                "default": string,
+                "hover": string,
+                "active": string
+              }
+            }
+          },
+          "dragControl": {
+            "separator": {
+              "color": {
+                "default": string
+              }
+            }
+          }
         }
       },
       "sqlSidebar": {
@@ -1531,6 +1558,54 @@
           },
           "stroke": {
             "default": string
+          }
+        },
+        "navigation": {
+          "item": {
+            "color": {
+              "background": {
+                "active": string,
+                "hover": string,
+                "default": string
+              },
+              "text": {
+                "default": string,
+                "hover": string,
+                "active": string,
+                "muted": string
+              },
+              "icon": {
+                "default": string
+              }
+            }
+          },
+          "title": {
+            "color": {
+              "default": string,
+              "hover": string,
+              "active": string
+            }
+          },
+          "subItem": {
+            "color": {
+              "text": {
+                "default": string,
+                "hover": string,
+                "active": string
+              },
+              "background": {
+                "default": string,
+                "hover": string,
+                "active": string
+              }
+            }
+          },
+          "dragControl": {
+            "separator": {
+              "color": {
+                "default": string
+              }
+            }
           }
         }
       }

--- a/src/styles/variables.classic.json
+++ b/src/styles/variables.classic.json
@@ -117,6 +117,23 @@
             "text": {
               "default": "#c10000"
             }
+          },
+          "ghost": {
+            "background": {
+              "default": "rgba(0,0,0,0)",
+              "hover": "rgba(0,0,0,0)",
+              "active": "rgb(0% 0% 0% / 0)"
+            },
+            "stroke": {
+              "default": "rgba(0,0,0,0)",
+              "hover": "rgba(0,0,0,0)",
+              "active": "rgba(0,0,0,0)"
+            },
+            "text": {
+              "default": "#696e79",
+              "hover": "#161517",
+              "active": "#161517"
+            }
           }
         }
       },
@@ -168,10 +185,10 @@
       "group": {
         "color": {
           "background": {
-            "default": "#ffffff",
-            "hover": "lch(68.1 1.1 272)",
-            "active": "lch(81 1.31 272)",
-            "panel": "#ffffff"
+            "default": "lch(100 0 0)",
+            "hover": "lch(97.4 1.44 272)",
+            "active": "lch(95.3 1.54 272)",
+            "panel": "lch(100 0 0)"
           },
           "text": {
             "default": "#161517",
@@ -216,54 +233,6 @@
       }
     },
     "sidebar": {
-      "navigation": {
-        "item": {
-          "color": {
-            "background": {
-              "active": "lch(38.8 16.8 296 / 0.6)",
-              "hover": "lch(40.9 16.2 296)",
-              "default": "rgba(0,0,0,0)"
-            },
-            "text": {
-              "default": "#f6f7fa",
-              "hover": "#ffffff",
-              "active": "#ffffff",
-              "muted": "#696e79"
-            },
-            "icon": {
-              "default": "#e4e2e9"
-            }
-          }
-        },
-        "title": {
-          "color": {
-            "default": "#ada8bd",
-            "hover": "#ada8bd",
-            "active": "#ada8bd"
-          }
-        },
-        "subItem": {
-          "color": {
-            "text": {
-              "default": "#f6f7fa",
-              "hover": "#ffffff",
-              "active": "#ffffff"
-            },
-            "background": {
-              "default": "rgba(0,0,0,0)",
-              "hover": "lch(40.9 16.2 296)",
-              "active": "rgba(0,0,0,0)"
-            }
-          }
-        },
-        "dragControl": {
-          "separator": {
-            "color": {
-              "default": "#FFC029"
-            }
-          }
-        }
-      },
       "main": {
         "color": {
           "background": {
@@ -279,6 +248,22 @@
         },
         "navigation": {
           "item": {
+            "color": {
+              "background": {
+                "active": "lch(38.8 16.8 296 / 0.6)",
+                "hover": "lch(40.9 16.2 296)",
+                "default": "rgba(0,0,0,0)"
+              },
+              "text": {
+                "default": "#f6f7fa",
+                "hover": "#ffffff",
+                "active": "#ffffff",
+                "muted": "#696e79"
+              },
+              "icon": {
+                "default": "#e4e2e9"
+              }
+            },
             "background": {
               "default": "rgba(0,0,0,0)",
               "active": "#474257",
@@ -287,6 +272,92 @@
             "text": {
               "default": "#ffffff",
               "muted": "#ada8bd"
+            }
+          },
+          "title": {
+            "color": {
+              "default": "#ada8bd",
+              "hover": "#ada8bd",
+              "active": "#ada8bd"
+            }
+          },
+          "subItem": {
+            "color": {
+              "text": {
+                "default": "#f6f7fa",
+                "hover": "#ffffff",
+                "active": "#ffffff"
+              },
+              "background": {
+                "default": "rgba(0,0,0,0)",
+                "hover": "lch(40.9 16.2 296)",
+                "active": "rgba(0,0,0,0)"
+              }
+            }
+          },
+          "dragControl": {
+            "separator": {
+              "color": {
+                "default": "#FFC029"
+              }
+            }
+          }
+        }
+      },
+      "sqlSidebar": {
+        "color": {
+          "background": {
+            "default": "#f6f7fa"
+          },
+          "stroke": {
+            "default": "lch(91.6 1.1 266)"
+          }
+        },
+        "navigation": {
+          "item": {
+            "color": {
+              "background": {
+                "active": "lch(91.6 1.1 266 / 0.6)",
+                "hover": "lch(91.6 1.1 266 / 0.6)",
+                "default": "rgba(0,0,0,0)"
+              },
+              "text": {
+                "default": "#161517",
+                "hover": "#161517",
+                "active": "#161517",
+                "muted": "#696e79"
+              },
+              "icon": {
+                "default": "#696e79"
+              }
+            }
+          },
+          "title": {
+            "color": {
+              "default": "#696e79",
+              "hover": "#696e79",
+              "active": "#696e79"
+            }
+          },
+          "subItem": {
+            "color": {
+              "text": {
+                "default": "#696e79",
+                "hover": "#ffffff",
+                "active": "#161517"
+              },
+              "background": {
+                "default": "rgba(0,0,0,0)",
+                "hover": "lch(40.9 16.2 296)",
+                "active": "rgba(0,0,0,0)"
+              }
+            }
+          },
+          "dragControl": {
+            "separator": {
+              "color": {
+                "default": "#161517"
+              }
             }
           }
         }

--- a/src/styles/variables.dark.json
+++ b/src/styles/variables.dark.json
@@ -229,6 +229,23 @@
             "text": {
               "default": "#ff7575"
             }
+          },
+          "ghost": {
+            "background": {
+              "default": "rgba(0,0,0,0)",
+              "hover": "rgba(0,0,0,0)",
+              "active": "rgb(0% 0% 0% / 0)"
+            },
+            "stroke": {
+              "default": "rgba(0,0,0,0)",
+              "hover": "rgba(0,0,0,0)",
+              "active": "rgba(0,0,0,0)"
+            },
+            "text": {
+              "default": "#b3b6bd",
+              "hover": "#ffffff",
+              "active": "#ffffff"
+            }
           }
         }
       },
@@ -271,10 +288,10 @@
       "group": {
         "color": {
           "background": {
-            "default": "#282828",
-            "hover": "lch(19.3 0 0)",
-            "active": "lch(23.4 0 0)",
-            "panel": "#282828"
+            "default": "lch(18.2 0 0)",
+            "hover": "lch(22.8 0 0)",
+            "active": "#414141",
+            "panel": "lch(18.2 0 0)"
           },
           "text": {
             "default": "#ffffff",
@@ -663,54 +680,6 @@
       }
     },
     "sidebar": {
-      "navigation": {
-        "item": {
-          "color": {
-            "background": {
-              "active": "lch(27.5 0 0 / 0.6)",
-              "hover": "lch(19.1 0 0)",
-              "default": "rgba(0,0,0,0)"
-            },
-            "text": {
-              "default": "#ffffff",
-              "hover": "#ffffff",
-              "active": "#ffffff",
-              "muted": "#b3b6bd"
-            },
-            "icon": {
-              "default": "#b3b6bd"
-            }
-          }
-        },
-        "title": {
-          "color": {
-            "default": "#b3b6bd",
-            "hover": "#b3b6bd",
-            "active": "#b3b6bd"
-          }
-        },
-        "subItem": {
-          "color": {
-            "text": {
-              "default": "#b3b6bd",
-              "hover": "#ffffff",
-              "active": "#ffffff"
-            },
-            "background": {
-              "default": "rgba(0,0,0,0)",
-              "hover": "lch(19.1 0 0)",
-              "active": "rgba(0,0,0,0)"
-            }
-          }
-        },
-        "dragControl": {
-          "separator": {
-            "color": {
-              "default": "#FAFF69"
-            }
-          }
-        }
-      },
       "main": {
         "color": {
           "background": {
@@ -723,6 +692,54 @@
           "stroke": {
             "default": "lch(27.5 0 0 / 0.3)"
           }
+        },
+        "navigation": {
+          "item": {
+            "color": {
+              "background": {
+                "active": "lch(27.5 0 0 / 0.6)",
+                "hover": "lch(19.1 0 0)",
+                "default": "rgba(0,0,0,0)"
+              },
+              "text": {
+                "default": "#ffffff",
+                "hover": "#ffffff",
+                "active": "#ffffff",
+                "muted": "#b3b6bd"
+              },
+              "icon": {
+                "default": "#b3b6bd"
+              }
+            }
+          },
+          "title": {
+            "color": {
+              "default": "#b3b6bd",
+              "hover": "#b3b6bd",
+              "active": "#b3b6bd"
+            }
+          },
+          "subItem": {
+            "color": {
+              "text": {
+                "default": "#b3b6bd",
+                "hover": "#ffffff",
+                "active": "#ffffff"
+              },
+              "background": {
+                "default": "rgba(0,0,0,0)",
+                "hover": "lch(19.1 0 0)",
+                "active": "rgba(0,0,0,0)"
+              }
+            }
+          },
+          "dragControl": {
+            "separator": {
+              "color": {
+                "default": "#FAFF69"
+              }
+            }
+          }
         }
       },
       "sqlSidebar": {
@@ -732,6 +749,54 @@
           },
           "stroke": {
             "default": "lch(27.5 0 0 / 0.3)"
+          }
+        },
+        "navigation": {
+          "item": {
+            "color": {
+              "background": {
+                "active": "lch(27.5 0 0 / 0.6)",
+                "hover": "lch(19.1 0 0)",
+                "default": "rgba(0,0,0,0)"
+              },
+              "text": {
+                "default": "#ffffff",
+                "hover": "#ffffff",
+                "active": "#ffffff",
+                "muted": "#b3b6bd"
+              },
+              "icon": {
+                "default": "#b3b6bd"
+              }
+            }
+          },
+          "title": {
+            "color": {
+              "default": "#b3b6bd",
+              "hover": "#b3b6bd",
+              "active": "#b3b6bd"
+            }
+          },
+          "subItem": {
+            "color": {
+              "text": {
+                "default": "#b3b6bd",
+                "hover": "#ffffff",
+                "active": "#ffffff"
+              },
+              "background": {
+                "default": "rgba(0,0,0,0)",
+                "hover": "lch(19.1 0 0)",
+                "active": "rgba(0,0,0,0)"
+              }
+            }
+          },
+          "dragControl": {
+            "separator": {
+              "color": {
+                "default": "#FAFF69"
+              }
+            }
           }
         }
       }

--- a/src/styles/variables.json
+++ b/src/styles/variables.json
@@ -307,7 +307,7 @@
       "basic": {
         "space": {
           "x": "1rem",
-          "y": "0.344rem",
+          "y": "0.281rem",
           "gap": "0.5rem",
           "group": "0.5rem"
         },
@@ -399,8 +399,8 @@
       "iconButton": {
         "default": {
           "space": {
-            "x": "0.5rem",
-            "y": "0.5rem"
+            "x": "0.438rem",
+            "y": "0.438rem"
           }
         },
         "size": {
@@ -475,6 +475,23 @@
             "text": {
               "default": "#c10000"
             }
+          },
+          "ghost": {
+            "background": {
+              "default": "rgba(0,0,0,0)",
+              "hover": "rgba(0,0,0,0)",
+              "active": "rgb(0% 0% 0% / 0)"
+            },
+            "stroke": {
+              "default": "rgba(0,0,0,0)",
+              "hover": "rgba(0,0,0,0)",
+              "active": "rgba(0,0,0,0)"
+            },
+            "text": {
+              "default": "#696e79",
+              "hover": "#161517",
+              "active": "#161517"
+            }
           }
         }
       },
@@ -482,7 +499,7 @@
       "split": {
         "icon": {
           "space": {
-            "y": "0.516rem",
+            "y": "0.438rem",
             "x": "0.344rem"
           }
         },
@@ -537,10 +554,26 @@
           }
         }
       },
-      "button-group": {
+      "group": {
         "radii": {
           "center": "0",
           "end": "0.25rem"
+        },
+        "color": {
+          "background": {
+            "default": "lch(94.5 0.72 266)",
+            "hover": "lch(97.4 1.44 272)",
+            "active": "#ffffff",
+            "panel": "lch(94.5 0.72 266)"
+          },
+          "text": {
+            "default": "#161517",
+            "hover": "#161517",
+            "active": "#151515"
+          },
+          "stroke": {
+            "panel": "lch(91.6 1.1 266)"
+          }
         }
       },
       "alignLeft": {
@@ -567,24 +600,6 @@
               "hover": "500 1rem/1.5 \"Inter\", '\"SF Pro Display\"', -apple-system, BlinkMacSystemFont, '\"Segoe UI\"', Roboto, Oxygen, Ubuntu, Cantarell, '\"Open Sans\"', '\"Helvetica Neue\"', sans-serif;",
               "active": "600 1rem/1.5 \"Inter\", '\"SF Pro Display\"', -apple-system, BlinkMacSystemFont, '\"Segoe UI\"', Roboto, Oxygen, Ubuntu, Cantarell, '\"Open Sans\"', '\"Helvetica Neue\"', sans-serif;"
             }
-          }
-        }
-      },
-      "group": {
-        "color": {
-          "background": {
-            "default": "#ffffff",
-            "hover": "lch(68.1 1.1 272)",
-            "active": "lch(81 1.31 272)",
-            "panel": "#ffffff"
-          },
-          "text": {
-            "default": "#161517",
-            "hover": "#161517",
-            "active": "#151515"
-          },
-          "stroke": {
-            "panel": "lch(91.6 1.1 266)"
           }
         }
       },
@@ -987,7 +1002,7 @@
       },
       "space": {
         "x": "0.75rem",
-        "y": "0.344rem",
+        "y": "0.281rem",
         "gap": "0.5rem"
       },
       "size": {
@@ -1387,7 +1402,7 @@
           "default": {
             "space": {
               "right": "0.75rem",
-              "y": "0.344rem",
+              "y": "0.281rem",
               "gap": "0.75rem",
               "left": "0"
             }
@@ -1415,7 +1430,7 @@
             "space": {
               "left": "0",
               "right": "0.75rem",
-              "y": "0.344rem",
+              "y": "0.281rem",
               "gap": "0.75rem"
             }
           },
@@ -1423,22 +1438,6 @@
             "size": {
               "height": "1rem",
               "width": "1rem"
-            }
-          },
-          "color": {
-            "background": {
-              "active": "lch(91.6 1.1 266 / 0.6)",
-              "hover": "lch(91.6 1.1 266 / 0.6)",
-              "default": "rgba(0,0,0,0)"
-            },
-            "text": {
-              "default": "#161517",
-              "hover": "#161517",
-              "active": "#161517",
-              "muted": "#696e79"
-            },
-            "icon": {
-              "default": "#696e79"
             }
           }
         },
@@ -1448,11 +1447,6 @@
             "hover": "500 0.75rem/1.5 \"Inter\", '\"SF Pro Display\"', -apple-system, BlinkMacSystemFont, '\"Segoe UI\"', Roboto, Oxygen, Ubuntu, Cantarell, '\"Open Sans\"', '\"Helvetica Neue\"', sans-serif;",
             "active": "500 0.75rem/1.5 \"Inter\", '\"SF Pro Display\"', -apple-system, BlinkMacSystemFont, '\"Segoe UI\"', Roboto, Oxygen, Ubuntu, Cantarell, '\"Open Sans\"', '\"Helvetica Neue\"', sans-serif;",
             "disabled": "500 0.75rem/1.5 \"Inter\", '\"SF Pro Display\"', -apple-system, BlinkMacSystemFont, '\"Segoe UI\"', Roboto, Oxygen, Ubuntu, Cantarell, '\"Open Sans\"', '\"Helvetica Neue\"', sans-serif;"
-          },
-          "color": {
-            "default": "#696e79",
-            "hover": "#696e79",
-            "active": "#696e79"
           }
         },
         "subItem": {
@@ -1460,7 +1454,7 @@
             "space": {
               "left": "2.75rem",
               "right": "0.75rem",
-              "y": "0.344rem"
+              "y": "0.281rem"
             }
           },
           "mobile": {
@@ -1484,27 +1478,12 @@
             "hover": "400 0.875rem/1.5 \"Inter\", '\"SF Pro Display\"', -apple-system, BlinkMacSystemFont, '\"Segoe UI\"', Roboto, Oxygen, Ubuntu, Cantarell, '\"Open Sans\"', '\"Helvetica Neue\"', sans-serif;",
             "active": "500 0.875rem/1.5 \"Inter\", '\"SF Pro Display\"', -apple-system, BlinkMacSystemFont, '\"Segoe UI\"', Roboto, Oxygen, Ubuntu, Cantarell, '\"Open Sans\"', '\"Helvetica Neue\"', sans-serif;",
             "disabled": "500 0.875rem/1.5 \"Inter\", '\"SF Pro Display\"', -apple-system, BlinkMacSystemFont, '\"Segoe UI\"', Roboto, Oxygen, Ubuntu, Cantarell, '\"Open Sans\"', '\"Helvetica Neue\"', sans-serif;"
-          },
-          "color": {
-            "text": {
-              "default": "#696e79",
-              "hover": "#161517",
-              "active": "#161517"
-            },
-            "background": {
-              "default": "rgba(0,0,0,0)",
-              "hover": "lch(91.6 1.1 266 / 0.6)",
-              "active": "rgba(0,0,0,0)"
-            }
           }
         },
         "dragControl": {
           "separator": {
             "size": {
               "height": "0.125rem"
-            },
-            "color": {
-              "default": "#161517"
             }
           }
         }
@@ -1521,6 +1500,54 @@
           "stroke": {
             "default": "lch(91.6 1.1 266)"
           }
+        },
+        "navigation": {
+          "item": {
+            "color": {
+              "background": {
+                "active": "lch(91.6 1.1 266 / 0.6)",
+                "hover": "lch(91.6 1.1 266 / 0.6)",
+                "default": "rgba(0,0,0,0)"
+              },
+              "text": {
+                "default": "#161517",
+                "hover": "#161517",
+                "active": "#161517",
+                "muted": "#696e79"
+              },
+              "icon": {
+                "default": "#696e79"
+              }
+            }
+          },
+          "title": {
+            "color": {
+              "default": "#696e79",
+              "hover": "#696e79",
+              "active": "#696e79"
+            }
+          },
+          "subItem": {
+            "color": {
+              "text": {
+                "default": "#696e79",
+                "hover": "#161517",
+                "active": "#161517"
+              },
+              "background": {
+                "default": "rgba(0,0,0,0)",
+                "hover": "lch(91.6 1.1 266 / 0.6)",
+                "active": "rgba(0,0,0,0)"
+              }
+            }
+          },
+          "dragControl": {
+            "separator": {
+              "color": {
+                "default": "#161517"
+              }
+            }
+          }
         }
       },
       "sqlSidebar": {
@@ -1530,6 +1557,54 @@
           },
           "stroke": {
             "default": "lch(91.6 1.1 266)"
+          }
+        },
+        "navigation": {
+          "item": {
+            "color": {
+              "background": {
+                "active": "lch(91.6 1.1 266 / 0.6)",
+                "hover": "lch(91.6 1.1 266 / 0.6)",
+                "default": "rgba(0,0,0,0)"
+              },
+              "text": {
+                "default": "#161517",
+                "hover": "#161517",
+                "active": "#161517",
+                "muted": "#696e79"
+              },
+              "icon": {
+                "default": "#696e79"
+              }
+            }
+          },
+          "title": {
+            "color": {
+              "default": "#696e79",
+              "hover": "#696e79",
+              "active": "#696e79"
+            }
+          },
+          "subItem": {
+            "color": {
+              "text": {
+                "default": "#696e79",
+                "hover": "#161517",
+                "active": "#161517"
+              },
+              "background": {
+                "default": "rgba(0,0,0,0)",
+                "hover": "lch(91.6 1.1 266 / 0.6)",
+                "active": "rgba(0,0,0,0)"
+              }
+            }
+          },
+          "dragControl": {
+            "separator": {
+              "color": {
+                "default": "#161517"
+              }
+            }
           }
         }
       }

--- a/src/styles/variables.json
+++ b/src/styles/variables.json
@@ -574,22 +574,6 @@
           "stroke": {
             "panel": "lch(91.6 1.1 266)"
           }
-        },
-        "color": {
-          "background": {
-            "default": "lch(91.8 1.07 266)",
-            "hover": "lch(97.4 1.45 272)",
-            "active": "#ffffff",
-            "panel": "lch(91.8 1.07 266)"
-          },
-          "text": {
-            "default": "#161517",
-            "hover": "#161517",
-            "active": "#151515"
-          },
-          "stroke": {
-            "panel": "lch(91.6 1.1 266)"
-          }
         }
       },
       "alignLeft": {

--- a/src/styles/variables.light.json
+++ b/src/styles/variables.light.json
@@ -229,6 +229,23 @@
             "text": {
               "default": "#c10000"
             }
+          },
+          "ghost": {
+            "background": {
+              "default": "rgba(0,0,0,0)",
+              "hover": "rgba(0,0,0,0)",
+              "active": "rgb(0% 0% 0% / 0)"
+            },
+            "stroke": {
+              "default": "rgba(0,0,0,0)",
+              "hover": "rgba(0,0,0,0)",
+              "active": "rgba(0,0,0,0)"
+            },
+            "text": {
+              "default": "#696e79",
+              "hover": "#161517",
+              "active": "#161517"
+            }
           }
         }
       },
@@ -271,10 +288,10 @@
       "group": {
         "color": {
           "background": {
-            "default": "#ffffff",
-            "hover": "lch(68.1 1.1 272)",
-            "active": "lch(81 1.31 272)",
-            "panel": "#ffffff"
+            "default": "lch(94.5 0.72 266)",
+            "hover": "lch(97.4 1.44 272)",
+            "active": "#ffffff",
+            "panel": "lch(94.5 0.72 266)"
           },
           "text": {
             "default": "#161517",
@@ -659,54 +676,6 @@
       }
     },
     "sidebar": {
-      "navigation": {
-        "item": {
-          "color": {
-            "background": {
-              "active": "lch(91.6 1.1 266 / 0.6)",
-              "hover": "lch(91.6 1.1 266 / 0.6)",
-              "default": "rgba(0,0,0,0)"
-            },
-            "text": {
-              "default": "#161517",
-              "hover": "#161517",
-              "active": "#161517",
-              "muted": "#696e79"
-            },
-            "icon": {
-              "default": "#696e79"
-            }
-          }
-        },
-        "title": {
-          "color": {
-            "default": "#696e79",
-            "hover": "#696e79",
-            "active": "#696e79"
-          }
-        },
-        "subItem": {
-          "color": {
-            "text": {
-              "default": "#696e79",
-              "hover": "#161517",
-              "active": "#161517"
-            },
-            "background": {
-              "default": "rgba(0,0,0,0)",
-              "hover": "lch(91.6 1.1 266 / 0.6)",
-              "active": "rgba(0,0,0,0)"
-            }
-          }
-        },
-        "dragControl": {
-          "separator": {
-            "color": {
-              "default": "#161517"
-            }
-          }
-        }
-      },
       "main": {
         "color": {
           "background": {
@@ -719,6 +688,54 @@
           "stroke": {
             "default": "lch(91.6 1.1 266)"
           }
+        },
+        "navigation": {
+          "item": {
+            "color": {
+              "background": {
+                "active": "lch(91.6 1.1 266 / 0.6)",
+                "hover": "lch(91.6 1.1 266 / 0.6)",
+                "default": "rgba(0,0,0,0)"
+              },
+              "text": {
+                "default": "#161517",
+                "hover": "#161517",
+                "active": "#161517",
+                "muted": "#696e79"
+              },
+              "icon": {
+                "default": "#696e79"
+              }
+            }
+          },
+          "title": {
+            "color": {
+              "default": "#696e79",
+              "hover": "#696e79",
+              "active": "#696e79"
+            }
+          },
+          "subItem": {
+            "color": {
+              "text": {
+                "default": "#696e79",
+                "hover": "#161517",
+                "active": "#161517"
+              },
+              "background": {
+                "default": "rgba(0,0,0,0)",
+                "hover": "lch(91.6 1.1 266 / 0.6)",
+                "active": "rgba(0,0,0,0)"
+              }
+            }
+          },
+          "dragControl": {
+            "separator": {
+              "color": {
+                "default": "#161517"
+              }
+            }
+          }
         }
       },
       "sqlSidebar": {
@@ -728,6 +745,54 @@
           },
           "stroke": {
             "default": "lch(91.6 1.1 266)"
+          }
+        },
+        "navigation": {
+          "item": {
+            "color": {
+              "background": {
+                "active": "lch(91.6 1.1 266 / 0.6)",
+                "hover": "lch(91.6 1.1 266 / 0.6)",
+                "default": "rgba(0,0,0,0)"
+              },
+              "text": {
+                "default": "#161517",
+                "hover": "#161517",
+                "active": "#161517",
+                "muted": "#696e79"
+              },
+              "icon": {
+                "default": "#696e79"
+              }
+            }
+          },
+          "title": {
+            "color": {
+              "default": "#696e79",
+              "hover": "#696e79",
+              "active": "#696e79"
+            }
+          },
+          "subItem": {
+            "color": {
+              "text": {
+                "default": "#696e79",
+                "hover": "#161517",
+                "active": "#161517"
+              },
+              "background": {
+                "default": "rgba(0,0,0,0)",
+                "hover": "lch(91.6 1.1 266 / 0.6)",
+                "active": "rgba(0,0,0,0)"
+              }
+            }
+          },
+          "dragControl": {
+            "separator": {
+              "color": {
+                "default": "#161517"
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
### Summary
The buttons and field heights were coming out to 34px instead of 32px as the are in figma. It's due to the 1px border, originally I thought that this could be fixed with `box-sizing: border` but alas it can not be. This PR updates the tokens on these components so the the Y paddings are reduced to recalculate the heights to 32px. I also noticed we were using the `md` size icon for buttons which is incorrect.