### PR TITLE
Fix overlap issue in flyout

### DIFF
--- a/src/components/Flyout/Flyout.tsx
+++ b/src/components/Flyout/Flyout.tsx
@@ -464,6 +464,7 @@ const CustomCodeBlock = styled(CodeBlock)`
   height: 100%;
   pre {
     flex: 1;
+    overflow-wrap: break-word;
     code {
       display: inline-block;
       max-width: calc(100% - 1rem);
@@ -471,7 +472,7 @@ const CustomCodeBlock = styled(CodeBlock)`
   }
 `;
 
-interface FlyoutCodeBlockProps {
+interface FlyoutCodeBlockProps extends ContainerProps {
   language?: string;
   statement: string;
   showLineNumbers?: boolean;


### PR DESCRIPTION
The wrapping of the content so that the element does not overlap the copy button 