### PR TITLE
Add component to text component

### DIFF
--- a/src/components/Typography/Text/Text.tsx
+++ b/src/components/Typography/Text/Text.tsx
@@ -15,7 +15,7 @@ export interface TextProps<T extends ElementType> {
   size?: TextSize;
   weight?: TextWeight;
   className?: string;
-  component: T;
+  component?: T;
 }
 
 /** Component for writing blocks of body copy */

--- a/src/components/Typography/Text/Text.tsx
+++ b/src/components/Typography/Text/Text.tsx
@@ -1,21 +1,39 @@
-import { HTMLAttributes, forwardRef } from "react";
+import {
+  ComponentPropsWithRef,
+  ComponentPropsWithoutRef,
+  ElementType,
+  forwardRef,
+} from "react";
 import styled from "styled-components";
 
 export type TextColor = "default" | "muted";
 export type TextSize = "xs" | "sm" | "md" | "lg";
 export type TextWeight = "normal" | "medium" | "semibold" | "bold" | "mono";
 
-export interface TextProps extends HTMLAttributes<HTMLParagraphElement> {
+export interface TextProps<T extends ElementType> {
   color?: TextColor;
   size?: TextSize;
   weight?: TextWeight;
   className?: string;
+  component: T;
 }
 
 /** Component for writing blocks of body copy */
-const _Text = forwardRef<HTMLParagraphElement, TextProps>(
-  ({ color, size, weight, className, children, ...props }, ref) => (
+const _Text = forwardRef(
+  <T extends ElementType = "p">(
+    {
+      color,
+      size,
+      weight,
+      className,
+      children,
+      component,
+      ...props
+    }: TextProps<T> & ComponentPropsWithoutRef<T>,
+    ref: ComponentPropsWithRef<T>["ref"]
+  ) => (
     <CuiText
+      as={component}
       ref={ref}
       $color={color}
       $size={size}


### PR DESCRIPTION
This is to fix the paragraph-inside-paragraph errors
We allow components and we can add span or div accordingly