### PR TITLE
Fixing horizontal loading bug icon in Safari + Firefox

### DIFF
--- a/src/components/icons/HorizontalLoading.tsx
+++ b/src/components/icons/HorizontalLoading.tsx
@@ -57,17 +57,24 @@ const HorizontalLoading = styled(DotsHorizontal)`
     -webkit-animation-duration: 1.5s;
     -webkit-animation-iteration-count: infinite;
     -webkit-animation-timing-function: linear;
+    -moz-animation-name: horizontal-loading;
+    -moz-animation-duration: 1.5s;
+    -moz-animation-iteration-count: infinite;
+    -moz-animation-timing-function: linear;
     &:nth-child(1) {
       animation-name: ${animationCircle1};
       -webkit-animation-name: ${animationCircle1};
+      -moz-animation-name: ${animationCircle1};
     }
     &:nth-child(2) {
       animation-name: ${animationCircle2};
       -webkit-animation-name: ${animationCircle2};
+      -moz-animation-name: ${animationCircle2};
     }
     &:nth-child(3) {
       animation-name: ${animationCircle3};
       -webkit-animation-name: ${animationCircle3};
+      -moz-animation-name: ${animationCircle3};
     }
   }
 `;

--- a/src/components/icons/HorizontalLoading.tsx
+++ b/src/components/icons/HorizontalLoading.tsx
@@ -49,19 +49,25 @@ const animationCircle3 = keyframes`
 
 const HorizontalLoading = styled(DotsHorizontal)`
   circle {
-    r: 0;
-    animation-name: example;
+    animation-name: horizontal-loading;
     animation-duration: 1.5s;
     animation-iteration-count: infinite;
     animation-timing-function: linear;
+    -webkit-animation-name: horizontal-loading;
+    -webkit-animation-duration: 1.5s;
+    -webkit-animation-iteration-count: infinite;
+    -webkit-animation-timing-function: linear;
     &:nth-child(1) {
       animation-name: ${animationCircle1};
+      -webkit-animation-name: ${animationCircle1};
     }
     &:nth-child(2) {
       animation-name: ${animationCircle2};
+      -webkit-animation-name: ${animationCircle2};
     }
     &:nth-child(3) {
       animation-name: ${animationCircle3};
+      -webkit-animation-name: ${animationCircle3};
     }
   }
 `;

--- a/src/styles/types.ts
+++ b/src/styles/types.ts
@@ -1149,6 +1149,12 @@
             "default": string
           }
         }
+      },
+      "monacoTheme": {
+        "parameter": {
+          "foreground": string,
+          "background": string
+        }
       }
     },
     "codeInline": {
@@ -2437,7 +2443,26 @@
           "top": string
         },
         "inline": {
-          "top": string
+          "top": string,
+          "content": {
+            "x": string,
+            "row-gap": string,
+            "column-gap": string
+          },
+          "y": string,
+          "x": string,
+          "gap": string,
+          "default": {
+            "top": string
+          },
+          "inline": {
+            "top": string,
+            "content": {
+              "x": string,
+              "row-gap": string,
+              "column-gap": string
+            }
+          }
         },
         "content": {
           "x": string,

--- a/src/styles/variables.dark.json
+++ b/src/styles/variables.dark.json
@@ -659,6 +659,12 @@
             "default": "#282828"
           }
         }
+      },
+      "monacoTheme": {
+        "parameter": {
+          "foreground": "#c0c0c0",
+          "background": "#414141"
+        }
       }
     },
     "codeInline": {

--- a/src/styles/variables.json
+++ b/src/styles/variables.json
@@ -1148,6 +1148,12 @@
             "default": "#282828"
           }
         }
+      },
+      "monacoTheme": {
+        "parameter": {
+          "foreground": "#53575f",
+          "background": "#e6e7e9"
+        }
       }
     },
     "codeInline": {
@@ -2436,7 +2442,26 @@
           "top": "0"
         },
         "inline": {
-          "top": "3.5rem"
+          "top": "3.5rem",
+          "content": {
+            "x": "1.5rem",
+            "row-gap": "0.25rem",
+            "column-gap": "1rem"
+          },
+          "y": "1rem",
+          "x": "0",
+          "gap": "1rem",
+          "default": {
+            "top": "0"
+          },
+          "inline": {
+            "top": "3.5rem",
+            "content": {
+              "x": "0.75rem",
+              "row-gap": "0.25rem",
+              "column-gap": "0.75rem"
+            }
+          }
         },
         "content": {
           "x": "1.5rem",

--- a/src/styles/variables.light.json
+++ b/src/styles/variables.light.json
@@ -653,6 +653,12 @@
             "default": "#282828"
           }
         }
+      },
+      "monacoTheme": {
+        "parameter": {
+          "foreground": "#53575f",
+          "background": "#e6e7e9"
+        }
       }
     },
     "codeInline": {


### PR DESCRIPTION
### Summary
Safari and firefox's behaviour around keyframes is slightly different to chrome. Easy fix, just adding `-webkit` and `-moz` sorted things. 

#### Before
![CleanShot 2024-01-25 at 12 27 09@2x](https://github.com/ClickHouse/click-ui/assets/305167/0f983b42-a24e-4b93-9ed2-dcc5e834249c)


#### After
https://github.com/ClickHouse/click-ui/assets/305167/724f67ea-c096-43cb-a6c1-a7e6d567d75c


**Note** It looks a little funky in safari, but we can probably fix later. 
