### PR TITLE
Add element wrapper to asChild elements

### DIFF
--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,17 +1,21 @@
 import { DropdownMenuProps } from "@radix-ui/react-dropdown-menu";
 import { Dropdown } from "./Dropdown";
 import { GridCenter } from "../commonElement";
+import { Button } from "..";
 
 interface Props extends DropdownMenuProps {
   disabled?: boolean;
   showArrow?: boolean;
   side: "top" | "right" | "left" | "bottom";
+  type: "text" | "button";
 }
-const DropdownExample = ({ showArrow, disabled, side, ...props }: Props) => {
+const DropdownExample = ({ showArrow, disabled, side, type, ...props }: Props) => {
   return (
     <GridCenter>
       <Dropdown {...props}>
-        <Dropdown.Trigger disabled={disabled}>Dropdown Trigger</Dropdown.Trigger>
+        <Dropdown.Trigger disabled={disabled}>
+          {type === "text" ? "Dropdown Trigger" : <Button>Dropdown Trigger</Button>}
+        </Dropdown.Trigger>
         <Dropdown.Content
           showArrow={showArrow}
           side={side}
@@ -57,11 +61,13 @@ export default {
     defaultOpen: { control: "boolean" },
     showArrow: { control: "boolean" },
     side: { control: "select", options: ["top", "right", "left", "bottom"] },
+    type: { control: "inline-radio", options: ["text", "button"] },
   },
 };
 
 export const Playground = {
   args: {
     side: "bottom",
+    type: "text",
   },
 };

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -11,9 +11,7 @@ const DropdownExample = ({ showArrow, disabled, side, ...props }: Props) => {
   return (
     <GridCenter>
       <Dropdown {...props}>
-        <Dropdown.Trigger disabled={disabled}>
-          <div>Dropdown Trigger</div>
-        </Dropdown.Trigger>
+        <Dropdown.Trigger disabled={disabled}>Dropdown Trigger</Dropdown.Trigger>
         <Dropdown.Content
           showArrow={showArrow}
           side={side}

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -9,7 +9,7 @@ interface Props extends DropdownMenuProps {
   side: "top" | "right" | "left" | "bottom";
   type: "text" | "button";
 }
-const DropdownExample = ({ showArrow, disabled, side, type, ...props }: Props) => {
+const DropdownExample = ({ showArrow, disabled, side, ...props }: Props) => {
   return (
     <GridCenter>
       <Dropdown {...props}>

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -13,8 +13,42 @@ const DropdownExample = ({ showArrow, disabled, side, type, ...props }: Props) =
   return (
     <GridCenter>
       <Dropdown {...props}>
+        <Dropdown.Trigger disabled={disabled}>Dropdown Trigger</Dropdown.Trigger>
+        <Dropdown.Content
+          showArrow={showArrow}
+          side={side}
+        >
+          <Dropdown.Group>
+            <Dropdown.Item>Content0</Dropdown.Item>
+          </Dropdown.Group>
+          <Dropdown.Item icon="activity">Content1 long text content</Dropdown.Item>
+          <Dropdown.Sub>
+            <Dropdown.Trigger sub>Hover over</Dropdown.Trigger>
+            <Dropdown.Content sub>
+              <Dropdown.Item>SubContent0</Dropdown.Item>
+              <Dropdown.Item>SubContent1</Dropdown.Item>
+              <Dropdown.Item>SubContent0</Dropdown.Item>
+              <Dropdown.Item>SubContent1</Dropdown.Item>
+              <Dropdown.Item>SubContent0</Dropdown.Item>
+              <Dropdown.Item>SubContent1</Dropdown.Item>
+              <Dropdown.Item>SubContent0</Dropdown.Item>
+              <Dropdown.Item>SubContent1</Dropdown.Item>
+              <Dropdown.Item>SubContent0</Dropdown.Item>
+              <Dropdown.Item>SubContent1</Dropdown.Item>
+            </Dropdown.Content>
+          </Dropdown.Sub>
+          <Dropdown.Item
+            icon="activity"
+            iconDir="end"
+          >
+            Content2
+          </Dropdown.Item>
+          <Dropdown.Item disabled>Content3</Dropdown.Item>
+        </Dropdown.Content>
+      </Dropdown>
+      <Dropdown {...props}>
         <Dropdown.Trigger disabled={disabled}>
-          {type === "text" ? "Dropdown Trigger" : <Button>Dropdown Trigger</Button>}
+          <Button>Dropdown Trigger Button</Button>
         </Dropdown.Trigger>
         <Dropdown.Content
           showArrow={showArrow}
@@ -68,6 +102,5 @@ export default {
 export const Playground = {
   args: {
     side: "bottom",
-    type: "text",
   },
 };

--- a/src/components/Dropdown/Dropdown.test.tsx
+++ b/src/components/Dropdown/Dropdown.test.tsx
@@ -20,9 +20,7 @@ describe("Dropdown", () => {
   const renderDropdown = ({ disabled, ...props }: Props) =>
     renderCUI(
       <Dropdown {...props}>
-        <Dropdown.Trigger disabled={disabled}>
-          <div>Dropdown Trigger</div>
-        </Dropdown.Trigger>
+        <Dropdown.Trigger disabled={disabled}>Dropdown Trigger</Dropdown.Trigger>
         <Dropdown.Content>
           <Dropdown.Group>
             <Dropdown.Item>Content0</Dropdown.Item>

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -4,7 +4,7 @@ import { HorizontalDirection, Icon, IconName } from "@/components";
 import { Arrow, GenericMenuItem, GenericMenuPanel } from "../GenericMenu";
 import PopoverArrow from "../icons/PopoverArrow";
 import IconWrapper from "../IconWrapper/IconWrapper";
-import { HTMLAttributes } from "react";
+import { EmptyButton } from "../commonElement";
 
 export const Dropdown = (props: DropdownMenu.DropdownMenuProps) => (
   <DropdownMenu.Root {...props} />
@@ -62,9 +62,13 @@ const DropdownTrigger = ({
       </DropdownMenuItem>
     );
   }
+  const { disabled, ...otherProps } = props as DropdownTriggerProps;
   return (
-    <Trigger asChild>
-      <div {...(props as HTMLAttributes<HTMLDivElement>)} />
+    <Trigger
+      asChild
+      disabled={disabled}
+    >
+      <EmptyButton {...otherProps} />
     </Trigger>
   );
 };

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -36,6 +36,9 @@ type DropdownTriggerProps = DropdownMenu.DropdownMenuTriggerProps & MainDropdown
 const Trigger = styled(DropdownMenu.Trigger)`
   cursor: pointer;
   width: fit-content;
+  &[disabled] {
+    cursor: not-allowed;
+  }
 `;
 
 const DropdownTrigger = ({

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -4,6 +4,7 @@ import { HorizontalDirection, Icon, IconName } from "@/components";
 import { Arrow, GenericMenuItem, GenericMenuPanel } from "../GenericMenu";
 import PopoverArrow from "../icons/PopoverArrow";
 import IconWrapper from "../IconWrapper/IconWrapper";
+import { HTMLAttributes } from "react";
 
 export const Dropdown = (props: DropdownMenu.DropdownMenuProps) => (
   <DropdownMenu.Root {...props} />
@@ -62,10 +63,9 @@ const DropdownTrigger = ({
     );
   }
   return (
-    <Trigger
-      asChild
-      {...(props as DropdownTriggerProps)}
-    />
+    <Trigger asChild>
+      <div {...(props as HTMLAttributes<HTMLDivElement>)} />
+    </Trigger>
   );
 };
 

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -4,7 +4,6 @@ import { HorizontalDirection, Icon, IconName } from "@/components";
 import { Arrow, GenericMenuItem, GenericMenuPanel } from "../GenericMenu";
 import PopoverArrow from "../icons/PopoverArrow";
 import IconWrapper from "../IconWrapper/IconWrapper";
-import { EmptyButton } from "../commonElement";
 
 export const Dropdown = (props: DropdownMenu.DropdownMenuProps) => (
   <DropdownMenu.Root {...props} />
@@ -41,10 +40,11 @@ const Trigger = styled(DropdownMenu.Trigger)`
 
 const DropdownTrigger = ({
   sub,
+  children,
   ...props
 }: DropdownSubTriggerProps | DropdownTriggerProps) => {
   if (sub) {
-    const { children, icon, iconDir, ...menuProps } = props as DropdownSubTriggerProps;
+    const { icon, iconDir, ...menuProps } = props as DropdownSubTriggerProps;
     return (
       <DropdownMenuItem
         as={DropdownMenu.SubTrigger}
@@ -62,13 +62,13 @@ const DropdownTrigger = ({
       </DropdownMenuItem>
     );
   }
-  const { disabled, ...otherProps } = props as DropdownTriggerProps;
+
   return (
     <Trigger
       asChild
-      disabled={disabled}
+      {...(props as DropdownTriggerProps)}
     >
-      <EmptyButton {...otherProps} />
+      <div>{children}</div>
     </Trigger>
   );
 };

--- a/src/components/Label/Label.stories.tsx
+++ b/src/components/Label/Label.stories.tsx
@@ -30,7 +30,7 @@ export default {
   },
 };
 
-export const Default = {
+export const Playground = {
   args: {
     text: "Form Field label",
     error: false,

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -55,7 +55,7 @@ export default {
   },
 };
 
-export const Default = {
+export const Playground = {
   args: {
     open: "default",
     showArrow: true,

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -11,7 +11,6 @@ const PopoverComponent = ({
   showClose,
   forceMount,
   side,
-  type,
 }: {
   open: "default" | "open" | "closed";
   modal: boolean;
@@ -19,15 +18,32 @@ const PopoverComponent = ({
   showClose: boolean;
   forceMount?: boolean;
   side: "top" | "right" | "left" | "bottom";
-  type: "text" | "button";
 }) => (
   <GridCenter>
     <Popover
       open={open === "default" ? undefined : open === "open"}
       modal={modal}
     >
+      <Popover.Trigger>Click Here</Popover.Trigger>
+      <Popover.Content
+        side={side}
+        showArrow={showArrow}
+        showClose={showClose}
+        forceMount={forceMount ? true : undefined}
+      >
+        <Title type="h2">Content popover</Title>
+        <br />
+        <Text>Click on the input element below.</Text>
+        <br />
+        <Checkbox label="This is a sample data to experiment the popover" />
+      </Popover.Content>
+    </Popover>
+    <Popover
+      open={open === "default" ? undefined : open === "open"}
+      modal={modal}
+    >
       <Popover.Trigger>
-        {type === "text" ? "Click Here" : <Button>Click Here</Button>}
+        <Button>Click Here Button</Button>
       </Popover.Trigger>
       <Popover.Content
         side={side}
@@ -56,7 +72,6 @@ export default {
     showClose: { control: "boolean" },
     forceMount: { control: "boolean" },
     side: { control: "select", options: ["top", "right", "left", "bottom"] },
-    type: { control: "inline-radio", options: ["text", "button"] },
   },
 };
 
@@ -66,6 +81,5 @@ export const Playground = {
     showArrow: true,
     showClose: true,
     side: "bottom",
-    type: "text",
   },
 };

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -24,9 +24,7 @@ const PopoverComponent = ({
       open={open === "default" ? undefined : open === "open"}
       modal={modal}
     >
-      <Popover.Trigger>
-        <div>Click Here</div>
-      </Popover.Trigger>
+      <Popover.Trigger>Click Here</Popover.Trigger>
       <Popover.Content
         side={side}
         showArrow={showArrow}

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -1,4 +1,4 @@
-import { Checkbox } from "..";
+import { Button, Checkbox } from "..";
 import { GridCenter } from "../commonElement";
 import { Text } from "../Typography/Text/Text";
 import { Title } from "../Typography/Title/Title";
@@ -11,6 +11,7 @@ const PopoverComponent = ({
   showClose,
   forceMount,
   side,
+  type,
 }: {
   open: "default" | "open" | "closed";
   modal: boolean;
@@ -18,13 +19,16 @@ const PopoverComponent = ({
   showClose: boolean;
   forceMount?: boolean;
   side: "top" | "right" | "left" | "bottom";
+  type: "text" | "button";
 }) => (
   <GridCenter>
     <Popover
       open={open === "default" ? undefined : open === "open"}
       modal={modal}
     >
-      <Popover.Trigger>Click Here</Popover.Trigger>
+      <Popover.Trigger>
+        {type === "text" ? "Click Here" : <Button>Click Here</Button>}
+      </Popover.Trigger>
       <Popover.Content
         side={side}
         showArrow={showArrow}
@@ -52,6 +56,7 @@ export default {
     showClose: { control: "boolean" },
     forceMount: { control: "boolean" },
     side: { control: "select", options: ["top", "right", "left", "bottom"] },
+    type: { control: "inline-radio", options: ["text", "button"] },
   },
 };
 
@@ -61,5 +66,6 @@ export const Playground = {
     showArrow: true,
     showClose: true,
     side: "bottom",
+    type: "text",
   },
 };

--- a/src/components/Popover/Popover.test.tsx
+++ b/src/components/Popover/Popover.test.tsx
@@ -7,9 +7,7 @@ describe("Popover", () => {
   const renderPopover = (props: PopoverProps) =>
     renderCUI(
       <Popover {...props}>
-        <Popover.Trigger>
-          <div>Click Here</div>
-        </Popover.Trigger>
+        <Popover.Trigger>Click Here</Popover.Trigger>
         <Popover.Content>
           <div>
             Click on the input element below

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -20,11 +20,14 @@ interface TriggerProps extends RadixPopover.PopoverTriggerProps {
   anchor?: ReactNode;
 }
 
-const PopoverTrigger = ({ anchor, ...props }: TriggerProps) => {
+const PopoverTrigger = ({ anchor, children, ...props }: TriggerProps) => {
   return (
     <>
-      <Trigger asChild>
-        <EmptyButton {...props} />
+      <Trigger
+        asChild
+        {...props}
+      >
+        <div>{children}</div>
       </Trigger>
       {anchor && <RadixPopover.Anchor asChild>{anchor}</RadixPopover.Anchor>}
     </>

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -1,7 +1,7 @@
 import * as RadixPopover from "@radix-ui/react-popover";
 import { Arrow, GenericMenuPanel } from "../GenericMenu";
 import styled from "styled-components";
-import { HTMLAttributes, ReactNode } from "react";
+import { ReactNode } from "react";
 import { Icon } from "@/components";
 import { EmptyButton } from "../commonElement";
 import PopoverArrow from "../icons/PopoverArrow";
@@ -24,7 +24,7 @@ const PopoverTrigger = ({ anchor, ...props }: TriggerProps) => {
   return (
     <>
       <Trigger asChild>
-        <div {...(props as HTMLAttributes<HTMLDivElement>)} />
+        <EmptyButton {...props} />
       </Trigger>
       {anchor && <RadixPopover.Anchor asChild>{anchor}</RadixPopover.Anchor>}
     </>

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -12,10 +12,11 @@ export const Popover = ({ children, ...props }: RadixPopover.PopoverProps) => {
 
 const Trigger = styled(RadixPopover.Trigger)`
   width: fit-content;
-  background: transparent;
+  font: inherit;
+  color: inherit;
+  background: inherit;
   border: none;
 `;
-
 interface TriggerProps extends RadixPopover.PopoverTriggerProps {
   anchor?: ReactNode;
 }

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -1,7 +1,7 @@
 import * as RadixPopover from "@radix-ui/react-popover";
 import { Arrow, GenericMenuPanel } from "../GenericMenu";
 import styled from "styled-components";
-import { ReactNode } from "react";
+import { HTMLAttributes, ReactNode } from "react";
 import { Icon } from "@/components";
 import { EmptyButton } from "../commonElement";
 import PopoverArrow from "../icons/PopoverArrow";
@@ -20,14 +20,11 @@ interface TriggerProps extends RadixPopover.PopoverTriggerProps {
   anchor?: ReactNode;
 }
 
-const PopoverTrigger = ({ children, anchor, ...props }: TriggerProps) => {
+const PopoverTrigger = ({ anchor, ...props }: TriggerProps) => {
   return (
     <>
-      <Trigger
-        asChild
-        {...props}
-      >
-        {children}
+      <Trigger asChild>
+        <div {...(props as HTMLAttributes<HTMLDivElement>)} />
       </Trigger>
       {anchor && <RadixPopover.Anchor asChild>{anchor}</RadixPopover.Anchor>}
     </>

--- a/src/components/RadioGroup/RadioGroup.stories.tsx
+++ b/src/components/RadioGroup/RadioGroup.stories.tsx
@@ -36,7 +36,7 @@ export default {
   },
 };
 
-export const Default = {
+export const Playground = {
   args: {
     disabled: false,
   },

--- a/src/components/SidebarCollapsibleItem/SidebarCollapsibleItem.stories.tsx
+++ b/src/components/SidebarCollapsibleItem/SidebarCollapsibleItem.stories.tsx
@@ -12,7 +12,7 @@ export default {
   },
 };
 
-export const Default = {
+export const Playground = {
   args: {
     icon: "table",
     selected: false,

--- a/src/components/SidebarCollapsibleTitle/SidebarCollapsibleTitle.stories.tsx
+++ b/src/components/SidebarCollapsibleTitle/SidebarCollapsibleTitle.stories.tsx
@@ -12,7 +12,7 @@ export default {
   },
 };
 
-export const Default = {
+export const Playground = {
   args: {
     icon: "code",
     label: "Queries",

--- a/src/components/SidebarNavigationItem/SidebarNavigationItem.stories.tsx
+++ b/src/components/SidebarNavigationItem/SidebarNavigationItem.stories.tsx
@@ -12,7 +12,7 @@ export default {
   },
 };
 
-export const Default = {
+export const Playground = {
   args: {
     icon: "code-in-square",
     selected: false,

--- a/src/components/SidebarNavigationTitle/SidebarNavigationTitle.stories.tsx
+++ b/src/components/SidebarNavigationTitle/SidebarNavigationTitle.stories.tsx
@@ -12,7 +12,7 @@ export default {
   },
 };
 
-export const Default = {
+export const Playground = {
   args: {
     icon: "table",
     selected: false,

--- a/src/components/SplitButton/SplitButton.stories.tsx
+++ b/src/components/SplitButton/SplitButton.stories.tsx
@@ -11,7 +11,7 @@ const menuItems: Array<Menu> = [
   },
   {
     icon: "code",
-    iconDir: "left",
+    iconDir: "start",
     label: "Content1",
   },
   {
@@ -34,7 +34,7 @@ const menuItems: Array<Menu> = [
   },
   {
     icon: "code",
-    iconDir: "right",
+    iconDir: "end",
     label: "Content2",
   },
   {

--- a/src/components/SplitButton/SplitButton.test.tsx
+++ b/src/components/SplitButton/SplitButton.test.tsx
@@ -19,7 +19,7 @@ const menuItems: Array<Menu> = [
   },
   {
     icon: "code",
-    iconDir: "left",
+    iconDir: "start",
     label: "Content1",
   },
   {
@@ -42,7 +42,7 @@ const menuItems: Array<Menu> = [
   },
   {
     icon: "code",
-    iconDir: "right",
+    iconDir: "end",
     label: "Content2",
   },
   {

--- a/src/components/SplitButton/SplitButton.tsx
+++ b/src/components/SplitButton/SplitButton.tsx
@@ -1,15 +1,15 @@
 import { HTMLAttributes, ReactNode, useEffect, useRef, useState } from "react";
 import styled from "styled-components";
 import { DropdownMenuProps } from "@radix-ui/react-dropdown-menu";
-import { Icon, IconName, Dropdown } from "@/components";
+import { Icon, IconName, Dropdown, HorizontalDirection } from "@/components";
 import { BaseButton } from "../commonElement";
+import IconWrapper from "../IconWrapper/IconWrapper";
 
 type ButtonType = "primary" | "secondary";
-type IconDirection = "left" | "right";
 type Alignment = "center" | "left";
 type MenuItem = {
   icon?: IconName;
-  iconDir?: IconDirection;
+  iconDir?: HorizontalDirection;
   label: ReactNode;
   type?: "item";
   items?: never;
@@ -39,7 +39,7 @@ export interface SplitButtonProps
   menu: Array<Menu>;
   side?: "top" | "bottom";
   icon?: IconName;
-  iconDir?: IconDirection;
+  iconDir?: HorizontalDirection;
 }
 
 export const SplitButton = ({
@@ -56,7 +56,7 @@ export const SplitButton = ({
   align,
   children,
   icon,
-  iconDir = "left",
+  iconDir = "start",
   ...props
 }: SplitButtonProps) => {
   const ref = useRef<HTMLDivElement>(null);
@@ -103,8 +103,9 @@ export const SplitButton = ({
           <IconWrapper
             icon={icon}
             iconDir={iconDir}
-            label={children}
-          />
+          >
+            {children}
+          </IconWrapper>
         </PrimaryButton>
         <SecondaryButton
           as={Dropdown.Trigger}
@@ -142,32 +143,12 @@ const DropdownContent = styled.div<{ $width: number }>`
   min-width: ${({ $width }) => $width}px;
 `;
 
-const IconWrapper = ({ label, icon, iconDir }: Omit<MenuItem, "type" | "items">) => {
-  return (
-    <>
-      {icon && iconDir === "left" && (
-        <Icon
-          name={icon}
-          size="sm"
-        />
-      )}
-      {label}
-      {icon && iconDir === "right" && (
-        <Icon
-          name={icon}
-          size="sm"
-        />
-      )}
-    </>
-  );
-};
-
 const MenuContentItem = ({
   items = [],
   type = "item",
   label,
   icon,
-  iconDir = "left",
+  iconDir = "start",
   parentKey,
   ...props
 }: Menu & { parentKey: string }) => {
@@ -177,8 +158,9 @@ const MenuContentItem = ({
         <IconWrapper
           icon={icon}
           iconDir={iconDir}
-          label={label}
-        />
+        >
+          {label}
+        </IconWrapper>
       </Dropdown.Item>
     );
   }
@@ -205,8 +187,9 @@ const MenuContentItem = ({
           <IconWrapper
             icon={icon}
             iconDir={iconDir}
-            label={label}
-          />
+          >
+            {label}
+          </IconWrapper>
         </Dropdown.Trigger>
         <Dropdown.Content sub>
           {items.map((item, index) => (

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -9,7 +9,7 @@ export default {
 
 type Story = StoryObj<typeof Tabs>;
 
-export const Default: Story = {
+export const Playground: Story = {
   args: {
     defaultValue: "tab2",
     onValueChange: s => console.log(s),
@@ -17,13 +17,22 @@ export const Default: Story = {
     children: (
       <>
         <Tabs.TriggersList>
-          <Tabs.Trigger value="tab1" key="tab1">
+          <Tabs.Trigger
+            value="tab1"
+            key="tab1"
+          >
             tab1
           </Tabs.Trigger>
-          <Tabs.Trigger value="tab2" key="tab2">
+          <Tabs.Trigger
+            value="tab2"
+            key="tab2"
+          >
             tab2
           </Tabs.Trigger>
-          <Tabs.Trigger value="tab3" key="tab3">
+          <Tabs.Trigger
+            value="tab3"
+            key="tab3"
+          >
             tab3
           </Tabs.Trigger>
         </Tabs.TriggersList>

--- a/src/components/commonElement.tsx
+++ b/src/components/commonElement.tsx
@@ -56,6 +56,9 @@ export const EmptyButton = styled.button`
   outline: none;
   padding: 0;
   border: 0;
+  color: inherit;
+  background: inherit;
+  font: inherit;
   &:disabled {
     cursor: not-allowed;
   }


### PR DESCRIPTION
Radix UI needs the content to have a single child if used with asChild and thats why we are wrapping the elements in a div why passing the values to the div element

https://github.com/ClickHouse/click-ui/assets/17908918/bf2bf7ae-3f76-42b6-ac22-84e097e8255c

