### PR TITLE
Fix FileTabs extra space

### DIFF
--- a/src/components/FileTabs/FileTabs.tsx
+++ b/src/components/FileTabs/FileTabs.tsx
@@ -30,12 +30,13 @@ export type FileTabStatusType =
   | "warning"
   | "info";
 
-const TabsContainer = styled.div`
+const TabsContainer = styled.div<{ $count: number }>`
   display: flex;
   position: relative;
   overflow: auto;
   overscroll-behavior: none;
   scrollbar-width: 0;
+  max-width: ${({ $count }) => `${$count * 200}px`};
   &::-webkit-scrollbar {
     height: 0;
   }
@@ -153,6 +154,7 @@ export const FileTabs = ({
           e.preventDefault();
           e.stopPropagation();
         }}
+        $count={(listProp ?? list).length}
       >
         <TabsSortableContainer
           as={ReactSortable}


### PR DESCRIPTION
Before
<img width="647" alt="Screenshot 2024-02-22 at 11 29 41" src="https://github.com/ClickHouse/click-ui/assets/17908918/42fc7b0b-2106-4ea8-9da5-7adf2018396c">

After
<img width="556" alt="Screenshot 2024-02-22 at 11 29 53" src="https://github.com/ClickHouse/click-ui/assets/17908918/c6abcd96-d8ee-4c4e-ae3a-8c591cce3f37">
