### PR TITLE
Add CheckboxMultiSelect

### DIFF
--- a/src/components/Select/CheckboxMultiSelect.stories.tsx
+++ b/src/components/Select/CheckboxMultiSelect.stories.tsx
@@ -20,7 +20,7 @@ const CheckboxMultiSelectExample = ({ childrenType, value, ...props }: Props) =>
         value={selectedValues}
         options={selectOptions}
         onSelect={value => setSelectedValues(value)}
-        selectLabel="Columns"
+        selectLabel="Columns;"
         {...props}
       />
     );
@@ -73,6 +73,7 @@ export default {
     showCheck: { control: "boolean" },
     orientation: { control: "inline-radio", options: ["horizontal", "vertical"] },
     dir: { control: "inline-radio", options: ["start", "end"] },
+    selectLabel: { control: "text" },
   },
 };
 

--- a/src/components/Select/CheckboxMultiSelect.stories.tsx
+++ b/src/components/Select/CheckboxMultiSelect.stories.tsx
@@ -35,6 +35,7 @@ const CheckboxMultiSelectExample = ({ childrenType, value, ...props }: Props) =>
         <CheckboxMultiSelect.Item
           value="content0"
           icon="user"
+          iconDir="start"
         >
           Content0
         </CheckboxMultiSelect.Item>

--- a/src/components/Select/CheckboxMultiSelect.stories.tsx
+++ b/src/components/Select/CheckboxMultiSelect.stories.tsx
@@ -1,0 +1,133 @@
+import { MultiSelectProps } from "..";
+import { CheckboxMultiSelect } from "./CheckboxMultiSelect";
+import { selectOptions } from "./selectOptions";
+import { useEffect, useState } from "react";
+interface Props extends Omit<MultiSelectProps, "value"> {
+  value: string;
+  childrenType: "children" | "options";
+}
+const CheckboxMultiSelectExample = ({ childrenType, value, ...props }: Props) => {
+  const [selectedValues, setSelectedValues] = useState(
+    value ? value.split(",") : undefined
+  );
+  useEffect(() => {
+    setSelectedValues(value ? value.split(",") : undefined);
+  }, [value]);
+
+  if (childrenType === "options") {
+    return (
+      <CheckboxMultiSelect
+        value={selectedValues}
+        options={selectOptions}
+        onSelect={value => setSelectedValues(value)}
+        selectLabel="Columns"
+        {...props}
+      />
+    );
+  }
+  return (
+    <CheckboxMultiSelect
+      value={value ? value.split(",") : undefined}
+      selectLabel="Columns"
+      {...props}
+    >
+      <CheckboxMultiSelect.Group heading="Group label">
+        <CheckboxMultiSelect.Item
+          value="content0"
+          icon="user"
+        >
+          Content0
+        </CheckboxMultiSelect.Item>
+      </CheckboxMultiSelect.Group>
+      <div>
+        <CheckboxMultiSelect.Item value="content1">
+          Content1 long text content
+        </CheckboxMultiSelect.Item>
+      </div>
+      <CheckboxMultiSelect.Item
+        value="content2"
+        label="Content2"
+      />
+      <CheckboxMultiSelect.Item value="content3">Content3</CheckboxMultiSelect.Item>
+    </CheckboxMultiSelect>
+  );
+};
+export default {
+  component: CheckboxMultiSelectExample,
+  title: "Forms/CheckboxMultiSelect",
+  tags: ["form-field", "select", "autodocs"],
+  argTypes: {
+    label: { control: "text" },
+    disabled: { control: "boolean" },
+    sortable: { control: "boolean" },
+    error: { control: "text" },
+    value: { control: "text" },
+    defaultValue: { control: "text" },
+    childrenType: { control: "radio", options: ["children", "options"] },
+    name: { control: "text" },
+    required: { control: "boolean" },
+    showSearch: { control: "boolean" },
+    form: { control: "text" },
+    allowCreateOption: { control: "boolean" },
+    showCheck: { control: "boolean" },
+    orientation: { control: "inline-radio", options: ["horizontal", "vertical"] },
+    dir: { control: "inline-radio", options: ["start", "end"] },
+  },
+};
+
+export const Playground = {
+  args: {
+    label: "Label",
+    value: "content1",
+    showSearch: false,
+    childrenType: "children",
+  },
+  parameters: {
+    docs: {
+      source: {
+        transform: (_: string, story: { args: Props; [x: string]: unknown }) => {
+          const { allowCreateOption, childrenType, value, ...props } = story.args;
+          return `<CheckboxMultiSelect\n  value={${JSON.stringify(
+            (value ?? "").split(",")
+          )}}\n${allowCreateOption ? "  allowCreateOption\n" : ""}
+          ${Object.entries(props)
+            .flatMap(([key, value]) =>
+              typeof value === "boolean"
+                ? value
+                  ? `  ${key}`
+                  : []
+                : `  ${key}=${typeof value == "string" ? `"${value}"` : `{${value}}`}`
+            )
+            .join("\n")}
+${
+  childrenType === "options"
+    ? `options={${JSON.stringify(selectOptions, null, 2)}}\n/`
+    : ""
+}>
+${
+  childrenType === "children"
+    ? `
+    <CheckboxMultiSelect.Group heading="Group label">
+      <CheckboxMultiSelect.Item value="content0" icon="user">
+        Content0
+      </CheckboxMultiSelect.Item>
+    </CheckboxMultiSelect.Group>
+    <div>
+      <CheckboxMultiSelect.Item value="content1">Content1 long text content</CheckboxMultiSelect.Item>
+    </div>
+    <CheckboxMultiSelect.Item
+      value="content2"
+      disabled
+    >
+      Content2
+    </CheckboxMultiSelect.Item>
+    <CheckboxMultiSelect.Item value="content3">Content3</CheckboxMultiSelect.Item>
+</CheckboxMultiSelect>
+`
+    : ""
+}`;
+        },
+      },
+    },
+  },
+};

