### PR TITLE
Improvements to FileTabs

### DIFF
--- a/src/components/FileTabs/FileTabs.tsx
+++ b/src/components/FileTabs/FileTabs.tsx
@@ -206,21 +206,16 @@ const TabElement = styled.div<{
   max-width: fill-available;
   max-width: stretch;
   border: none;
+  cursor: pointer;
+  height: 100%;
+  height: -webkit-fill-available;
+  height: fill-available;
+  height: stretch;
   ${({ theme, $active, $preview, $dismissable, $fixedTabElement }) => `
     width:${$fixedTabElement ? "auto" : "100%"};
     grid-template-columns: 1fr ${
       $dismissable ? theme.click.tabs.fileTabs.icon.size.width : ""
     };
-    ${
-      $dismissable
-        ? `
-        height: 100%;
-        height: -webkit-fill-available;
-        height: fill-available;
-        height: stretch;
-    `
-        : ""
-    }
     padding: ${theme.click.tabs.fileTabs.space.y} ${theme.click.tabs.fileTabs.space.x};
     gap: ${theme.click.tabs.fileTabs.space.gap};
     border-radius: ${theme.click.tabs.fileTabs.radii.all};
@@ -293,6 +288,7 @@ const TabContent = styled.div`
   flex-wrap: nowrap;
   overflow: hidden;
   gap: ${({ theme }) => theme.click.tabs.fileTabs.space.gap};
+  cursor: inherit;
 `;
 
 const TabContentText = styled.span`
@@ -304,6 +300,11 @@ const TabContentText = styled.span`
 
 const EmptyButton = styled.button`
   padding: 0;
+  ${({ theme }) => theme.click.tabs.fileTabs.color.closeButton.background.default};
+  &:hover {
+    background: ${({ theme }) =>
+      theme.click.tabs.fileTabs.color.closeButton.background.hover};
+  }
 `;
 
 const Tab = ({

--- a/src/components/FileTabs/FileTabs.tsx
+++ b/src/components/FileTabs/FileTabs.tsx
@@ -288,7 +288,6 @@ const TabContent = styled.div`
   flex-wrap: nowrap;
   overflow: hidden;
   gap: ${({ theme }) => theme.click.tabs.fileTabs.space.gap};
-  cursor: inherit;
 `;
 
 const TabContentText = styled.span`

--- a/src/styles/types.ts
+++ b/src/styles/types.ts
@@ -2283,6 +2283,12 @@
             "default": string,
             "hover": string,
             "active": string
+          },
+          "closeButton": {
+            "background": {
+              "default": string,
+              "hover": string
+            }
           }
         }
       }

--- a/src/styles/variables.dark.json
+++ b/src/styles/variables.dark.json
@@ -1165,6 +1165,12 @@
             "default": "lch(27.5 0 0 / 0.3)",
             "hover": "lch(27.5 0 0 / 0.3)",
             "active": "lch(27.5 0 0 / 0.3)"
+          },
+          "closeButton": {
+            "background": {
+              "default": "rgba(0,0,0,0)",
+              "hover": "#414141"
+            }
           }
         }
       }

--- a/src/styles/variables.json
+++ b/src/styles/variables.json
@@ -2282,6 +2282,12 @@
             "default": "lch(91.6 1.1 266)",
             "hover": "lch(91.6 1.1 266)",
             "active": "lch(91.6 1.1 266)"
+          },
+          "closeButton": {
+            "background": {
+              "default": "rgba(0,0,0,0)",
+              "hover": "#e6e7e9"
+            }
           }
         }
       }

--- a/src/styles/variables.light.json
+++ b/src/styles/variables.light.json
@@ -1161,6 +1161,12 @@
             "default": "lch(91.6 1.1 266)",
             "hover": "lch(91.6 1.1 266)",
             "active": "lch(91.6 1.1 266)"
+          },
+          "closeButton": {
+            "background": {
+              "default": "rgba(0,0,0,0)",
+              "hover": "#e6e7e9"
+            }
           }
         }
       }


### PR DESCRIPTION
### Summary
* Used `cursor:pointer` on hover as the current cursor made it feel as though you could edit the text inline
* Added a new button colour when hovering over the close button
* Fixed the height issue in Safari by pulling the `height` attributes to top level, previously they were only on `dismissible` tabs but safari wasn't picking it up. @vineethasok what was your thinking behind this?
 
![CleanShot 2024-01-17 at 16 09 02@2x](https://github.com/ClickHouse/click-ui/assets/305167/043de160-be3e-4686-96ab-363b2bc348ed)


Here's the safari bug
![CleanShot 2024-01-17 at 16 11 58@2x](https://github.com/ClickHouse/click-ui/assets/305167/64bfc2c7-fc3a-4665-9f92-2f2d0a6974d3)
