### PR TITLE
Adding visited state to link and specific colour for card icon.

### DIFF
--- a/src/components/CardSecondary/CardSecondary.tsx
+++ b/src/components/CardSecondary/CardSecondary.tsx
@@ -42,6 +42,13 @@ const HeaderLeft = styled.div<{ $disabled?: boolean }>`
         ? theme.click.global.color.text.muted
         : theme.click.global.color.text.default};
   }
+
+  svg {
+    color: ${({ $disabled, theme }) =>
+      $disabled == true
+        ? theme.click.global.color.text.muted
+        : theme.click.global.color.text.default};
+  }
 `;
 
 const Content = styled.div`

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -45,7 +45,6 @@ const CuiLink = styled.a<{ $size: TextSize; $weight: TextWeight }>`
 
   &:visited {
     color: ${({ theme }) => theme.click.global.color.text.link.default};
-    text-decoration: underline;
   }
 `;
 

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -42,6 +42,11 @@ const CuiLink = styled.a<{ $size: TextSize; $weight: TextWeight }>`
     text-decoration: underline;
     cursor: pointer;
   }
+
+  &:visited {
+    color: ${({ theme }) => theme.click.global.color.text.link.default};
+    text-decoration: underline;
+  }
 `;
 
 const IconWrapper = styled.span<{ $size: TextSize }>`


### PR DESCRIPTION
### Summary
We needed to a visited state to our links. For now, I've made them the same as non-visited links. For regular websites, this isn't ideal accessibility, however for web-apps, this is perfectly fine behaviour. I've also added a colour for the card icons, so that it doesn't inherited browser default blue when used as a link.