### PR TITLE
Fix grid

### DIFF
--- a/src/components/Grid/Cell.tsx
+++ b/src/components/Grid/Cell.tsx
@@ -20,7 +20,6 @@ export const Cell = memo(
       showRowNumber,
       showHeader,
       rowHeight,
-      rounded,
       rowStart,
     } = data;
 
@@ -79,7 +78,6 @@ export const Cell = memo(
           $isFirstRow={rowIndex === 0 && !showHeader}
           $selectionType={selectionType}
           $height={rowHeight}
-          $rounded={rounded}
           data-grid-row={currentRowIndex}
           data-grid-column={columnIndex}
           $showBorder

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -395,6 +395,7 @@ export const Grid = forwardRef<VariableSizeGrid, GridProps>(
             {showHeader && (
               <Header
                 scrolledVertical={scrolledVertical}
+                scrolledHorizontal={scrolledHorizontal}
                 showRowNumber={showRowNumber}
                 minColumn={minColumn}
                 maxColumn={maxColumn}

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -19,6 +19,7 @@ import {
   GridContextMenuItemProps,
   GridProps,
   ItemDataType,
+  RoundedType,
   SelectedRegion,
   SelectionAction,
   SelectionFocus,
@@ -79,21 +80,28 @@ const GridDataContainer = styled.div<{ $top: number; $left: number }>`
   `}
 `;
 
-const ContextMenuTrigger = styled.div`
+const ContextMenuTrigger = styled.div<{
+  $height?: number;
+  $rounded: RoundedType;
+  $showBorder: boolean;
+}>`
   outline: none;
-  height: 100%;
+  overflow: hidden;
+  height: ${({ $height }) => `${$height}px` ?? "100%"};
   width: 100%;
+  background: ${({ theme }) => theme.click.grid.body.cell.color.background.default};
+  border-radius: ${({ theme, $rounded }) => theme.click.grid.radii[$rounded]};
+  ${({ $showBorder, theme }) =>
+    $showBorder &&
+    `border: 1px solid ${theme.click.grid.header.cell.color.stroke.default}`};
 `;
 
 interface InnerElementTypeTypes extends HTMLAttributes<HTMLDivElement> {
   children: Array<ReactElement>;
 }
-const OuterElementContainer = styled.div`
-  background: ${({ theme }) => theme.click.grid.body.cell.color.background.default};
-`;
 
 const OuterElementType = forwardRef<HTMLDivElement>((props, ref) => (
-  <OuterElementContainer
+  <div
     ref={ref}
     data-testid="grid-outer-element"
     {...props}
@@ -104,6 +112,7 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
   (
     {
       autoFocus,
+      autoHeight = false,
       rowStart = 0,
       showRowNumber = true,
       rounded = "none",
@@ -352,7 +361,6 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
       cell,
       rowCount,
       columnCount,
-      rounded,
       showHeader,
       focus: focusProp ?? focus,
       getSelectionType,
@@ -386,7 +394,6 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
                 headerHeight={headerHeight}
                 rowWidth={rowNumberWidth}
                 rowCount={rowCount}
-                rounded={rounded}
                 getSelectionType={getSelectionType}
                 showHeader={showHeader}
                 rowStart={rowStart}
@@ -405,7 +412,6 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
                 columnWidth={columnWidth}
                 cell={cell}
                 rowNumberWidth={rowNumberWidth}
-                rounded={rounded}
                 getSelectionType={getSelectionType}
                 columnCount={columnCount}
                 onColumnResize={onColumnResize}
@@ -723,6 +729,15 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
           onPointerLeave={setPointerCapture}
           onPointerEnter={setPointerCapture}
           onContextMenu={onContextMenu}
+          $rounded={rounded}
+          $height={
+            autoHeight
+              ? rowCount * rowHeight +
+                (showHeader ? headerHeight : 0) +
+                elementBorderRef.current.scrollBarHeight
+              : undefined
+          }
+          $showBorder={showBorder}
         >
           <AutoSizer onResize={onResize}>
             {({ height, width }) => (

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -100,9 +100,10 @@ const OuterElementType = forwardRef<HTMLDivElement>((props, ref) => (
   />
 ));
 
-export const Grid = forwardRef<VariableSizeGrid, GridProps>(
+export const Grid = forwardRef<HTMLDivElement, GridProps>(
   (
     {
+      autoFocus,
       rowStart = 0,
       showRowNumber = true,
       rounded = "none",
@@ -127,6 +128,7 @@ export const Grid = forwardRef<VariableSizeGrid, GridProps>(
       showBorder = false,
       onCopy: onCopyProp,
       onContextMenu: onContextMenuProp,
+      forwardedGridRef,
       ...props
     },
     forwardedRef
@@ -417,8 +419,10 @@ export const Grid = forwardRef<VariableSizeGrid, GridProps>(
       }
     );
     useEffect(() => {
-      containerRef.current?.focus();
-    }, []);
+      if (autoFocus) {
+        containerRef.current?.focus();
+      }
+    }, [autoFocus]);
 
     const onMouseDown: MouseEventHandler<HTMLDivElement> = useCallback(
       e => {
@@ -709,7 +713,7 @@ export const Grid = forwardRef<VariableSizeGrid, GridProps>(
       >
         <ContextMenuTrigger
           as={ContextMenu.Trigger}
-          ref={containerRef}
+          ref={mergeRefs([forwardedRef, containerRef])}
           tabIndex={0}
           onMouseDown={onMouseDown}
           onMouseMove={onMouseMove}
@@ -723,7 +727,7 @@ export const Grid = forwardRef<VariableSizeGrid, GridProps>(
           <AutoSizer onResize={onResize}>
             {({ height, width }) => (
               <VariableSizeGrid
-                ref={mergeRefs([forwardedRef, gridRef])}
+                ref={forwardedGridRef ? mergeRefs([forwardedGridRef, gridRef]) : gridRef}
                 height={height}
                 width={width}
                 columnCount={columnCount}

--- a/src/components/Grid/Header.tsx
+++ b/src/components/Grid/Header.tsx
@@ -2,7 +2,6 @@ import styled from "styled-components";
 import {
   CellProps,
   ColumnResizeFn,
-  RoundedType,
   SelectionTypeFn,
   SetResizeCursorPositionFn,
 } from "./types";
@@ -18,7 +17,6 @@ interface HeaderProps {
   columnWidth: (index: number) => number;
   cell: CellProps;
   getSelectionType: SelectionTypeFn;
-  rounded: RoundedType;
   columnCount: number;
   onColumnResize: ColumnResizeFn;
   getColumnHorizontalPosition: (columnIndex: number) => number;
@@ -53,7 +51,6 @@ interface ColumnProps
     HeaderProps,
     | "cell"
     | "getSelectionType"
-    | "rounded"
     | "onColumnResize"
     | "columnWidth"
     | "height"
@@ -104,7 +101,6 @@ const RowColumn = styled(StyledCell)`
 const Column = ({
   columnIndex,
   cell,
-  rounded,
   columnWidth,
   getColumnHorizontalPosition,
   getSelectionType,
@@ -142,7 +138,6 @@ const Column = ({
         as={cell}
         columnIndex={columnIndex}
         type="header-cell"
-        $rounded={rounded}
         $isFirstColumn={isFirstColumn}
         $selectionType={selectionType}
         $isLastColumn={isLastColumn}
@@ -177,7 +172,6 @@ const Header = ({
   height,
   columnWidth,
   cell,
-  rounded,
   columnCount,
   getSelectionType,
   onColumnResize,
@@ -205,7 +199,6 @@ const Header = ({
             columnWidth={columnWidth}
             getColumnHorizontalPosition={getColumnHorizontalPosition}
             cell={cell}
-            rounded={rounded}
             isFirstColumn={columnIndex === 0 && !showRowNumber}
             isLastColumn={columnIndex + 1 === columnCount}
             onColumnResize={onColumnResize}
@@ -227,7 +220,6 @@ const Header = ({
             $type="header"
             $isFirstRow
             $isFirstColumn
-            $rounded={rounded}
             $selectionType={selectedAllType}
             $isLastRow={false}
             $isLastColumn={false}

--- a/src/components/Grid/Header.tsx
+++ b/src/components/Grid/Header.tsx
@@ -25,6 +25,7 @@ interface HeaderProps {
   scrolledVertical: boolean;
   setResizeCursorPosition: SetResizeCursorPositionFn;
   showBorder: boolean;
+  scrolledHorizontal: boolean;
 }
 
 const HeaderContainer = styled.div<{ $height: number; $scrolledVertical: boolean }>`
@@ -82,12 +83,17 @@ const HeaderCellContainer = styled.div<{
 
 const RowColumnContainer = styled(HeaderCellContainer)<{
   $width: string | number;
+  $scrolledHorizontal: boolean;
 }>`
   position: sticky;
   top: 0;
   left: 0;
   width: ${({ $width }) => (typeof $width === "string" ? $width : `${$width}px`)};
   text-align: right;
+  ${({ $scrolledHorizontal, theme }) =>
+    $scrolledHorizontal
+      ? `box-shadow: 0px 0 0px 1px ${theme.click.grid.header.cell.color.stroke.default};`
+      : ""}
 `;
 
 const RowColumn = styled(StyledCell)`
@@ -163,6 +169,7 @@ const Column = ({
 
 const Header = ({
   scrolledVertical,
+  scrolledHorizontal,
   showRowNumber,
   rowNumberWidth,
   minColumn,
@@ -213,6 +220,7 @@ const Header = ({
           $width={rowNumberWidth}
           $height={height}
           $columnPosition={0}
+          $scrolledHorizontal={scrolledHorizontal}
         >
           <RowColumn
             data-selected={selectedAllType === "selectDirect"}

--- a/src/components/Grid/RowNumberColumn.tsx
+++ b/src/components/Grid/RowNumberColumn.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { RoundedType, SelectionTypeFn } from "./types";
+import { SelectionTypeFn } from "./types";
 import { StyledCell } from "./StyledCell";
 const RowNumberColumnContainer = styled.div<{
   $height: number;
@@ -43,7 +43,6 @@ interface RowNumberColumnProps {
   rowWidth: number;
   getSelectionType: SelectionTypeFn;
   rowCount: number;
-  rounded: RoundedType;
   showHeader: boolean;
   scrolledHorizontal: boolean;
   rowStart: number;
@@ -52,7 +51,7 @@ interface RowNumberColumnProps {
 interface RowNumberProps
   extends Pick<
     RowNumberColumnProps,
-    "rowHeight" | "getSelectionType" | "rounded" | "showBorder" | "rowStart"
+    "rowHeight" | "getSelectionType" | "showBorder" | "rowStart"
   > {
   rowIndex: number;
   isLastRow: boolean;
@@ -63,7 +62,6 @@ const RowNumber = ({
   rowHeight,
   getSelectionType,
   isLastRow,
-  rounded,
   isFirstRow,
   showBorder,
   rowStart,
@@ -91,7 +89,6 @@ const RowNumber = ({
         $height={rowHeight}
         $isLastColumn={false}
         $selectionType={selectionType}
-        $rounded={rounded}
         $isFirstColumn
         $type="header"
         $isFirstRow={isFirstRow}
@@ -120,7 +117,6 @@ const RowNumberColumn = ({
   rowWidth,
   getSelectionType,
   rowCount,
-  rounded,
   showHeader,
   scrolledHorizontal,
   rowStart = 0,
@@ -140,7 +136,6 @@ const RowNumberColumn = ({
             rowHeight={rowHeight}
             rowIndex={rowIndex}
             isLastRow={rowIndex === rowCount}
-            rounded={rounded}
             isFirstRow={!showHeader && rowIndex === 0}
             showBorder={showBorder}
             rowStart={rowStart}

--- a/src/components/Grid/StyledCell.tsx
+++ b/src/components/Grid/StyledCell.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { RoundedType, SelectionType } from "./types";
+import { SelectionType } from "./types";
 
 export const StyledCell = styled.div<{
   $isFocused: boolean;
@@ -10,7 +10,6 @@ export const StyledCell = styled.div<{
   $isLastColumn: boolean;
   $isFirstRow: boolean;
   $isFirstColumn: boolean;
-  $rounded: RoundedType;
   $height: number;
   $type?: "body" | "header";
   $showBorder: boolean;
@@ -68,14 +67,22 @@ export const StyledCell = styled.div<{
     ${
       $isLastRow
         ? `
-        border-bottom-color: ${theme.click.grid[$type].cell.color.stroke.default};
+        border-bottom-color: ${
+          theme.click.grid[$type].cell.color.stroke[
+            $isFocused ? "selectDirect" : $selectionType
+          ]
+        };
     `
         : "border-bottom: none;"
     }
     ${
       $isLastColumn
         ? `
-        border-right-color: ${theme.click.grid[$type].cell.color.stroke.default};
+        border-right-color: ${
+          theme.click.grid[$type].cell.color.stroke[
+            $isFocused ? "selectDirect" : $selectionType
+          ]
+        };
     `
         : "border-right: none;"
     }
@@ -97,7 +104,7 @@ export const StyledCell = styled.div<{
             content: "";
             position: absolute;
             top: 0;
-            bottom: -1px;
+            bottom: 0;
             right: 0;
             left: 0;
             ${
@@ -123,21 +130,4 @@ export const StyledCell = styled.div<{
           }
         `
       : ""};
-  ${({ theme, $isFirstRow, $isFirstColumn, $rounded, $isLastColumn }) => `
-
-    ${
-      $isFirstColumn
-        ? `border-${$isFirstRow ? "top" : "bottom"}-left-radius: ${
-            theme.click.grid.radii[$rounded]
-          };`
-        : ""
-    }
-    ${
-      $isLastColumn
-        ? `border-${$isFirstRow ? "top" : "bottom"}-right-radius: ${
-            theme.click.grid.radii[$rounded]
-          };`
-        : ""
-    }
-  `}
 `;

--- a/src/components/Grid/types.ts
+++ b/src/components/Grid/types.ts
@@ -151,7 +151,6 @@ export interface ItemDataType {
   columnCount: number;
   cell: CellProps;
   focus: SelectionFocus;
-  rounded: RoundedType;
   rowHeight: number;
   headerHeight: number;
   rowNumberWidth: number;
@@ -176,6 +175,7 @@ export interface GridProps
     | "columnWidth"
   > {
   autoFocus?: boolean;
+  autoHeight?: boolean;
   rowStart?: number;
   rounded?: RoundedType;
   focus?: SelectionFocus;

--- a/src/components/Grid/types.ts
+++ b/src/components/Grid/types.ts
@@ -3,9 +3,10 @@ import {
   HTMLAttributes,
   KeyboardEventHandler,
   MouseEventHandler,
+  MutableRefObject,
   ReactNode,
 } from "react";
-import { VariableSizeGridProps } from "react-window";
+import { VariableSizeGrid, VariableSizeGridProps } from "react-window";
 import { ContextMenuItemProps } from "@/components";
 
 interface CellCommonProps extends HTMLAttributes<HTMLElement> {
@@ -174,6 +175,7 @@ export interface GridProps
     | "outerRef"
     | "columnWidth"
   > {
+  autoFocus?: boolean;
   rowStart?: number;
   rounded?: RoundedType;
   focus?: SelectionFocus;
@@ -198,6 +200,7 @@ export interface GridProps
   showBorder?: boolean;
   onCopy?: (isCopied: boolean) => void | Promise<void>;
   onContextMenu?: MouseEventHandler<HTMLDivElement>;
+  forwardedGridRef?: MutableRefObject<VariableSizeGrid>;
 }
 
 export type SetResizeCursorPositionFn = (

--- a/src/components/Grid/useColumns.ts
+++ b/src/components/Grid/useColumns.ts
@@ -76,8 +76,7 @@ const useColumns = ({
           outerGridRef.current
             .querySelectorAll<HTMLDivElement>(`[data-grid-column="${columnIndex}"]`)
             .forEach(item => {
-              item.style.width = "fit-content";
-              newWidth = Math.max(newWidth, item.scrollWidth);
+              newWidth = Math.max(newWidth, item.scrollWidth + 2); // +2 inorder to avoid the ellipsis
             });
           autoWidthIndices.current.push(columnIndex);
         }


### PR DESCRIPTION
The below issues are fixed

- The grid page number border is not shown when scrolled
- The border radius is applied to all the rows which are first and last column

The below features are added
- Add feature to have autoHeight
- Add autoFocus to have focus on loading
<img width="1098" alt="Screenshot 2024-02-23 at 11 49 14" src="https://github.com/ClickHouse/click-ui/assets/17908918/44a2f1cd-8d9c-4b57-b609-cbb29a8b7fdd">
