### PR TITLE
Fix collapsible width issue

### DIFF
--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -26,6 +26,9 @@ const NavContext = createContext<ContextProps>({
   open: false,
   onOpenChange: () => null,
 });
+const CollapsibleContainer = styled.div`
+  width: 100%;
+`;
 
 export const Collapsible = ({
   open: openProp,
@@ -52,9 +55,9 @@ export const Collapsible = ({
     onOpenChange,
   };
   return (
-    <div {...props}>
+    <CollapsibleContainer {...props}>
       <NavContext.Provider value={value}>{children}</NavContext.Provider>
-    </div>
+    </CollapsibleContainer>
   );
 };
 

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -8,17 +8,11 @@ import {
   forwardRef,
 } from "react";
 import styled from "styled-components";
-import {
-  Icon,
-  HorizontalDirection,
-  IconName,
-  ContainerProps,
-  Container,
-} from "@/components";
+import { Icon, HorizontalDirection, IconName } from "@/components";
 import { EmptyButton } from "../commonElement";
 import { IconWrapper } from "./IconWrapper";
 
-export interface CollapsibleProps extends ContainerProps {
+export interface CollapsibleProps extends HTMLAttributes<HTMLDivElement> {
   open?: boolean;
   onOpenChange?: (value: boolean) => void;
 }
@@ -58,12 +52,9 @@ export const Collapsible = ({
     onOpenChange,
   };
   return (
-    <Container
-      isResponsive={false}
-      {...props}
-    >
+    <div {...props}>
       <NavContext.Provider value={value}>{children}</NavContext.Provider>
-    </Container>
+    </div>
   );
 };
 


### PR DESCRIPTION
Using the container broke sql-console and reverted the changes and added the width: 100%;
Flex was not working as the content was in absolute and did not have width present when the react virtualized was creating the item
Another issue is that the flex was not column based but row based