### PR TITLE
Replacing P with Text in the Accordion

### DIFF
--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -13,6 +13,10 @@ export default {
       options: ["sm", "md", "lg"],
       control: { type: "radio" },
     },
+    gap: {
+      options: ["sm", "md", "lg"],
+      control: { type: "radio" },
+    },
     color: {
       options: ["default", "link"],
       control: { type: "radio" },
@@ -38,6 +42,7 @@ export const Playground = {
   args: {
     title: "Accordion title",
     size: "md",
+    gap: "md",
     color: "default",
     children,
   },

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -1,9 +1,10 @@
 import * as RadixAccordion from "@radix-ui/react-accordion";
 import styled from "styled-components";
 import { IconSize } from "@/components/Icon/types";
-import { Icon, IconName } from "@/components";
+import { Icon, IconName, Spacer, Text } from "@/components";
 
 type Size = "sm" | "md" | "lg";
+type Gap = "sm" | "md" | "lg";
 type Color = "default" | "link";
 
 export interface AccordionProps
@@ -13,6 +14,7 @@ export interface AccordionProps
   color?: Color;
   icon?: IconName;
   iconSize?: IconSize;
+  gap?: Gap;
   children: React.ReactNode;
 }
 
@@ -26,6 +28,7 @@ const Accordion = ({
   color,
   icon,
   iconSize,
+  gap,
   children,
   ...delegated
 }: AccordionProps) => (
@@ -54,8 +57,9 @@ const Accordion = ({
             />
           ) : null}
         </AccordionIconsWrapper>
-        <p>{title}</p>
+        <Text size={size}>{title}</Text>
       </AccordionTrigger>
+      <Spacer size={gap} />
       <AccordionContent>{children}</AccordionContent>
     </RadixAccordion.Item>
   </RadixAccordion.Root>


### PR DESCRIPTION
### Summary
- Replacing `p` with `Text` to remove the large padding area above and below the accordion.
- Adding a spacer to separate accordion from content
- Adding a `Gap` prop to optionally control the space between the accordion and the content (useful when using the small or large sized accordion)

Note: This will largely fix spacing issues with accordions in the Unified Console, however we should double check when upgrading as a few may need a <spacer> above. 