### PR TITLE
Grid: change toast text on copy to mention pasting

### DIFF
--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -168,7 +168,7 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
         if (showToast) {
           createToast({
             title: "Copied successfully",
-            description: "Now you can copy the content",
+            description: "Now you can paste the content",
             type: "success",
           });
         }


### PR DESCRIPTION
Helps with https://github.com/ClickHouse/control-plane-qa/issues/107

See [this comment](https://github.com/ClickHouse/control-plane/pull/7774#issuecomment-2004437534) which brings up the good point that when the toast is being shown, the content has already been copied. So it should mention pasting, not copying.