### PR TITLE
Add aria-pressed attribute to ButtonGroup component

### DIFF
--- a/src/components/ButtonGroup/ButtonGroup.test.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent } from "@testing-library/react";
 import { ButtonGroup, ButtonGroupProps } from "./ButtonGroup";
 import { renderCUI } from "@/utils/test-utils";
+import "@testing-library/jest-dom";
 
 describe("ButtonGroup", () => {
   const renderButtonGroup = (props: ButtonGroupProps) =>
@@ -33,14 +34,15 @@ describe("ButtonGroup", () => {
     expect(counter).toEqual(1);
   });
 
-  it("adds 'active' class to the active button", () => {
+  it("adds 'aria-pressed' attr to the active/pressed button", () => {
     const { getByText } = renderButtonGroup({
       options,
       selected: "option2",
     });
 
     const activeButton = getByText("Option 2");
-
-    expect(activeButton).active == true;
+    expect(activeButton).toHaveAttribute("aria-pressed", "true");
+    const inactiveButton = getByText("Option 1");
+    expect(inactiveButton).toHaveAttribute("aria-pressed", "false");
   });
 });

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -87,7 +87,9 @@ const leftBorderRadius = `${endRadii} 0px 0px ${endRadii}`;
 const rightBorderRadius = `0px ${endRadii} ${endRadii} 0px`;
 const centerBorderRadius = "var(--click-button-button-group-radii-center)";
 
-const Button = styled.button<ButtonProps>`
+const Button = styled.button.attrs<ButtonProps>(
+  (props: ButtonProps) => ({"aria-pressed": props.$active})
+)`
   box-sizing: border-box;
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
'aria-pressed' is an attribute used in ARIA (Accessible Rich Internet Applications) to indicate the current "pressed" state of toggle buttons. ARIA is a set of attributes that make web content and web applications more accessible to people with disabilities.

[Reference](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed).