### PR TITLE
Adding Ghost iconButton.

### DIFF
--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -5,7 +5,7 @@ import styled from "styled-components";
 export interface IconButtonProps extends HTMLAttributes<HTMLButtonElement> {
   size?: "sm" | "xs";
   disabled?: boolean;
-  type?: "primary" | "secondary";
+  type?: "primary" | "secondary" | "ghost";
   icon: IconName;
 }
 
@@ -34,13 +34,13 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
 IconButton.displayName = "IconButton";
 
 const Button = styled.button<{
-  $styleType?: "primary" | "secondary";
+  $styleType?: "primary" | "secondary" | "ghost";
   $size?: "sm" | "xs";
 }>`
   ${({ theme, $size, $styleType = "primary" }) => `
   border-radius: ${theme.click.button.iconButton.radii.all};
   border: ${theme.click.button.stroke} solid ${
-    theme.click.button.iconButton.color.primary.stroke.default
+    theme.click.button.iconButton.color[$styleType].stroke.default
   };
   cursor: pointer;
   padding: ${
@@ -68,6 +68,7 @@ const Button = styled.button<{
   &[disabled] {
     background-color: ${theme.click.button.iconButton.color.disabled.background.default};
     color: ${theme.click.button.iconButton.color.disabled.text.default};
+    cursor: not-allowed;
   }
   `}
 `;

--- a/src/styles/variables.dark.json
+++ b/src/styles/variables.dark.json
@@ -214,10 +214,10 @@
           },
           "disabled": {
             "background": {
-              "default": "#dfdfdf"
+              "default": "#414141"
             },
             "text": {
-              "default": "#a0a0a0"
+              "default": "#808080"
             }
           },
           "danger": {
@@ -433,7 +433,7 @@
           "default": "#ffffff",
           "hover": "#ffffff",
           "active": "#151515",
-          "disabled": "#a0a0a0"
+          "disabled": "#808080"
         },
         "label": {
           "default": "#ffffff",
@@ -668,7 +668,7 @@
           "default": "#1F1F1C",
           "hover": "#282828",
           "active": "#151515",
-          "disabled": "#a0a0a0"
+          "disabled": "#808080"
         }
       }
     },


### PR DESCRIPTION
### Summary
This PR adds the `Ghost` iconButton, this is essentially is a button with no border that has a low opacity, the opacity increases when hovered. This can be used for flouts, modals, and other things.

**Note:** This PR also fixes the `disabled` state in dark mode, which was a mess. 

#### Before
<img width="257" alt="CleanShot 2023-09-18 at 16 45 50@2x" src="https://github.com/ClickHouse/click-ui/assets/305167/9df94352-0906-4311-93c2-5c7ee913ecfc">


#### After
<img width="275" alt="CleanShot 2023-09-18 at 16 45 59@2x" src="https://github.com/ClickHouse/click-ui/assets/305167/04b1f4f0-750b-4d15-a365-42d6f4c5a128">



 