### PR TITLE
Adding height prop to BigStat

### DIFF
--- a/src/components/BigStat/BigStat.stories.ts
+++ b/src/components/BigStat/BigStat.stories.ts
@@ -7,11 +7,7 @@ export default {
   size: {
     options: ["lg", "sm"],
     control: { type: "radio" },
-  },
-  height: {
-    options: ["fixed", "fluid"],
-    control: { type: "radio" },
-  },
+  }
 };
 
 export const Playground = {
@@ -20,6 +16,6 @@ export const Playground = {
     title: "100%",
     state: "default",
     size: "lg",
-    height: "fixed"
+    height: ""
   },
 };

--- a/src/components/BigStat/BigStat.stories.ts
+++ b/src/components/BigStat/BigStat.stories.ts
@@ -8,6 +8,10 @@ export default {
     options: ["lg", "sm"],
     control: { type: "radio" },
   },
+  height: {
+    options: ["fixed", "fluid"],
+    control: { type: "radio" },
+  },
 };
 
 export const Playground = {
@@ -15,6 +19,7 @@ export const Playground = {
     label: "Percentage complete",
     title: "100%",
     state: "default",
-    size: "lg"
+    size: "lg",
+    height: "fixed"
   },
 };

--- a/src/components/BigStat/BigStat.tsx
+++ b/src/components/BigStat/BigStat.tsx
@@ -2,10 +2,12 @@ import styled from "styled-components";
 
 export type bigStatState = "default";
 export type bigStatSize = "sm" | "lg";
+export type bigStatHeight = "fixed" | "fluid";
 
 export interface BigStatProps {
   label: React.ReactNode;
   title: React.ReactNode;
+  height?: bigStatHeight;
   state?: bigStatState;
   size?: bigStatSize;
 }
@@ -14,12 +16,14 @@ export interface BigStatProps {
 export const BigStat = ({
   label = "Label",
   title = "Title",
+  height = "fixed",
   size,
   state,
 }: BigStatProps) => (
   <Wrapper
     $state={state}
     $size={size}
+    $height={height}
   >
     <Label
       $state={state}
@@ -39,9 +43,12 @@ export const BigStat = ({
 const Wrapper = styled.div<{
   $state?: bigStatState;
   $size?: bigStatSize;
+  $height?: bigStatHeight;
 }>`
   display: flex;
-  ${({ $state = "default", $size = "lg", theme }) => `
+  justify-content: center;
+  box-sizing: border-box;
+  ${({ $state = "default", $size = "lg", $height = "fixed", theme }) => `
     background-color: ${theme.click.bigStat.color.background[$state]};
     color: ${theme.click.bigStat.color.label[$state]};
     font: ${theme.click.bigStat.typography[$size].label[$state]};
@@ -50,7 +57,8 @@ const Wrapper = styled.div<{
     theme.click.bigStat.color.stroke[$state]
   };
     gap: ${theme.click.bigStat.space.gap};
-    padding: ${theme.click.bigStat.space.all};
+    padding: ${$height === "fixed" ? `0 ${theme.click.bigStat.space.all}` : theme.click.bigStat.space.all};
+    min-height: ${$height === "fixed" ? theme.click.bigStat.size.height : "auto"};
     flex-direction: ${$size === "sm" ? "column-reverse" : "column"};
   `}
 `;

--- a/src/components/BigStat/BigStat.tsx
+++ b/src/components/BigStat/BigStat.tsx
@@ -7,7 +7,7 @@ export type bigStatHeight = "fixed" | "fluid";
 export interface BigStatProps {
   label: React.ReactNode;
   title: React.ReactNode;
-  height?: bigStatHeight;
+  height?: string;
   state?: bigStatState;
   size?: bigStatSize;
 }
@@ -16,7 +16,7 @@ export interface BigStatProps {
 export const BigStat = ({
   label = "Label",
   title = "Title",
-  height = "fixed",
+  height = "6rem",
   size,
   state,
 }: BigStatProps) => (
@@ -43,7 +43,7 @@ export const BigStat = ({
 const Wrapper = styled.div<{
   $state?: bigStatState;
   $size?: bigStatSize;
-  $height?: bigStatHeight;
+  $height?: number;
 }>`
   display: flex;
   justify-content: center;
@@ -58,7 +58,7 @@ const Wrapper = styled.div<{
   };
     gap: ${theme.click.bigStat.space.gap};
     padding: ${$height === "fixed" ? `0 ${theme.click.bigStat.space.all}` : theme.click.bigStat.space.all};
-    min-height: ${$height === "fixed" ? theme.click.bigStat.size.height : "auto"};
+    min-height: ${$height !== undefined ? `${$height}` : "auto"};
     flex-direction: ${$size === "sm" ? "column-reverse" : "column"};
   `}
 `;

--- a/src/styles/variables.json
+++ b/src/styles/variables.json
@@ -283,7 +283,7 @@
         }
       },
       "size": {
-        "height": "6rem"
+        "height": "96px"
       },
       "color": {
         "stroke": {


### PR DESCRIPTION
### Summary
This PR adds the ability to set a manual height for the `bigStat` component if you would like to. By default, `bigStat` has a padding of 1rem; however, should you need `bigStat` to have a specific height, you can enter it, in pixels, ems, rems, or percentage, and the content will remain vertically centred. 

#### Preview

https://github.com/ClickHouse/click-ui/assets/305167/16b0cb83-1222-4688-9e10-2d5c03c6ee9d

