### PR TITLE
Fix flyout styling

### DIFF
--- a/src/components/CodeBlock/CodeBlock.tsx
+++ b/src/components/CodeBlock/CodeBlock.tsx
@@ -38,6 +38,9 @@ interface CustomRendererProps {
 }
 
 const CodeBlockContainer = styled.div<{ $theme?: CodeThemeType }>`
+  width: 100%;
+  width: -webkit-fill-available;
+  width: fill-available;
   width: stretch;
   position: relative;
   cursor: pointer;

--- a/src/components/Flyout/Flyout.stories.tsx
+++ b/src/components/Flyout/Flyout.stories.tsx
@@ -28,7 +28,6 @@ const FlyoutExample = ({
         strategy="fixed"
         size={size}
         width={width}
-        align="start"
       >
         <Flyout.Header
           type={type}

--- a/src/components/Flyout/Flyout.stories.tsx
+++ b/src/components/Flyout/Flyout.stories.tsx
@@ -7,9 +7,18 @@ interface Props extends FlyoutProps {
   align: "default" | "top";
   type: "default" | "inline";
   size: "default" | "narrow" | "wide";
+  width?: string;
 }
 
-const FlyoutExample = ({ title, description, align, type, size, ...props }: Props) => {
+const FlyoutExample = ({
+  title,
+  description,
+  align,
+  type,
+  size,
+  width,
+  ...props
+}: Props) => {
   return (
     <Flyout {...props}>
       <Flyout.Trigger>
@@ -18,6 +27,8 @@ const FlyoutExample = ({ title, description, align, type, size, ...props }: Prop
       <Flyout.Content
         strategy="fixed"
         size={size}
+        width={width}
+        align="start"
       >
         <Flyout.Header
           type={type}
@@ -25,9 +36,7 @@ const FlyoutExample = ({ title, description, align, type, size, ...props }: Prop
           description={description}
         />
         <Flyout.Body align={align}>
-          <Flyout.Element type={type}>
-            <Text>Flyout content belongs here.</Text>
-          </Flyout.Element>
+          <Flyout.CodeBlock statement="aaaa" />
         </Flyout.Body>
         <Flyout.Footer type={type}>
           <Flyout.Close label="Cancel" />
@@ -47,6 +56,7 @@ export default {
     align: { control: "select", options: ["default", "top"] },
     size: { control: "select", options: ["default", "narrow", "wide"] },
     type: { control: "select", options: ["default", "inline"] },
+    width: { control: "text" },
   },
 };
 
@@ -62,7 +72,7 @@ export const Playground = {
     docs: {
       source: {
         transform: (_: string, story: { args: Props; [x: string]: unknown }) => {
-          const { title, description, align, size, ...props } = story.args;
+          const { title, description, align, size, width, ...props } = story.args;
           return `<Flyout\n
           ${Object.entries(props)
             .flatMap(([key, value]) =>
@@ -77,7 +87,7 @@ export const Playground = {
 
       <Flyout.Content
         strategy="fixed"
-        size="${size}"
+        size="${size}"${width ? `\n\t\twidth="${width}"` : "\b"}
       >
         <Flyout.Header
           title="${title}"

--- a/src/components/Flyout/Flyout.tsx
+++ b/src/components/Flyout/Flyout.tsx
@@ -12,7 +12,16 @@ import {
   DialogTriggerProps,
   DialogContentProps as RadixDialogContentProps,
 } from "@radix-ui/react-dialog";
-import { Button, ButtonProps, Container, ContainerProps, Icon, Separator } from "..";
+import {
+  Button,
+  ButtonProps,
+  CodeBlock,
+  Container,
+  ContainerProps,
+  Icon,
+  Separator,
+  Spacer,
+} from "@/components";
 import styled from "styled-components";
 import { CrossButton } from "../commonElement";
 import { keyframes } from "styled-components";
@@ -45,6 +54,7 @@ type FlyoutSizeType = "default" | "narrow" | "wide";
 type Strategy = "relative" | "absolute" | "fixed";
 type FlyoutType = "default" | "inline";
 
+type DialogContentAlignmentType = "start" | "end";
 export interface DialogContentProps extends RadixDialogContentProps {
   container?: HTMLElement | null;
   showOverlay?: boolean;
@@ -53,17 +63,22 @@ export interface DialogContentProps extends RadixDialogContentProps {
   type?: FlyoutType;
   strategy?: Strategy;
   closeOnInteractOutside?: boolean;
+  width?: string;
+  align?: DialogContentAlignmentType;
 }
 
-const animationWidth = keyframes({
-  "0%": { maxWidth: 0, minWidth: 0 },
-  "100%": { maxWidth: "fit-content", minWidth: "var(--flyout-width, 100%)" },
-});
+const animationWidth = () =>
+  keyframes({
+    "0%": { width: 0 },
+    "100%": { width: "var(--flyout-width, 100%)" },
+  });
 
 const FlyoutContent = styled(DialogContent)<{
   $size?: FlyoutSizeType;
   $type?: FlyoutType;
   $strategy: Strategy;
+  $width?: string;
+  $align: DialogContentAlignmentType;
 }>`
   display: flex;
   flex-direction: column;
@@ -71,11 +86,11 @@ const FlyoutContent = styled(DialogContent)<{
   overflow: hidden;
   flex: 1;
   top: 0;
-  right: 0;
+  ${({ $align }) => ($align === "start" ? "left" : "right")}: 0;
   bottom: 0;
   width: 100%;
-  --flyout-width: ${({ theme, $size = "default" }) =>
-    theme.click.flyout.size[$size].width};
+  --flyout-width: ${({ theme, $size = "default", $width }) =>
+    $width ?? theme.click.flyout.size[$size].width};
   animation: ${animationWidth} 500ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
   ${({ theme, $strategy, $type = "default" }) => `
     position: ${$strategy};
@@ -121,6 +136,8 @@ const Content = ({
   size,
   type = "default",
   closeOnInteractOutside = false,
+  width,
+  align = "end",
   onInteractOutside,
   ...props
 }: DialogContentProps) => {
@@ -139,6 +156,8 @@ const Content = ({
             onInteractOutside(e);
           }
         }}
+        $width={width}
+        $align={align}
         {...props}
       >
         {children}
@@ -400,3 +419,33 @@ const Footer = (props: FlyoutFooterProps) => {
 };
 Footer.displayName = "Flyout.Footer";
 Flyout.Footer = Footer;
+
+const CustomCodeBlock = styled(CodeBlock)`
+  display: flex;
+  height: 100%;
+  pre {
+    flex: 1;
+  }
+`;
+
+const FlyoutCodeBlock = ({
+  statement,
+  ...props
+}: { statement: string } & ElementProps) => {
+  return (
+    <Element
+      fillHeight
+      {...props}
+    >
+      <CustomCodeBlock
+        wrapLines
+        className="fs-exclude"
+      >
+        {statement}
+      </CustomCodeBlock>
+      <Spacer size="xs" />
+    </Element>
+  );
+};
+
+Flyout.CodeBlock = FlyoutCodeBlock;


### PR DESCRIPTION
Added the following features

1. Added option to align the flyout left or right
2. Add option to add width to the flyout content (Fixing the issue regarding the flyout width)
3. Move the logic of the CodeBlock to click-ui
<img width="328" alt="Screenshot 2024-02-22 at 13 31 00" src="https://github.com/ClickHouse/click-ui/assets/17908918/c0a5b2ce-cfa4-4b65-9ec3-87a23489fb1d">
<img width="933" alt="Screenshot 2024-02-22 at 13 34 26" src="https://github.com/ClickHouse/click-ui/assets/17908918/d7e034d0-a579-4706-a491-e9a34ffd2dd2">
