### PR TITLE
Adding colour tokens for charts

### DIFF
--- a/src/styles/types.ts
+++ b/src/styles/types.ts
@@ -2662,6 +2662,18 @@
       "global": {
         "background": string
       }
+    },
+    "chart": {
+      "values": {
+        "color": {
+          "green": string,
+          "blue": string,
+          "fuchsia": string,
+          "orange": string,
+          "violet": string,
+          "teal": string
+        }
+      }
     }
   },
   "transition": {

--- a/src/styles/variables.classic.json
+++ b/src/styles/variables.classic.json
@@ -790,6 +790,18 @@
       "global": {
         "background": "#ffffff"
       }
+    },
+    "chart": {
+      "values": {
+        "color": {
+          "green": "#00FF15",
+          "blue": "#6c9af3",
+          "fuchsia": "#FB64D6",
+          "orange": "#ffb864",
+          "violet": "#CC66FF",
+          "teal": "#00CCAA"
+        }
+      }
     }
   },
   "name": "classic",

--- a/src/styles/variables.dark.json
+++ b/src/styles/variables.dark.json
@@ -1350,6 +1350,18 @@
       "global": {
         "background": "rgb(27,28,29)"
       }
+    },
+    "chart": {
+      "values": {
+        "color": {
+          "green": "#66FF73",
+          "blue": "#6c9af3",
+          "fuchsia": "#FB64D6",
+          "orange": "#FAFF69",
+          "violet": "#BB33FF",
+          "teal": "#66FFE5"
+        }
+      }
     }
   },
   "name": "dark",

--- a/src/styles/variables.json
+++ b/src/styles/variables.json
@@ -2661,6 +2661,18 @@
       "global": {
         "background": "#ffffff"
       }
+    },
+    "chart": {
+      "values": {
+        "color": {
+          "green": "#00FF15",
+          "blue": "#6c9af3",
+          "fuchsia": "#FB64D6",
+          "orange": "#ffb864",
+          "violet": "#CC66FF",
+          "teal": "#00CCAA"
+        }
+      }
     }
   },
   "transition": {

--- a/src/styles/variables.light.json
+++ b/src/styles/variables.light.json
@@ -1343,6 +1343,18 @@
       "global": {
         "background": "#ffffff"
       }
+    },
+    "chart": {
+      "values": {
+        "color": {
+          "green": "#00FF15",
+          "blue": "#6c9af3",
+          "fuchsia": "#FB64D6",
+          "orange": "#ffb864",
+          "violet": "#CC66FF",
+          "teal": "#00CCAA"
+        }
+      }
     }
   },
   "name": "light",


### PR DESCRIPTION
### Summary 
Quick PR to add the colour tokens for charting. 

They should look like this:


![CleanShot 2024-01-08 at 13 32 15@2x](https://github.com/ClickHouse/click-ui/assets/305167/2e1fe045-f688-4e50-9ddc-d2ad9fc86228)


They can be access via the following tokens:
```
click.theme.chart.values.color.green
click.theme.chart.values.color.blue
click.theme.chart.values.color.fuchsia
click.theme.chart.values.color.orange
click.theme.chart.values.color.violet
click.theme.chart.values.color.teal
```