### PR TITLE
Style: Add Table width to headers and showHeader tag

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -143,9 +143,11 @@ const TableRow = styled.tr<{
   $isDeleted?: boolean;
   $isDisabled?: boolean;
   $showActions?: boolean;
+  $rowHeight?: string;
 }>`
   overflow: hidden;
-  ${({ theme, $isDeleted, $isDisabled }) => `
+  ${({ theme, $isDeleted, $isDisabled, $rowHeight }) => `
+    ${$rowHeight ? `height: ${$rowHeight};` : ""}
     background-color: ${theme.click.table.row.color.background.default};
     border-bottom: ${theme.click.table.cell.stroke} solid ${
     theme.click.table.row.color.stroke.default
@@ -349,6 +351,7 @@ interface CommonTableProps
   noDataMessage?: ReactNode;
   size?: TableSize;
   showHeader?: boolean;
+  rowHeight?: string;
 }
 
 type SelectReturnValue = {
@@ -379,6 +382,7 @@ interface TableBodyRowProps extends Omit<TableRowType, "id"> {
   onEdit?: () => void;
   actionsList: Array<string>;
   size: TableSize;
+  rowHeight?: string;
 }
 
 const TableText = styled.div`
@@ -400,6 +404,7 @@ const TableBodyRow = ({
   isDisabled,
   size,
   actionsList,
+  rowHeight,
   ...rowProps
 }: TableBodyRowProps) => {
   const isDeletable = typeof onDelete === "function";
@@ -410,6 +415,7 @@ const TableBodyRow = ({
       $isDeleted={isDeleted}
       $isDisabled={isDisabled}
       $showActions={isDeletable || isEditable}
+      $rowHeight={rowHeight}
       {...rowProps}
     >
       {isSelectable && (
@@ -520,6 +526,7 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
       noDataMessage,
       size = "sm",
       showHeader = true,
+      rowHeight,
       ...props
     },
     ref
@@ -630,6 +637,7 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
                     isEditable ? () => onEdit({ id, ...rowProps }, rowIndex) : undefined
                   }
                   size={size}
+                  rowHeight={rowHeight}
                   {...rowProps}
                 />
               ))}

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -18,7 +18,6 @@ const StyledHeader = styled.th<{ $size: TableSize }>`
     font: ${theme.click.table.header.title.default};
     color: ${theme.click.table.header.color.title.default};
   `}
