### PR TITLE
Removing accidental lineheight declaration.

### DIFF
--- a/src/components/Typography/Title/Title.tsx
+++ b/src/components/Typography/Title/Title.tsx
@@ -39,5 +39,4 @@ const CuiTitle = styled.div<{
   margin: 0;
   padding: 0;
   font-style: inherit;
-  line-height: 1;
 `;


### PR DESCRIPTION
### Summary
The title line-height, which is passed through tokens, was being overwritten by this property in the `title` component. This was causing issues when the title dropped to two lines. 