### PR TITLE
Ensure alert content is centred when set to dismissible banner 

### DIFF
--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -46,7 +46,7 @@ const Alert = ({
       data-testid="click-alert"
       {...delegated}
     >
-      {dismissible && <DismissWrapper></DismissWrapper>}
+      {dismissible && type === "banner" && <DismissWrapper></DismissWrapper>}
       {showIcon && (
         <IconWrapper
           $state={state}

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -144,6 +144,7 @@ const DismissWrapper = styled.button`
   border: none;
   background-color: transparent;
   color: inherit;
+  cursor: pointer;
 `;
 
 const DangerAlert = (props: AlertProps) => (

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -3,7 +3,7 @@ import { IconName } from "@/components/Icon/types";
 import { useState, ReactNode } from "react";
 import styled from "styled-components";
 
-type AlertType = "default" | "banner"
+type AlertType = "default" | "banner";
 type AlertSize = "small" | "medium";
 type AlertState = "neutral" | "success" | "warning" | "danger" | "info";
 export type AlertProps = {
@@ -46,6 +46,7 @@ const Alert = ({
       data-testid="click-alert"
       {...delegated}
     >
+      {dismissible && <DismissWrapper></DismissWrapper>}
       {showIcon && (
         <IconWrapper
           $state={state}
@@ -89,16 +90,19 @@ const Wrapper = styled.div<{
 }>`
   display: flex;
   border-radius: ${({ $type, theme }) =>
-  $type === "banner" ? theme.sizes[0] : theme.click.alert.radii.end};
-  justify-content: ${({ $type }) =>
-  $type === "banner" ? "center" : "start"};
+    $type === "banner" ? theme.sizes[0] : theme.click.alert.radii.end};
+  justify-content: ${({ $type }) => ($type === "banner" ? "center" : "start")};
   overflow: hidden;
   background-color: ${({ $state = "neutral", theme }) =>
     theme.click.alert.color.background[$state]};
   color: ${({ $state = "neutral", theme }) => theme.click.alert.color.text[$state]};
 `;
 
-const IconWrapper = styled.div<{ $state: AlertState; $size: AlertSize; $type: AlertType }>`
+const IconWrapper = styled.div<{
+  $state: AlertState;
+  $size: AlertSize;
+  $type: AlertType;
+}>`
   display: flex;
   align-items: center;
   background-color: ${({ $state = "neutral", $type, theme }) =>


### PR DESCRIPTION
### Summary 
Closes: https://github.com/ClickHouse/click-ui/issues/268. When the alert was set to type `banner` and `dismissible:true` the content previously jumped to the left due to a missed flex alignment, this PR fixes that. 


https://github.com/ClickHouse/click-ui/assets/305167/38dd8694-6731-4077-a988-1c586b685de9

