### PR TITLE
Fixing the text alignment in cards

### DIFF
--- a/src/components/CardPrimary/CardPrimary.tsx
+++ b/src/components/CardPrimary/CardPrimary.tsx
@@ -182,7 +182,7 @@ export const CardPrimary = ({
           $size={size}
           $alignContent={alignContent}
         >
-          {description && <Text color="muted">{description}</Text>}
+          {description && <Text color="muted" align={alignContent}>{description}</Text>}
           {children}
         </Content>
       )}


### PR DESCRIPTION
### Summary 
Adding `align` prop to the Primary Card component's description text. Fixes issue with Primary card alignment

<img width="834" alt="Screenshot 2024-01-09 at 21 01 48" src="https://github.com/ClickHouse/click-ui/assets/305167/ed176a1e-4a4f-4137-97f1-e3fc3a177ad5">
