### PR TITLE
Adding text color to a tags in select

### DIFF
--- a/src/components/GenericMenu.tsx
+++ b/src/components/GenericMenu.tsx
@@ -92,6 +92,10 @@ export const GenericMenuItem = styled.div`
     font: ${theme.click.genericMenu.item.typography.label.default};
     background: ${theme.click.genericMenu.item.color.background.default};
     color: ${theme.click.genericMenu.item.color.text.default};
+    a {
+      color: ${theme.click.genericMenu.item.color.text.default}; 
+      text-decoration: none;
+    }
     &[data-highlighted] {
       font: ${theme.click.genericMenu.item.typography.label.hover};
       background: ${theme.click.genericMenu.item.color.background.hover};
@@ -102,18 +106,22 @@ export const GenericMenuItem = styled.div`
       background:${theme.click.genericMenu.item.color.background.active};
       color:${theme.click.genericMenu.item.color.text.active};
       font: ${theme.click.genericMenu.item.typography.label.active};
+      &:hover {
+        background: ${theme.click.genericMenu.item.color.background.hover};
+      }
     }
     &[data-disabled] {
       background:${theme.click.genericMenu.item.color.background.disabled};
       color:${theme.click.genericMenu.item.color.text.disabled};
       font: ${theme.click.genericMenu.item.typography.label.disabled};
       pointer-events: none;
+      cursor: not-allowed;
+      a {
+        color:${theme.click.genericMenu.item.color.text.disabled};
+      }
     }
     &:visited {
       color: ${theme.click.genericMenu.item.color.text.default};
-      a {
-        color: ${theme.click.genericMenu.item.color.text.default}; 
-      }
     }
   `};
   position: relative;


### PR DESCRIPTION
### Summary
When a select item is wrapped in an `<a></a>`, the item text colour is overridden, this PR ensures that doesn't happen while also respecting the `disabled` option. It also re-adds the hover effect on a selected item as it felt weird without it.

  
![CleanShot 2023-12-28 at 16 33 28@2x](https://github.com/ClickHouse/click-ui/assets/305167/4671840e-3887-44ae-931b-e65c0a7006e1)
