### PR TITLE
Allowing cards to accept custom icons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -290,6 +290,7 @@ const App = () => {
           <CardSecondary
             title="Card title"
             icon="building"
+            iconUrl="https://upload.wikimedia.org/wikipedia/sco/3/3c/Cardiff_City_crest.svg"
             description="This is a card description"
             badgeText="experiment"
             infoText="Read More"
@@ -308,6 +309,7 @@ const App = () => {
         <Container alignItems="start">
           <CardPrimary
             title="Card title"
+            size="sm"
             icon="building"
             description="This is a card description"
             infoText="Read More"
@@ -316,6 +318,7 @@ const App = () => {
           <CardPrimary
             title="Card title"
             icon="building"
+            iconUrl="https://upload.wikimedia.org/wikipedia/sco/3/3c/Cardiff_City_crest.svg"
             description="This is a card description"
             infoText="Read More"
             infoUrl="#"

--- a/src/components/CardPrimary/CardPrimary.test.tsx
+++ b/src/components/CardPrimary/CardPrimary.test.tsx
@@ -92,5 +92,19 @@ describe("CardPrimary Component", () => {
 
       expect(queryAllByTestId("card-top-badge").length).toEqual(0);
     });
+
+    it("should render an image when iconUrl is provided", () => {
+      const iconUrl = "https://example.com/icon.png";
+      renderCard({
+        iconUrl,
+        title: "Card with custom icon",
+        description: "",
+        infoUrl: "",
+        infoText: "",
+      });
+
+      const imgElement = screen.getByAltText("card image");
+      expect(imgElement).toHaveAttribute("src", iconUrl);
+    });
   });
 });

--- a/src/components/CardPrimary/CardPrimary.test.tsx
+++ b/src/components/CardPrimary/CardPrimary.test.tsx
@@ -103,7 +103,7 @@ describe("CardPrimary Component", () => {
         infoText: "",
       });
 
-      const imgElement = screen.getByAltText("card image");
+      const imgElement = screen.getByAltText("card icon");
       expect(imgElement).toHaveAttribute("src", iconUrl);
     });
   });

