### PR TITLE
Removing unnecessessary borders.

### DIFF
--- a/src/components/SplitButton/SplitButton.tsx
+++ b/src/components/SplitButton/SplitButton.tsx
@@ -258,7 +258,7 @@ const PrimaryButton = styled(BaseButton)<{
   $align?: Alignment;
   $fillWidth?: boolean;
 }>`
-  border: 1px solid transparent;
+  border: none;
   align-self: stretch;
   border-radius: 0;
   align-items: center;


### PR DESCRIPTION
### Summary
The split button height was totalling 34px when it should be 32px. This is because of an accidental inner border, this PR removes said border.