### PR TITLE
Add options to hide data present in option in trigger

### DIFF
--- a/src/components/Select/common/SelectStyled.tsx
+++ b/src/components/Select/common/SelectStyled.tsx
@@ -77,6 +77,9 @@ export const StyledSelectTrigger = styled(Trigger)<{ $error: boolean }>`
       cursor: not-allowed;
     }
   `}
+  [data-hide-in-trigger] {
+    display: none;
+  }
 `;
 
 export const SelectPopoverContent = styled(Content)`


### PR DESCRIPTION
In order for some content to be present in the options but not in the trigger element a dataset is added

https://github.com/ClickHouse/click-ui/assets/17908918/cbb9441a-1929-4c5a-833a-f90ab9fbf5f8