--- a/src/components/CardPrimary/CardPrimary.tsx
+++ b/src/components/CardPrimary/CardPrimary.tsx
@@ -179,7 +179,7 @@ const Card = ({
           {iconUrl ? (
             <img
               src={iconUrl}
-              alt="card image"
+              alt="card icon"
               aria-hidden
             />
           ) : (

--- a/src/components/CardPrimary/CardPrimary.tsx
+++ b/src/components/CardPrimary/CardPrimary.tsx
@@ -12,6 +12,7 @@ export interface CardPrimaryProps
     WithTopBadgeProps {
   title?: string;
   icon?: IconName;
+  iconUrl?: string;
   hasShadow?: boolean;
   disabled?: boolean;
   description?: ReactNode;
@@ -109,7 +110,8 @@ const Header = styled.div<{
         : theme.click.global.color.text.default};
   }
 
-  svg {
+  svg,
+  img {
     height: ${({ $size = "md", theme }) => theme.click.card.primary.size.icon[$size].all};
     width: ${({ $size = "md", theme }) => theme.click.card.primary.size.icon[$size].all};
   }
@@ -136,6 +138,7 @@ const Card = ({
   alignContent,
   title,
   icon,
+  iconUrl,
   hasShadow = false,
   description,
   infoUrl,
@@ -173,11 +176,19 @@ const Card = ({
           $disabled={disabled}
           $alignContent={alignContent}
         >
-          {icon && (
-            <Icon
-              name={icon}
+          {iconUrl ? (
+            <img
+              src={iconUrl}
+              alt="card image"
               aria-hidden
             />
+          ) : (
+            icon && (
+              <Icon
+                name={icon}
+                aria-hidden
+              />
+            )
           )}
           {title && <Title type="h3">{title}</Title>}
         </Header>

--- a/src/components/CardSecondary/CardSecondary.test.tsx
+++ b/src/components/CardSecondary/CardSecondary.test.tsx
@@ -56,7 +56,7 @@ describe("CardSecondary Component", () => {
       infoText: "",
     });
 
-    const imgElement = screen.getByAltText("card image");
+    const imgElement = screen.getByAltText("card icon");
     expect(imgElement).toHaveAttribute("src", iconUrl);
   });
 });

--- a/src/components/CardSecondary/CardSecondary.test.tsx
+++ b/src/components/CardSecondary/CardSecondary.test.tsx
@@ -45,4 +45,18 @@ describe("CardSecondary Component", () => {
 
     expect(screen.getAllByText(badgeText).length).toEqual(1);
   });
+
+  it("should render an image when iconUrl is provided", () => {
+    const iconUrl = "https://example.com/icon.png";
+    renderCard({
+      iconUrl,
+      title: "Card with custom icon",
+      description: "",
+      infoUrl: "",
+      infoText: "",
+    });
+
+    const imgElement = screen.getByAltText("card image");
+    expect(imgElement).toHaveAttribute("src", iconUrl);
+  });
 });

--- a/src/components/CardSecondary/CardSecondary.tsx
+++ b/src/components/CardSecondary/CardSecondary.tsx
@@ -15,7 +15,8 @@ export type BadgeState =
 
 export interface CardSecondaryProps extends HTMLAttributes<HTMLDivElement> {
   title: string;
-  icon: IconName;
+  icon?: IconName;
+  iconUrl?: string;
   badgeState?: BadgeState;
   hasShadow?: boolean;
   disabled?: boolean;
@@ -49,6 +50,11 @@ const Content = styled.div`
   display: flex;
   flex-direction: column;
   flex: 1;
+`;
+
+const CustomImage = styled.img`
+  height: ${({ theme }) => theme.click.image.lg.size.height};
+  width: ${({ theme }) => theme.click.image.lg.size.width};
 `;
 
 const InfoLink = styled.a`
@@ -112,6 +118,7 @@ const Wrapper = styled.div<{
 export const CardSecondary = ({
   title,
   icon,
+  iconUrl,
   badgeState,
   badgeText = "",
   hasShadow = false,
@@ -130,11 +137,21 @@ export const CardSecondary = ({
     >
       <Header>
         <HeaderLeft $disabled={disabled}>
-          <Icon
-            name={icon}
-            size="lg"
-            area-hidden=""
-          />
+          {iconUrl ? (
+            <CustomImage
+              src={iconUrl}
+              alt="card image"
+              aria-hidden
+            />
+          ) : (
+            icon && (
+              <Icon
+                name={icon}
+                aria-hidden
+                size="lg"
+              />
+            )
+          )}
           <Title type="h3">{title}</Title>
         </HeaderLeft>
         {badgeText && (

--- a/src/components/CardSecondary/CardSecondary.tsx
+++ b/src/components/CardSecondary/CardSecondary.tsx
@@ -52,7 +52,7 @@ const Content = styled.div`
   flex: 1;
 `;
 
-const CustomImage = styled.img`
+const CustomIcon = styled.img`
   height: ${({ theme }) => theme.click.image.lg.size.height};
   width: ${({ theme }) => theme.click.image.lg.size.width};
 `;
@@ -138,9 +138,9 @@ export const CardSecondary = ({
       <Header>
         <HeaderLeft $disabled={disabled}>
           {iconUrl ? (
-            <CustomImage
+            <CustomIcon
               src={iconUrl}
-              alt="card image"
+              alt="card icon"
               aria-hidden
             />
           ) : (


### PR DESCRIPTION
### Summary
Closes: https://github.com/ClickHouse/click-ui/issues/429. This PR allows the Primary and Secondary Cards to accept external urls for icons rather than just the built in Click UI icon library. This adds a little more flexibility. 

For the primary card, like the built in Icon, the height and width of the custom icons are controls by the card's `size` prop.    
### Screenshots

#### Primary
![CleanShot 2024-05-31 at 11 44 19@2x](https://github.com/ClickHouse/click-ui/assets/305167/a4abd8a9-51d6-4300-8a4d-fbd4cb25d0e0)

#### Secondary
![CleanShot 2024-05-31 at 11 44 13@2x](https://github.com/ClickHouse/click-ui/assets/305167/b6fd4d91-253e-4717-b4e7-0ab996a7a5de)
