### PR TITLE
Adding a boolean to allow the search icon to change

### DIFF
--- a/src/components/Input/SearchField.stories.tsx
+++ b/src/components/Input/SearchField.stories.tsx
@@ -12,7 +12,7 @@ const SearchField = ({
   }, [valueProp]);
 
   return (
-    <Container maxWidth="350px">
+    <Container maxWidth="75%">
       <SearchFieldInput
         value={value}
         onChange={(inputValue: string) => {
@@ -38,7 +38,6 @@ export default {
     readOnly: { control: "boolean" },
     orientation: { control: "inline-radio", options: ["horizontal", "vertical"] },
     dir: { control: "inline-radio", options: ["start", "end"] },
-    isFilter: { control: "boolean" },
   },
 };
 
@@ -47,10 +46,5 @@ export const Playground = {
     label: "Label",
     disabled: false,
     placeholder: "Placeholder",
-    clear: false,
-    readOnly: false,
-    isFilter: false,
-    value: "",
-    error: "",
   },
 };

--- a/src/components/Input/SearchField.stories.tsx
+++ b/src/components/Input/SearchField.stories.tsx
@@ -12,7 +12,7 @@ const SearchField = ({
   }, [valueProp]);
 
   return (
-    <Container maxWidth="75%">
+    <Container maxWidth="350px">
       <SearchFieldInput
         value={value}
         onChange={(inputValue: string) => {
@@ -38,6 +38,7 @@ export default {
     readOnly: { control: "boolean" },
     orientation: { control: "inline-radio", options: ["horizontal", "vertical"] },
     dir: { control: "inline-radio", options: ["start", "end"] },
+    isFilter: { control: "boolean" },
   },
 };
 
@@ -46,5 +47,10 @@ export const Playground = {
     label: "Label",
     disabled: false,
     placeholder: "Placeholder",
+    clear: false,
+    readOnly: false,
+    isFilter: false,
+    value: "",
+    error: "",
   },
 };

--- a/src/components/Input/SearchField.tsx
+++ b/src/components/Input/SearchField.tsx
@@ -15,6 +15,7 @@ export interface SearchFieldProps
   onChange: (inputValue: string, e?: ChangeEvent<HTMLInputElement>) => void;
   orientation?: "vertical" | "horizontal";
   dir?: "start" | "end";
+  isFilter?: boolean;
 }
 
 export const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
@@ -30,6 +31,7 @@ export const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
       onChange: onChangeProp,
       orientation,
       dir,
+      isFilter = false,
       ...props
     },
     ref
@@ -53,9 +55,10 @@ export const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
         dir={dir}
       >
         <Icon
-          name="search"
+          name={isFilter ? "filter" : "search"}
           size="sm"
         />
+
         <InputElement
           ref={mergeRefs([inputRef, ref])}
           type="text"

--- a/src/components/Input/SearchField.tsx
+++ b/src/components/Input/SearchField.tsx
@@ -15,7 +15,6 @@ export interface SearchFieldProps
   onChange: (inputValue: string, e?: ChangeEvent<HTMLInputElement>) => void;
   orientation?: "vertical" | "horizontal";
   dir?: "start" | "end";
-  isFilter?: boolean;
 }
 
 export const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
@@ -31,7 +30,6 @@ export const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
       onChange: onChangeProp,
       orientation,
       dir,
-      isFilter,
       ...props
     },
     ref
@@ -55,10 +53,9 @@ export const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
         dir={dir}
       >
         <Icon
-          name={isFilter ? "filter" : "search"}
+          name="search"
           size="sm"
         />
-
         <InputElement
           ref={mergeRefs([inputRef, ref])}
           type="text"

--- a/src/components/Input/SearchField.tsx
+++ b/src/components/Input/SearchField.tsx
@@ -15,6 +15,7 @@ export interface SearchFieldProps
   onChange: (inputValue: string, e?: ChangeEvent<HTMLInputElement>) => void;
   orientation?: "vertical" | "horizontal";
   dir?: "start" | "end";
+  isFilter?: boolean;
 }
 
 export const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
@@ -30,6 +31,7 @@ export const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
       onChange: onChangeProp,
       orientation,
       dir,
+      isFilter,
       ...props
     },
     ref
@@ -53,9 +55,10 @@ export const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
         dir={dir}
       >
         <Icon
-          name="search"
+          name={isFilter ? "filter" : "search"}
           size="sm"
         />
+
         <InputElement
           ref={mergeRefs([inputRef, ref])}
           type="text"


### PR DESCRIPTION
### Summary
In the search field, the only icon option is the search icon, but sometimes the search field can be used to filter items rather than search. For these times, I've added a `isFilter` boolean that switches the icon. 

#### Video 
https://github.com/ClickHouse/click-ui/assets/305167/f3398c54-bd67-4d0a-981c-cee92dbaa29d

