### PR TITLE
Add onOpenChange function as prop to select

### DIFF
--- a/src/components/Select/MultiSelect.tsx
+++ b/src/components/Select/MultiSelect.tsx
@@ -12,6 +12,7 @@ export interface MultiSelectProps
   onSelect?: (value: Array<string>) => void;
   value?: Array<string>;
   defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 export const MultiSelect = ({
@@ -20,12 +21,23 @@ export const MultiSelect = ({
   onSelect: onSelectProp,
   options,
   children,
+  onOpenChange: onOpenChangeProp,
   ...props
 }: MultiSelectProps) => {
   const [selectedValues, setSelectedValues] = useState<Array<string>>(
     valueProp ?? defaultValue ?? []
   );
   const [open, setOpen] = useState(false);
+
+  const onOpenChange = useCallback(
+    (open: boolean) => {
+      setOpen(open);
+      if (typeof onOpenChangeProp === "function") {
+        onOpenChangeProp(open);
+      }
+    },
+    [onOpenChangeProp]
+  );
 
   useEffect(() => {
     setSelectedValues(valueProp ?? []);
@@ -67,7 +79,7 @@ export const MultiSelect = ({
       onChange={onChange}
       value={valueProp ?? selectedValues}
       open={open}
-      onOpenChange={setOpen}
+      onOpenChange={onOpenChange}
       onSelect={onSelect}
       multiple
       {...conditionalProps}

--- a/src/components/Select/SingleSelect.tsx
+++ b/src/components/Select/SingleSelect.tsx
@@ -11,6 +11,7 @@ export interface SelectProps
   onSelect?: (value: string) => void;
   value?: string;
   placeholder?: string;
+  onOpenChange?: (open: boolean) => void;
 }
 
 export const Select = ({
@@ -19,6 +20,7 @@ export const Select = ({
   onSelect: onSelectProp,
   options,
   children,
+  onOpenChange: onOpenChangeProp,
   ...props
 }: SelectProps) => {
   const [selectedValues, setSelectedValues] = useState<Array<string>>(
@@ -26,9 +28,15 @@ export const Select = ({
   );
   const [open, setOpen] = useState(false);
 
-  const onOpenChange = useCallback((open: boolean) => {
-    setOpen(open);
-  }, []);
+  const onOpenChange = useCallback(
+    (open: boolean) => {
+      setOpen(open);
+      if (typeof onOpenChangeProp === "function") {
+        onOpenChangeProp(open);
+      }
+    },
+    [onOpenChangeProp]
+  );
 
   const onSelect = useCallback(
     (value: string) => {


### PR DESCRIPTION
Added onOpenChange and not open is because we don't want the user to edit the open state
The onOpenChange can be used for the tooltip or using inside the flyout absolute state where it goes to the right side when not hovered
Using this we can have the flyout to stay still when the select is opened