### PR TITLE
Adding different options for PanelRadii

### DIFF
--- a/src/components/Panel/Panel.stories.tsx
+++ b/src/components/Panel/Panel.stories.tsx
@@ -11,6 +11,10 @@ export default {
       options: ["none", "xs", "sm", "md", "lg", "xl"],
       control: { type: "select" },
     },
+    radii: {
+      options: ["none", "sm", "md", "lg"],
+      control: { type: "select" },
+    },
   },
 };
 
@@ -20,6 +24,7 @@ export const Playground = {
     color: "default",
     padding: "md",
     hasBorder: true,
+    radii: "sm",
     hasShadow: true,
     fillWidth: false,
     height: "",

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 
 export type PanelPadding = "none" | "xs" | "sm" | "md" | "lg" | "xl";
 export type PanelColor = "default" | "muted" | "transparent";
+export type PanelRadii = "none" |"sm" | "md" | "lg"
 type AlignItemsOption = "start" | "center" | "end";
 
 export interface PanelProps extends HTMLAttributes<HTMLDivElement> {
@@ -12,6 +13,7 @@ export interface PanelProps extends HTMLAttributes<HTMLDivElement> {
   color?: PanelColor;
   padding?: PanelPadding;
   children?: React.ReactNode;
+  radii?: PanelRadii;
   orientation?: Orientation;
   width?: string;
   fillWidth?: boolean;
@@ -28,6 +30,7 @@ export const Panel = ({
   children,
   orientation = "horizontal",
   width,
+  radii = "sm",
   fillWidth,
   height,
   fillHeight,
@@ -40,6 +43,7 @@ export const Panel = ({
     $color={color}
     $padding={padding}
     $width={width}
+    $radii={radii}
     $orientation={orientation}
     $fillWidth={fillWidth}
     $height={height}
@@ -57,6 +61,7 @@ const Wrapper = styled.div<{
   $color?: PanelColor;
   $padding?: PanelPadding;
   $width?: string;
+  $radii?: PanelRadii;
   $fillWidth?: boolean;
   $height?: string;
   $fillHeight?: boolean;
@@ -72,7 +77,7 @@ const Wrapper = styled.div<{
   height: ${({ $height, $fillHeight }) => ($fillHeight ? "100%" : $height)};
   background-color: ${({ $color = "default", theme }) =>
     theme.click.panel.color.background[$color]};
-  border-radius: ${({ theme }) => theme.click.panel.radii.all};
+  border-radius: ${({ $radii = "sm", theme }) => theme.click.panel.radii[$radii]};
   padding: ${({ $padding = "md", theme }) => theme.click.panel.space.y[$padding]};
   border: ${({ $hasBorder, theme }) =>
     $hasBorder ? `1px solid ${theme.click.global.color.stroke.default}` : "none"};

--- a/src/styles/types.ts
+++ b/src/styles/types.ts
@@ -283,9 +283,6 @@
           }
         }
       },
-      "size": {
-        "height": string
-      },
       "color": {
         "stroke": {
           "default": string
@@ -1355,7 +1352,10 @@
         "default": string
       },
       "radii": {
-        "all": string
+        "none": string,
+        "sm": string,
+        "md": string,
+        "lg": string
       },
       "stroke": {
         "default": string
@@ -2698,6 +2698,7 @@
       "0": string,
       "1": string,
       "2": string,
+      "3": string,
       "full": string
     },
     "width": {

--- a/src/styles/variables.json
+++ b/src/styles/variables.json
@@ -282,9 +282,6 @@
           }
         }
       },
-      "size": {
-        "height": "6rem"
-      },
       "color": {
         "stroke": {
           "default": "lch(91.6 1.1 266)"
@@ -1354,7 +1351,10 @@
         "default": "1px"
       },
       "radii": {
-        "all": "0.25rem"
+        "none": "0",
+        "sm": "0.25rem",
+        "md": "0.5rem",
+        "lg": "0.75rem"
       },
       "stroke": {
         "default": "1px solid lch(91.6 1.1 266)"
@@ -2697,6 +2697,7 @@
       "0": "0",
       "1": "0.25rem",
       "2": "0.5rem",
+      "3": "0.75rem",
       "full": "9999px"
     },
     "width": {


### PR DESCRIPTION
### Summary
This PR adds the ability to adjust the border radii of the `Panel` component. Now you can choose between 
`none`, 0px 
`sm` 4px (default)
`md` 8px 
`lg` 12px

#### Preview
https://github.com/ClickHouse/click-ui/assets/305167/44d9130e-e2a1-443b-a1ca-abdd3ffb0e42