--- a/src/components/Select/CheckboxMultiSelect.test.tsx
+++ b/src/components/Select/CheckboxMultiSelect.test.tsx
@@ -1,0 +1,303 @@
+import {
+  act,
+  fireEvent,
+  queryByText as queryByTestingText,
+  screen,
+} from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { CheckboxMultiSelect, CheckboxMultiSelectProps } from "./CheckboxMultiSelect";
+import { ReactNode } from "react";
+import { renderCUI } from "@/utils/test-utils";
+import { selectOptions } from "./selectOptions";
+
+interface Props extends Omit<CheckboxMultiSelectProps, "children" | "label"> {
+  nodata?: ReactNode;
+  showSearch?: boolean;
+}
+
+const renderSelect = (props: Props) => {
+  if (props.options) {
+    return renderCUI(
+      <CheckboxMultiSelect
+        label="Test CheckboxMultiSelect Label"
+        {...props}
+      />
+    );
+  }
+
+  return renderCUI(
+    <CheckboxMultiSelect
+      label="Test CheckboxMultiSelect Label"
+      {...props}
+    >
+      <CheckboxMultiSelect.Group heading="Group label">
+        <CheckboxMultiSelect.Item value="content0">Content0</CheckboxMultiSelect.Item>
+      </CheckboxMultiSelect.Group>
+      <CheckboxMultiSelect.Item value="content1">
+        Content1 long text content
+      </CheckboxMultiSelect.Item>
+      <CheckboxMultiSelect.Item
+        value="content2"
+        disabled
+      >
+        Content2
+      </CheckboxMultiSelect.Item>
+      <CheckboxMultiSelect.Item value="content3">Content3</CheckboxMultiSelect.Item>
+      <CheckboxMultiSelect.Item
+        value="content4"
+        label="Content4"
+      />
+    </CheckboxMultiSelect>
+  );
+};
+
+describe("CheckboxCheckboxMultiSelect", () => {
+  beforeAll(() => {
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
+    global.ResizeObserver = jest.fn().mockImplementation(() => ({
+      observe: jest.fn(),
+      unobserve: jest.fn(),
+      disconnect: jest.fn(),
+    }));
+  });
+
+  it("opens on click", () => {
+    const { queryByText } = renderSelect({});
+    const selectTrigger = queryByText("Select an option");
+    expect(selectTrigger).toBeInTheDocument();
+    selectTrigger && fireEvent.click(selectTrigger);
+
+    expect(queryByText("Content0")).toBeInTheDocument();
+  });
+
+  it("shows the label if one is passed in", () => {
+    const { queryByText, getByTestId, getByText } = renderSelect({
+      selectLabel: "Do something",
+      value: ["content0", "content1"],
+    });
+
+    const selectTrigger = getByTestId("select-trigger");
+
+    expect(queryByTestingText(selectTrigger, "Do something")).toBeInTheDocument();
+
+    selectTrigger && fireEvent.click(selectTrigger);
+    expect(queryByText("Content3")).toBeInTheDocument();
+
+    act(() => {
+      getByText("Content3").click();
+    });
+
+    expect(queryByTestingText(selectTrigger, "Do something")).toBeInTheDocument();
+    expect(queryByTestingText(selectTrigger, "Content3")).not.toBeInTheDocument();
+  });
+
+  it("shows allows checking and unchecking", async () => {
+    const { getByTestId } = renderSelect({
+      selectLabel: "Select columns",
+      value: ["content0", "content1"],
+    });
+
+    const selectTrigger = getByTestId("select-trigger");
+    selectTrigger && fireEvent.click(selectTrigger);
+
+    expect(screen.getByTestId("multi-select-checkbox-content0")).toHaveAttribute(
+      "data-state",
+      "checked"
+    );
+
+    const content2 = screen.getByTestId("multi-select-checkbox-content2");
+    expect(content2).toHaveAttribute("data-state", "unchecked");
+
+    const checkbox = content2.querySelector("[data-testid='multi-select-checkbox']");
+    checkbox && fireEvent.click(checkbox);
+    expect(screen.getByTestId("multi-select-checkbox-content2")).toHaveAttribute(
+      "data-state",
+      "checked"
+    );
+  });
+
+  it("shows errors", () => {
+    const { queryByText } = renderSelect({
+      error: "Select Error",
+    });
+    expect(queryByText("Select an option")).toBeInTheDocument();
+    expect(queryByText("Select Error")).toBeInTheDocument();
+  });
+
+  it("should not open a disabled select on click", () => {
+    const { getByTestId, queryByText } = renderSelect({
+      selectLabel: "Do the thing",
+      disabled: true,
+    });
+
+    const selectTrigger = getByTestId("select-trigger");
+    selectTrigger && fireEvent.click(selectTrigger);
+
+    expect(queryByText("Content0")).not.toBeInTheDocument();
+  });
+
+  it("closes on clicking outside content", () => {
+    const { getByTestId, queryByText } = renderSelect({ selectLabel: "Do the thing" });
+
+    const selectTrigger = getByTestId("select-trigger");
+    selectTrigger && fireEvent.click(selectTrigger);
+
+    expect(queryByText("Content0")).toBeInTheDocument();
+    selectTrigger && fireEvent.click(selectTrigger);
+    expect(queryByText("Content0")).not.toBeInTheDocument();
+  });
+
+  it("does not close when selecting an item", () => {
+    const { queryByText, getByTestId } = renderSelect({ selectLabel: "Do the thing" });
+
+    const selectTrigger = getByTestId("select-trigger");
+    selectTrigger && fireEvent.click(selectTrigger);
+
+    const item = queryByText("Content0");
+    expect(item).toBeInTheDocument();
+    item && fireEvent.click(item);
+    expect(item).toBeInTheDocument();
+    expect(getByTestId("select-trigger")).toHaveTextContent("Do the thing");
+  });
+
+  it("does not close when selecting a diabled item", () => {
+    const { getByTestId, queryByText } = renderSelect({ selectLabel: "Select" });
+
+    const selectTrigger = getByTestId("select-trigger");
+    selectTrigger && fireEvent.click(selectTrigger);
+
+    const item = queryByText("Content4");
+    expect(item).toBeInTheDocument();
+    item && fireEvent.click(item);
+    expect(item).toBeInTheDocument();
+    expect(queryByText("Content1 long text content")).toBeInTheDocument();
+  });
+
+  it("renders options", () => {
+    const { queryByText, getByTestId } = renderSelect({
+      selectLabel: "A different label",
+      options: selectOptions,
+    });
+
+    const selectTrigger = getByTestId("select-trigger");
+    selectTrigger && fireEvent.click(selectTrigger);
+
+    const item = queryByText("Content0");
+    expect(item).toBeInTheDocument();
+    item && fireEvent.click(item);
+    expect(item).toBeInTheDocument();
+    expect(getByTestId("select-trigger")).toHaveTextContent("A different label");
+  });
+
+  describe("searching through items", () => {
+    it("shows all items on initial opening", () => {
+      const { getByTestId, queryByText } = renderSelect({
+        selectLabel: "Select an option",
+        showSearch: true,
+      });
+
+      const selectTrigger = getByTestId("select-trigger");
+      selectTrigger && fireEvent.click(selectTrigger);
+
+      expect(queryByText("Content0")).toBeInTheDocument();
+      expect(queryByText("Content1 long text content")).toBeInTheDocument();
+      expect(queryByText("Content2")).toBeInTheDocument();
+      expect(queryByText("Content3")).toBeInTheDocument();
+      expect(queryByText("Content4")).toBeInTheDocument();
+    });
+
+    it("filters items by search text", () => {
+      const { queryByText, getByTestId } = renderSelect({
+        selectLabel: "Do the thing",
+        showSearch: true,
+      });
+
+      const selectTrigger = getByTestId("select-trigger");
+      selectTrigger && fireEvent.click(selectTrigger);
+
+      expect(queryByText("Group label")).toBeVisible();
+      expect(queryByText("Content0")).toBeInTheDocument();
+      expect(queryByText("Content1 long text content")).toBeInTheDocument();
+      expect(queryByText("Content2")).toBeInTheDocument();
+      expect(queryByText("Content3")).toBeInTheDocument();
+      expect(queryByText("Content4")).toBeInTheDocument();
+      fireEvent.change(getByTestId("select-search-input"), {
+        target: { value: "content2" },
+      });
+      expect(queryByText("Content2")).toBeInTheDocument();
+      expect(queryByText("Content1 long text content")).not.toBeInTheDocument();
+      expect(queryByText("Group label")).not.toBeVisible();
+    });
+
+    it("filters by text", () => {
+      const { queryByText, getByTestId } = renderSelect({
+        selectLabel: "Pick something",
+        options: selectOptions,
+        showSearch: true,
+      });
+
+      const selectTrigger = getByTestId("select-trigger");
+      selectTrigger && fireEvent.click(selectTrigger);
+
+      expect(queryByText("Group label")).toBeVisible();
+      expect(queryByText("Content0")).toBeInTheDocument();
+      expect(queryByText("Content1 long text content")).toBeInTheDocument();
+      expect(queryByText("Content2")).toBeInTheDocument();
+      expect(queryByText("Content3")).toBeInTheDocument();
+      expect(queryByText("Content4")).toBeInTheDocument();
+      fireEvent.change(getByTestId("select-search-input"), {
+        target: { value: "content2" },
+      });
+      expect(queryByText("Content2")).toBeInTheDocument();
+      expect(queryByText("Content1 long text content")).not.toBeInTheDocument();
+      expect(queryByText("Group label")).not.toBeVisible();
+    });
+
+    it("shows all data after clearing", () => {
+      const { queryByText, getByTestId } = renderSelect({
+        selectLabel: "Pick something",
+        showSearch: true,
+      });
+
+      const selectTrigger = getByTestId("select-trigger");
+      selectTrigger && fireEvent.click(selectTrigger);
+
+      const selectInput = getByTestId("select-search-input");
+      fireEvent.change(selectInput, {
+        target: { value: "content2" },
+      });
+      expect(queryByText("Content2")).toBeInTheDocument();
+      expect(queryByText("Content1 long text content")).not.toBeInTheDocument();
+      expect(queryByText("Group label")).not.toBeVisible();
+      fireEvent.click(getByTestId("select-search-close"));
+      expect(queryByText("Group label")).toBeVisible();
+      expect(queryByText("Content0")).toBeInTheDocument();
+      expect(queryByText("Content1 long text content")).toBeInTheDocument();
+      expect(queryByText("Content2")).toBeInTheDocument();
+      expect(queryByText("Content3")).toBeInTheDocument();
+      expect(queryByText("Content4")).toBeInTheDocument();
+      expect(document.activeElement).toBe(selectInput);
+    });
+
+    it("shows no data when there are no options", () => {
+      const { queryByText, getByTestId } = renderSelect({
+        selectLabel: "Pick something",
+        showSearch: true,
+      });
+
+      const selectTrigger = getByTestId("select-trigger");
+      selectTrigger && fireEvent.click(selectTrigger);
+
+      fireEvent.change(getByTestId("select-search-input"), {
+        target: { value: "nodata" },
+      });
+      expect(queryByText("Content2")).not.toBeInTheDocument();
+      expect(queryByText("Content1 long text content")).not.toBeInTheDocument();
+      expect(queryByText("Group label")).not.toBeVisible();
+      const btn = queryByText(/No Options found/i);
+      expect(btn).toBeInTheDocument();
+      btn && fireEvent.click(btn);
+      expect(btn).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/Select/CheckboxMultiSelect.test.tsx
+++ b/src/components/Select/CheckboxMultiSelect.test.tsx
@@ -100,17 +100,21 @@ describe("CheckboxCheckboxMultiSelect", () => {
     const selectTrigger = getByTestId("select-trigger");
     selectTrigger && fireEvent.click(selectTrigger);
 
-    expect(screen.getByTestId("multi-select-checkbox-content0")).toHaveAttribute(
+    expect(
+      screen
+        .getByTestId("multi-select-checkbox-content0")
+        .querySelector("[role='checkbox']")
+    ).toHaveAttribute("data-state", "checked");
+
+    const content3 = screen.getByTestId("multi-select-checkbox-content3");
+    expect(content3.querySelector("[role='checkbox']")).toHaveAttribute(
       "data-state",
-      "checked"
+      "unchecked"
     );
 
-    const content2 = screen.getByTestId("multi-select-checkbox-content2");
-    expect(content2).toHaveAttribute("data-state", "unchecked");
-
-    const checkbox = content2.querySelector("[data-testid='multi-select-checkbox']");
+    const checkbox = content3.querySelector("[role='checkbox']");
     checkbox && fireEvent.click(checkbox);
-    expect(screen.getByTestId("multi-select-checkbox-content2")).toHaveAttribute(
+    expect(await content3.querySelector("[role='checkbox']")).toHaveAttribute(
       "data-state",
       "checked"
     );

--- a/src/components/Select/CheckboxMultiSelect.tsx
+++ b/src/components/Select/CheckboxMultiSelect.tsx
@@ -1,33 +1,28 @@
 import { useCallback, useEffect, useState } from "react";
 
-import { SelectContainerProps, SelectOptionProp, SelectionType } from "./common/types";
+import { SelectOptionProp, SelectionType } from "./common/types";
 import {
   SelectGroup,
-  SelectItem,
-  InternalSelect
+  InternalSelect,
+  MultiSelectCheckboxItem,
 } from "./common/InternalSelect";
 
-export interface MultiSelectProps
-  extends Omit<
-    SelectContainerProps,
-    "onChange" | "value" | "open" | "onOpenChange" | "onSelect"
-  > {
-  defaultValue?: Array<string>;
-  onSelect?: (value: Array<string>, type?: SelectionType) => void;
-  value?: Array<string>;
-  defaultOpen?: boolean;
-  onOpenChange?: (open: boolean) => void;
+import { MultiSelectProps } from "..";
+
+export interface CheckboxMultiSelectProps extends MultiSelectProps {
+  selectLabel?: string;
 }
 
-export const MultiSelect = ({
+export const CheckboxMultiSelect = ({
   value: valueProp,
   defaultValue,
   onSelect: onSelectProp,
   options,
   children,
   onOpenChange: onOpenChangeProp,
+  selectLabel,
   ...props
-}: MultiSelectProps) => {
+}: CheckboxMultiSelectProps) => {
   const [selectedValues, setSelectedValues] = useState<Array<string>>(
     valueProp ?? defaultValue ?? []
   );
@@ -81,16 +76,17 @@ export const MultiSelect = ({
   return (
     <InternalSelect
       onChange={onChange}
-      value={valueProp ?? selectedValues}
+      value={selectedValues}
       open={open}
       onOpenChange={onOpenChange}
       onSelect={onSelect}
-      multiple
+      checkbox={true}
+      selectLabel={selectLabel}
       {...conditionalProps}
       {...props}
     />
   );
 };
 
-MultiSelect.Group = SelectGroup;
-MultiSelect.Item = SelectItem;
+CheckboxMultiSelect.Group = SelectGroup;
+CheckboxMultiSelect.Item = MultiSelectCheckboxItem;

--- a/src/components/Select/common/InternalSelect.tsx
+++ b/src/components/Select/common/InternalSelect.tsx
@@ -336,7 +336,7 @@ export const InternalSelect = ({
                 ) : (
                   <SingleSelectValue
                     valueNode={
-                      checkbox
+                      checkbox && selectLabel
                         ? { label: selectLabel as string, value: selectLabel as string }
                         : valueNode.current.get(selectedValues[0])
                     }
@@ -644,7 +644,6 @@ export const MultiSelectCheckboxItem = forwardRef<HTMLDivElement, SelectItemProp
           onClick={onSelectValue}
           onMouseOver={onMouseOver}
           ref={forwardedRef}
-          data-state={isChecked ? "checked" : "unchecked"}
           data-disabled={disabled ? true : undefined}
           data-highlighted={highlighted == value ? "true" : undefined}
           data-testid={`multi-select-checkbox-${value}`}

--- a/src/components/Select/common/InternalSelect.tsx
+++ b/src/components/Select/common/InternalSelect.tsx
@@ -598,6 +598,7 @@ export const MultiSelectCheckboxItem = forwardRef<HTMLDivElement, SelectItemProp
       disabled = false,
       children,
       icon,
+      iconDir = "end",
       label,
       onMouseOver: onMouseOverProp,
       onSelect: onSelectProp,
@@ -649,17 +650,56 @@ export const MultiSelectCheckboxItem = forwardRef<HTMLDivElement, SelectItemProp
           data-testid={`multi-select-checkbox-${value}`}
           cui-select-item=""
         >
-          <IconWrapper
-            icon={icon}
-            iconDir="end"
-          >
+          {icon && iconDir === "start" && (
             <Checkbox
-              label={label ?? children}
               checked={isChecked}
-              onClick={onChange}
               data-testid="multi-select-checkbox"
+              disabled={disabled}
+              label={
+                label ? (
+                  <div style={{ display: "flex", justifyContent: "center" }}>
+                    <Icon
+                      name={icon}
+                      size="sm"
+                    />
+                    {label}
+                  </div>
+                ) : (
+                  <div style={{ display: "flex", justifyContent: "center" }}>
+                    <Icon
+                      name={icon}
+                      size="sm"
+                    />
+                    {children}
+                  </div>
+                )
+              }
+              onClick={onChange}
             />
-          </IconWrapper>
+          )}
+          {icon && iconDir === "end" && (
+            <IconWrapper
+              icon={icon}
+              iconDir="end"
+            >
+              <Checkbox
+                checked={isChecked}
+                data-testid="multi-select-checkbox"
+                disabled={disabled}
+                label={label ?? children}
+                onClick={onChange}
+              />
+            </IconWrapper>
+          )}
+          {!icon && (
+            <Checkbox
+              checked={isChecked}
+              data-testid="multi-select-checkbox"
+              disabled={disabled}
+              label={label ?? children}
+              onClick={onChange}
+            />
+          )}
         </GenericMenuItem>
         {separator && <Separator size="sm" />}
       </>

--- a/src/components/Select/common/InternalSelect.tsx
+++ b/src/components/Select/common/InternalSelect.tsx
@@ -598,7 +598,6 @@ export const MultiSelectCheckboxItem = forwardRef<HTMLDivElement, SelectItemProp
       disabled = false,
       children,
       icon,
-      iconDir,
       label,
       onMouseOver: onMouseOverProp,
       onSelect: onSelectProp,
@@ -652,7 +651,7 @@ export const MultiSelectCheckboxItem = forwardRef<HTMLDivElement, SelectItemProp
         >
           <IconWrapper
             icon={icon}
-            iconDir={iconDir}
+            iconDir="end"
           >
             <Checkbox
               label={label ?? children}

--- a/src/components/Select/common/types.ts
+++ b/src/components/Select/common/types.ts
@@ -76,6 +76,8 @@ interface InternalSelectProps
   sortable?: boolean;
   onSelect: (value: string, type?: SelectionType) => void;
   multiple?: boolean;
+  checkbox?: boolean;
+  selectLabel?: string;
   placeholder?: string;
   showSearch?: boolean;
   customText?: string;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -43,6 +43,7 @@ export { RadioGroup } from "./RadioGroup/RadioGroup";
 export { SearchField } from "./Input/SearchField";
 export { Select } from "./Select/SingleSelect";
 export { MultiSelect } from "./Select/MultiSelect";
+export { CheckboxMultiSelect } from "./Select/CheckboxMultiSelect";
 export { default as Separator } from "./Separator/Separator";
 export { SidebarNavigationItem } from "./SidebarNavigationItem/SidebarNavigationItem";
 export { SidebarCollapsibleItem } from "./SidebarCollapsibleItem/SidebarCollapsibleItem";

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -32,6 +32,7 @@ export type { Menu, SplitButtonProps } from "./SplitButton/SplitButton";
 export type { ToastProps } from "./Toast/Toast";
 export type { SelectOptionListItem } from "./Select/common/types";
 export type { MultiSelectProps } from "./Select/MultiSelect";
+export type { CheckboxMultiSelectProps } from "./Select/CheckboxMultiSelect";
 export type { PanelProps } from "./Panel/Panel";
 export type { FlyoutProps, FlyoutFooterProps, FlyoutHeaderProps } from "./Flyout/Flyout";
 export type { DialogContentProps } from "./Dialog/Dialog";


### PR DESCRIPTION
Closes https://github.com/ClickHouse/control-plane/issues/7993

- Adds `CheckboxMultiSelect`, a multi select component that shows selected items inline with a checkbox, rather than the typical label cloud of `MultiSelect`


**Edit, new screenshot with icon to the left of the checkbox**
<img width="1584" alt="Screenshot 2024-04-05 at 11 23 58 AM" src="https://github.com/ClickHouse/click-ui/assets/146112/6423b343-cf4d-48ea-8fb8-847808dd5583">
