### PR TITLE
Fix crashing Grid story

### DIFF
--- a/src/components/Grid/Grid.stories.tsx
+++ b/src/components/Grid/Grid.stories.tsx
@@ -93,7 +93,7 @@ export const Playground = {
     docs: {
       source: {
         transform: (_: string, story: { args: Props; [x: string]: unknown }) => {
-          const { focus, ...props } = story.args;
+          const { rowCount, columnCount, ...props } = story.args;
           return `const Cell: CellProps = ({ type, rowIndex, columnIndex, isScrolling, ...props }) => {
   return (
     <div {...props}>
@@ -102,9 +102,7 @@ export const Playground = {
   );
 };
 
-<Grid\n  cell={Cell}\n  focus={{ row: ${focus.row}, column: ${
-            focus.column
-          } }}// this value changes with onFocusChange and would be updated (user has control over it)\n  columnWidth={getColumnWidth}// this determines the
+<Grid\n  cell={Cell}\n  focus={{ row: ${rowCount}, column: ${columnCount} }}// this value changes with onFocusChange and would be updated (user has control over it)\n  columnWidth={getColumnWidth}// this determines the
   onFocusChange={(row: number, column: number) => {}}// change focus and update state
   onColumnResize={(columnIndex: number, newWidth: number): void => {}}// update columnWidth using this function on resize
   getMenuOptions={getMenuOptions}\n${Object.entries(props)


### PR DESCRIPTION
Storybook is crashing on the `Grid` story because of an attempted access on an `undefined` object.