### PR TITLE
Add highlight feature without error message

### DIFF
--- a/src/components/Input/InputWrapper.tsx
+++ b/src/components/Input/InputWrapper.tsx
@@ -77,27 +77,26 @@ export interface WrapperProps {
 export const InputWrapper = ({
   id,
   label = "",
-  error = "",
+  error,
   disabled,
   children,
   orientation,
   dir,
 }: WrapperProps) => {
-  const showError = error ? typeof error === "string" && error.length !== 0 : false;
   return (
     <FormRoot
       $orientation={orientation}
       $dir={dir}
     >
       <FormElementContainer>
-        <Wrapper $error={showError}>{children}</Wrapper>
-        {showError && <Error>{error}</Error>}
+        <Wrapper $error={!!error}>{children}</Wrapper>
+        {!!error && error !== true && <Error>{error}</Error>}
       </FormElementContainer>
       {label && (
         <Label
           htmlFor={id}
           disabled={disabled}
-          error={showError}
+          error={!!error}
         >
           {label}
         </Label>

--- a/src/components/Select/common/InternalSelect.tsx
+++ b/src/components/Select/common/InternalSelect.tsx
@@ -463,7 +463,7 @@ export const InternalSelect = ({
             </SelectPopoverContent>
           </Portal>
         </SelectPopoverRoot>
-        {!!error && <Error>{error}</Error>}
+        {!!error && error !== true && <Error>{error}</Error>}
       </FormElementContainer>
       {label && (
         <Label


### PR DESCRIPTION
Add coded to show highlighted error when the error is boolean and no error message is present
This is used in console create table and clickpipes etc

<img width="1444" alt="Screenshot 2023-09-28 at 14 19 28" src="https://github.com/ClickHouse/click-ui/assets/17908918/fdc8d391-3211-48aa-8e70-bcfc0fedc24b">
<img width="1432" alt="Screenshot 2023-09-28 at 14 18 48" src="https://github.com/ClickHouse/click-ui/assets/17908918/9a0fb015-385f-4b99-8f09-6b2441752b1a">
