### PR TITLE
Fixing icon size in story

### DIFF
--- a/src/components/Icon/Icon.stories.ts
+++ b/src/components/Icon/Icon.stories.ts
@@ -18,13 +18,18 @@ export default {
       options: [...IconNames, ...FlagNames, ...LogoNames, ...PaymentNames],
       control: { type: "select" },
     },
+    size: {
+      options: ["xs" , "sm" , "md" , "lg" , "xl" , "xxl"],
+      control: { type: "select" },
+    },
   },
 };
 
 export const Playground = {
   args: {
     name: "users",
-    width: "1rem",
-    height: "16px",
+    size: "md",
+    width: "",
+    height: "",
   },
 };


### PR DESCRIPTION
### Summary
The size wasn't shown in the icon story so it was not possible to see the options or how it appears visually. 


https://github.com/ClickHouse/click-ui/assets/305167/d1a50201-7f46-4ebf-8112-d055900bf2bc

