### PR TITLE
Making alerts and banners always full width.

### DIFF
--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -1,10 +1,37 @@
-import { Alert } from "@/components/Alert/Alert";
-import {ICON_NAMES} from "@/components/Icon/types.ts";
+import { Alert, AlertProps } from "@/components/Alert/Alert";
+import { ICON_NAMES } from "@/components/Icon/types.ts";
+import { Container } from "..";
+
+const ExampleAlert = (props: AlertProps) => {
+  return (
+    <Container maxWidth="65%">
+      <Alert
+        title={props.title}
+        text={props.text}
+        state={props.state}
+        type={props.type}
+        showIcon={props.showIcon}
+        customIcon={props.customIcon}
+        dismissible={props.dismissible}
+      />
+    </Container>
+  );
+};
 
 export default {
-  component: Alert,
+  component: ExampleAlert,
   title: "Display/Alert",
   tags: ["alert", "autodocs"],
+
+  argTypes: {
+    state: {
+      control: "select",
+      options: ["neutral", "info", "success", "warning", "danger"],
+    },
+    type: { control: "radio", options: ["default", "banner"] },
+    size: { control: "radio", options: ["medium", "small"] },
+    customIcon: { control: "select", options: ICON_NAMES },
+  },
 };
 
 export const Playground = {
@@ -15,13 +42,6 @@ export const Playground = {
     size: "small",
     type: "default",
     showIcon: true,
-    dismissible: false
+    dismissible: false,
   },
-  argTypes: {
-    state: { control: "select", options: ["neutral", "info", "success", "warning", "danger"] },
-    type: { control: "radio", options: ["default", "banner"] },
-    size: { control: "radio", options: ["medium", "small"] },
-    customIcon: {control: "select", options: ICON_NAMES}
-  }
-
 };

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -96,6 +96,7 @@ const Wrapper = styled.div<{
   background-color: ${({ $state = "neutral", theme }) =>
     theme.click.alert.color.background[$state]};
   color: ${({ $state = "neutral", theme }) => theme.click.alert.color.text[$state]};
+  width: 100%;
 `;
 
 const IconWrapper = styled.div<{


### PR DESCRIPTION
### Summary
Alerts and banners should be full width of the container they're in. If you need less than that, adjust the width of the container. 

#### Screenshot (no visible change) 
![CleanShot 2024-01-20 at 13 45 55@2x](https://github.com/ClickHouse/click-ui/assets/305167/9c8386ce-4048-47d1-9b42-34a2c6886dcc)