-  gap: 0.25rem;
   text-align: left;
 `;
 

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -9,21 +9,14 @@ export interface TableHeaderType extends HTMLAttributes<HTMLTableCellElement> {
   isSortable?: boolean;
   sortDir?: SortDir;
   sortPosition?: HorizontalDirection;
-  width?: number | string;
+  width?: string;
 }
 
-const StyledHeader = styled.th<{ $size: TableSize; $width?: number | string }>`
-  ${({ theme, $size, $width }) => `
-    padding: ${theme.click.table.header.cell.space[$size].y} ${
-    theme.click.table.body.cell.space[$size].x
-  };
+const StyledHeader = styled.th<{ $size: TableSize }>`
+  ${({ theme, $size }) => `
+    padding: ${theme.click.table.header.cell.space[$size].y} ${theme.click.table.body.cell.space[$size].x};
     font: ${theme.click.table.header.title.default};
     color: ${theme.click.table.header.color.title.default};
-    ${
-      typeof $width !== "undefined"
-        ? `width: ${typeof $width === "number" ? `${$width}px` : $width};`
-        : ""
-    }
   `}
   gap: 0.25rem;
   text-align: left;
@@ -63,7 +56,6 @@ const TableHeader = ({
   };
   return (
     <StyledHeader
-      $width={width}
       $size={size}
       {...delegated}
     >
@@ -91,7 +83,7 @@ interface TheadProps {
   headers: Array<TableHeaderType>;
   isSelectable?: boolean;
   onSelectAll: (checked: boolean) => void;
-  showActionsHeader?: boolean;
+  actionsCount: number;
   onSort?: SortFn;
   hasRows: boolean;
   size: TableSize;
@@ -101,7 +93,7 @@ const Thead = ({
   headers,
   isSelectable,
   onSelectAll,
-  showActionsHeader,
+  actionsCount,
   onSort: onSortProp,
   hasRows,
   size,
@@ -114,14 +106,14 @@ const Thead = ({
   return (
     <>
       <StyledColGroup>
-        {isSelectable && <col />}
+        {isSelectable && <col width={48} />}
         {headers.map((headerProps, index) => (
           <col
             key={`header-col-${index}`}
             width={headerProps.width}
           />
         ))}
-        {showActionsHeader && <col />}
+        {actionsCount > 0 && <col width={(actionsCount + 1) * 32 + 10} />}
       </StyledColGroup>
       <StyledThead>
         <tr>
@@ -141,7 +133,7 @@ const Thead = ({
               {...headerProps}
             />
           ))}
-          {showActionsHeader && <StyledHeader $size={size} />}
+          {actionsCount > 0 && <StyledHeader $size={size} />}
         </tr>
       </StyledThead>
     </>
@@ -226,7 +218,7 @@ const StyledThead = styled.thead`
   }
 `;
 
-const MobileHeader = styled.span`
+const MobileHeader = styled.div`
   display: none;
   ${({ theme }) => `
     color: ${theme.click.table.row.color.label.default};
@@ -285,7 +277,7 @@ const ActionsList = styled.td<{ $size: TableSize }>`
   }
 `;
 
-const ActionsContainer = styled.span`
+const ActionsContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
@@ -390,6 +382,13 @@ interface TableBodyRowProps extends Omit<TableRowType, "id"> {
   size: TableSize;
 }
 
+const TableText = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  height: 1lh;
+  white-space: nowrap;
+`;
+
 const TableBodyRow = ({
   headers,
   items,
@@ -428,7 +427,7 @@ const TableBodyRow = ({
           {...cellProps}
         >
           {headers[cellIndex] && <MobileHeader>{headers[cellIndex].label}</MobileHeader>}
-          <span>{label}</span>
+          <TableText>{label}</TableText>
         </TableData>
       ))}
       {(isDeletable || isEditable) && (
@@ -583,7 +582,9 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
                 headers={headers}
                 isSelectable={isSelectable}
                 onSelectAll={onSelectAll}
-                showActionsHeader={isDeletable || isEditable}
+                actionsCount={
+                  isDeletable && isEditable ? 2 : isDeletable && isEditable ? 1 : 0
+                }
                 onSort={onSort}
                 hasRows={hasRows}
                 size={size}

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -9,7 +9,7 @@ export interface TableHeaderType extends HTMLAttributes<HTMLTableCellElement> {
   isSortable?: boolean;
   sortDir?: SortDir;
   sortPosition?: HorizontalDirection;
-  width: number | string;
+  width?: number | string;
 }
 
 const StyledHeader = styled.th<{ $size: TableSize; $width?: number | string }>`

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,11 +1,4 @@
-import {
-  Checkbox,
-  HorizontalDirection,
-  Icon,
-  IconButton,
-  IconName,
-  Text,
-} from "@/components";
+import { Checkbox, HorizontalDirection, Icon, IconButton, Text } from "@/components";
 import { HTMLAttributes, MouseEvent, ReactNode, forwardRef } from "react";
 import styled from "styled-components";
 type SortDir = "asc" | "desc";

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -19,7 +19,11 @@ const StyledHeader = styled.th<{ $size: TableSize; $width?: number | string }>`
   };
     font: ${theme.click.table.header.title.default};
     color: ${theme.click.table.header.color.title.default};
-    ${$width ? `width: ${typeof $width === "number" ? `${$width}px` : $width}` : ""}
+    ${
+      typeof $width !== "undefined"
+        ? `width: ${typeof $width === "number" ? `${$width}px` : $width};`
+        : ""
+    }
   `}
   gap: 0.25rem;
   text-align: left;

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -81,7 +81,7 @@ interface TheadProps {
   headers: Array<TableHeaderType>;
   isSelectable?: boolean;
   onSelectAll: (checked: boolean) => void;
-  actionsCount: number;
+  actionsList: Array<string>;
   onSort?: SortFn;
   hasRows: boolean;
   size: TableSize;
@@ -91,7 +91,7 @@ const Thead = ({
   headers,
   isSelectable,
   onSelectAll,
-  actionsCount,
+  actionsList,
   onSort: onSortProp,
   hasRows,
   size,
@@ -111,7 +111,7 @@ const Thead = ({
             width={headerProps.width}
           />
         ))}
-        {actionsCount > 0 && <col width={(actionsCount + 1) * 32 + 10} />}
+        {actionsList.length > 0 && <col width={(actionsList.length + 1) * 32 + 10} />}
       </StyledColGroup>
       <StyledThead>
         <tr>
@@ -131,7 +131,7 @@ const Thead = ({
               {...headerProps}
             />
           ))}
-          {actionsCount > 0 && <StyledHeader $size={size} />}
+          {actionsList.length > 0 && <StyledHeader $size={size} />}
         </tr>
       </StyledThead>
     </>
@@ -377,6 +377,7 @@ interface TableBodyRowProps extends Omit<TableRowType, "id"> {
   isSelected: boolean;
   onDelete?: () => void;
   onEdit?: () => void;
+  actionsList: Array<string>;
   size: TableSize;
 }
 
@@ -398,6 +399,7 @@ const TableBodyRow = ({
   isDeleted,
   isDisabled,
   size,
+  actionsList,
   ...rowProps
 }: TableBodyRowProps) => {
   const isDeletable = typeof onDelete === "function";
@@ -428,23 +430,23 @@ const TableBodyRow = ({
           <TableText>{label}</TableText>
         </TableData>
       ))}
-      {(isDeletable || isEditable) && (
+      {actionsList.length > 0 && (
         <ActionsList $size={size}>
           <ActionsContainer>
-            {isEditable && (
+            {actionsList.includes("editAction") && (
               <EditButton
                 as={IconButton}
                 type="ghost"
-                disabled={isDisabled || isDeleted}
+                disabled={isDisabled || isDeleted || !isEditable}
                 icon="pencil"
                 onClick={onEdit}
                 data-testid="table-row-edit"
               />
             )}
-            {isDeletable && (
+            {actionsList.includes("deleteAction") && (
               <TableRowCloseButton
                 as={IconButton}
-                disabled={isDisabled}
+                disabled={isDisabled || !isDeletable}
                 $isDeleted={isDeleted}
                 type="ghost"
                 icon="cross"
@@ -557,6 +559,14 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
         }
       };
     const hasRows = rows.length > 0;
+    const actionsList: Array<string> = [];
+    if (isDeletable) {
+      actionsList.push("deleteAction");
+    }
+    if (isEditable) {
+      actionsList.push("editAction");
+    }
+
     return (
       <TableOuterContainer>
         {hasRows && showHeader && (
@@ -580,9 +590,7 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
                 headers={headers}
                 isSelectable={isSelectable}
                 onSelectAll={onSelectAll}
-                actionsCount={
-                  isDeletable && isEditable ? 2 : isDeletable && isEditable ? 1 : 0
-                }
+                actionsList={actionsList}
                 onSort={onSort}
                 hasRows={hasRows}
                 size={size}
@@ -608,6 +616,7 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
                   isSelectable={isSelectable}
                   isSelected={selectedIds?.includes(id)}
                   onSelect={onRowSelect(id)}
+                  actionsList={actionsList}
                   onDelete={
                     isDeletable
                       ? () =>

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -112,27 +112,39 @@ const Thead = ({
     }
   };
   return (
-    <StyledThead>
-      <tr>
-        {isSelectable && (
-          <StyledHeader $size={size}>
-            <Checkbox
-              onCheckedChange={onSelectAll}
-              disabled={!hasRows}
-            />
-          </StyledHeader>
-        )}
+    <>
+      <StyledColGroup>
+        {isSelectable && <col />}
         {headers.map((headerProps, index) => (
-          <TableHeader
-            key={`table-header-${index}`}
-            onSort={onSort(headerProps, index)}
-            size={size}
-            {...headerProps}
+          <col
+            key={`header-col-${index}`}
+            width={headerProps.width}
           />
         ))}
-        {showActionsHeader && <StyledHeader $size={size} />}
-      </tr>
-    </StyledThead>
+        {showActionsHeader && <col />}
+      </StyledColGroup>
+      <StyledThead>
+        <tr>
+          {isSelectable && (
+            <StyledHeader $size={size}>
+              <Checkbox
+                onCheckedChange={onSelectAll}
+                disabled={!hasRows}
+              />
+            </StyledHeader>
+          )}
+          {headers.map((headerProps, index) => (
+            <TableHeader
+              key={`table-header-${index}`}
+              onSort={onSort(headerProps, index)}
+              size={size}
+              {...headerProps}
+            />
+          ))}
+          {showActionsHeader && <StyledHeader $size={size} />}
+        </tr>
+      </StyledThead>
+    </>
   );
 };
 
@@ -199,7 +211,11 @@ const TableData = styled.td<{ $size: TableSize }>`
       ${({ theme }) => theme.click.table.body.cell.space.sm.x};
   }
 `;
-
+const StyledColGroup = styled.colgroup`
+  @media (max-width: 768px) {
+    display: none;
+  }
+`;
 const StyledThead = styled.thead`
   tr {
     overflow: hidden;
@@ -621,6 +637,7 @@ const StyledTable = styled.table`
   width: 100%;
   border-spacing: 0;
   overflow: hidden;
+  table-layout: fixed;
   ${({ theme }) => `
     border-radius: ${theme.click.table.radii.all};
     border: ${theme.click.table.cell.stroke} solid ${theme.click.table.global.color.stroke.default};
@@ -628,6 +645,7 @@ const StyledTable = styled.table`
 
   @media (max-width: 768px) {
     border: none;
+    table-layout: auto;
   }
 `;
 

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -12,19 +12,21 @@ type SortDir = "asc" | "desc";
 type SortFn = (sortDir: SortDir, header: TableHeaderType, index: number) => void;
 type TableSize = "sm" | "md";
 export interface TableHeaderType extends HTMLAttributes<HTMLTableCellElement> {
-  icon?: IconName;
-  iconDir?: HorizontalDirection;
   label: ReactNode;
   isSortable?: boolean;
   sortDir?: SortDir;
   sortPosition?: HorizontalDirection;
+  width: number | string;
 }
 
-const StyledHeader = styled.th<{ $size: TableSize }>`
-  ${({ theme, $size }) => `
-    padding: ${theme.click.table.header.cell.space[$size].y} ${theme.click.table.body.cell.space[$size].x};
+const StyledHeader = styled.th<{ $size: TableSize; $width?: number | string }>`
+  ${({ theme, $size, $width }) => `
+    padding: ${theme.click.table.header.cell.space[$size].y} ${
+    theme.click.table.body.cell.space[$size].x
+  };
     font: ${theme.click.table.header.title.default};
     color: ${theme.click.table.header.color.title.default};
+    ${$width ? `width: ${typeof $width === "number" ? `${$width}px` : $width}` : ""}
   `}
   gap: 0.25rem;
   text-align: left;
@@ -50,6 +52,7 @@ const TableHeader = ({
   onSort,
   onClick,
   size,
+  width,
   ...delegated
 }: TableHeaderType & { onSort?: () => void; size: TableSize }) => {
   const isSorted = typeof sortDir === "string";
@@ -63,6 +66,7 @@ const TableHeader = ({
   };
   return (
     <StyledHeader
+      $width={width}
       $size={size}
       {...delegated}
     >
@@ -341,6 +345,7 @@ interface CommonTableProps
   loading?: boolean;
   noDataMessage?: ReactNode;
   size?: TableSize;
+  showHeader?: boolean;
 }
 
 type SelectReturnValue = {
@@ -502,6 +507,7 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
       loading,
       noDataMessage,
       size = "sm",
+      showHeader = true,
       ...props
     },
     ref
@@ -543,7 +549,7 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
     const hasRows = rows.length > 0;
     return (
       <TableOuterContainer>
-        {hasRows && (
+        {hasRows && showHeader && (
           <MobileActions>
             {isSelectable && (
               <Checkbox
@@ -559,15 +565,17 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
             ref={ref}
             {...props}
           >
-            <Thead
-              headers={headers}
-              isSelectable={isSelectable}
-              onSelectAll={onSelectAll}
-              showActionsHeader={isDeletable || isEditable}
-              onSort={onSort}
-              hasRows={hasRows}
-              size={size}
-            />
+            {showHeader && (
+              <Thead
+                headers={headers}
+                isSelectable={isSelectable}
+                onSelectAll={onSelectAll}
+                showActionsHeader={isDeletable || isEditable}
+                onSort={onSort}
+                hasRows={hasRows}
+                size={size}
+              />
+            )}
             <Tbody>
               {(loading || !hasRows) && (
                 <CustomTableRow

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -42,9 +42,8 @@ const TableHeader = ({
   onSort,
   onClick,
   size,
-  width,
   ...delegated
-}: TableHeaderType & { onSort?: () => void; size: TableSize }) => {
+}: Omit<TableHeaderType, "width"> & { onSort?: () => void; size: TableSize }) => {
   const isSorted = typeof sortDir === "string";
   const onHeaderClick = (e: MouseEvent<HTMLTableCellElement>): void => {
     if (typeof onClick === "function") {
@@ -125,9 +124,9 @@ const Thead = ({
               />
             </StyledHeader>
           )}
-          {headers.map((headerProps, index) => (
+          {headers.map(({ width, ...headerProps }, index) => (
             <TableHeader
-              key={`table-header-${index}`}
+              key={`table-header-${index}-${width}`}
               onSort={onSort(headerProps, index)}
               size={size}
               {...headerProps}


### PR DESCRIPTION
Width tag only affects in desktop
The showHeader is implemented for the data loading inorder to hide the header when csv without names are selected
<img width="1438" alt="Screenshot 2023-12-05 at 11 27 19" src="https://github.com/ClickHouse/click-ui/assets/17908918/14b8f122-e9ac-4841-a078-13e654fcf7bb">

<img width="782" alt="Screenshot 2023-12-14 at 13 54 35" src="https://github.com/ClickHouse/click-ui/assets/17908918/46a027d5-6757-40bb-8852-80405bca1350">
