### PR TITLE
Gj button group token update

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,7 @@ import {
   Spacer,
   SuccessAlert,
   Switch,
+  Panel,
   Tabs,
   WarningAlert,
   CardPrimary,
@@ -40,6 +41,8 @@ import {
   Container,
   InlineCodeBlock,
   GridContainer,
+  TextField,
+  Label,
 } from "@/components";
 import { Dialog } from "@/components/Dialog/Dialog";
 import { ConfirmationDialog } from "@/components/ConfirmationDialog/ConfirmationDialog";
@@ -286,7 +289,7 @@ const App = () => {
             state={"disabled"}
           ></Badge>
         </div>
-        <div style={{ display: "flex", padding: "1rem" }}>
+        <Container>
           <CardSecondary
             title="Card title"
             icon="building"
@@ -305,8 +308,12 @@ const App = () => {
             infoText="Read More"
             infoUrl="#"
           />
-        </div>
-        <Container alignItems="start">
+        </Container>
+        <Spacer size="xl" />
+        <Container
+          alignItems="start"
+          gap="lg"
+        >
           <CardPrimary
             title="Card title"
             size="sm"
@@ -343,7 +350,10 @@ const App = () => {
         </Container>
 
         <Text>Same-height cards</Text>
-        <Container alignItems="stretch">
+        <Container
+          alignItems="stretch"
+          gap="xl"
+        >
           <CardPrimary
             title="Development"
             alignContent="center"
@@ -382,17 +392,89 @@ const App = () => {
             </ul>
           </CardPrimary>
         </div>
-        <ButtonGroup
-          options={[
-            { label: "Left center", value: "leftEnd" },
-            { label: "Center", value: "center1" },
-            { label: "Center", value: "center2" },
-            { label: "Center", value: "center3" },
-            { label: "Right end", value: "rightEnd" },
-          ]}
-          selected={selectedButton}
-          onClick={setSelectedButton}
-        />
+
+        <Spacer size="lg" />
+        <Panel
+          orientation="vertical"
+          gap="lg"
+          alignItems="start"
+        >
+          <ButtonGroup
+            options={[
+              { label: "Left center", value: "leftEnd" },
+              { label: "Center", value: "center1" },
+              { label: "Center", value: "center2" },
+              { label: "Center", value: "center3" },
+              { label: "Right end", value: "rightEnd" },
+            ]}
+            selected={selectedButton}
+            onClick={setSelectedButton}
+          />
+
+          <ButtonGroup
+            options={[
+              { label: "Left center", value: "leftEnd" },
+              { label: "Center", value: "center1" },
+              { label: "Center", value: "center2" },
+              { label: "Center", value: "center3" },
+              { label: "Right end", value: "rightEnd" },
+            ]}
+            selected={selectedButton}
+            onClick={setSelectedButton}
+            type="borderless"
+          />
+        </Panel>
+
+        <Spacer size="lg" />
+
+        <Panel>
+          <Container
+            orientation="vertical"
+            gap="xs"
+          >
+            <Label>Example label</Label>
+            <TextField
+              onChange={inputValue => console.log(inputValue)}
+              placeholder="Placeholder"
+            />
+          </Container>
+
+          <Container
+            orientation="vertical"
+            gap="xs"
+          >
+            <Label>Example label</Label>
+            <TextField
+              onChange={inputValue => console.log(inputValue)}
+              value="Value"
+            />
+          </Container>
+
+          <Container
+            orientation="vertical"
+            gap="xs"
+          >
+            <Label disabled>Example label</Label>
+            <TextField
+              onChange={inputValue => console.log(inputValue)}
+              value="Value"
+              disabled
+            />
+          </Container>
+
+          <Container
+            orientation="vertical"
+            gap="xs"
+          >
+            <Label disabled>Example label</Label>
+            <TextField
+              onChange={inputValue => console.log(inputValue)}
+              placeholder="Placeholder"
+              disabled
+            />
+          </Container>
+        </Panel>
+        <Spacer size="lg" />
         <Switch
           checked={checked}
           disabled={disabled}

--- a/src/components/ButtonGroup/ButtonGroup.stories.ts
+++ b/src/components/ButtonGroup/ButtonGroup.stories.ts
@@ -8,6 +8,14 @@ export default {
     options: ["default", "borderless"],
     control: { type: "radio" },
   },
+  selected:{ 
+    options: ["option1","option2","option3"],
+    control: { type: "select" },
+  },
+  disabled:{ 
+    options: ["option1","option2","option3"],
+    control: { type: "select" },
+  },
 };
 
 export const Playground = {
@@ -18,6 +26,7 @@ export const Playground = {
       { label: "Option 3", value: "option3" },
     ],
     fillWidth: false,
-    type: "default"
+    type: "default",
+    selected: "option3",
   },
 };

--- a/src/components/ButtonGroup/ButtonGroup.stories.ts
+++ b/src/components/ButtonGroup/ButtonGroup.stories.ts
@@ -11,11 +11,7 @@ export default {
   selected:{ 
     options: ["option1","option2","option3"],
     control: { type: "select" },
-  },
-  disabled:{ 
-    options: ["option1","option2","option3"],
-    control: { type: "select" },
-  },
+  }
 };
 
 export const Playground = {

--- a/src/components/ButtonGroup/ButtonGroup.stories.ts
+++ b/src/components/ButtonGroup/ButtonGroup.stories.ts
@@ -7,11 +7,7 @@ export default {
   type: {
     options: ["default", "borderless"],
     control: { type: "radio" },
-  },
-  selected:{ 
-    options: ["option1","option2","option3"],
-    control: { type: "select" },
-  }
+  } 
 };
 
 export const Playground = {

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -104,8 +104,8 @@ const Button = styled.button.attrs<ButtonProps>((props: ButtonProps) => ({
   font: ${({ theme }) => theme.click.button.group.typography.label.default};
   padding: ${({ theme }) => theme.click.button.basic.space.y}
     ${({ theme }) => theme.click.button.basic.space.x};
-  gap: ${({ theme }) => theme.click.button.basic.space.group}
-    ${({ $fillWidth = false }) => ($fillWidth ? "flex: 1;" : "")};
+  gap: ${({ theme }) => theme.click.button.basic.space.group};
+  ${({ $fillWidth = false }) => ($fillWidth ? "flex: 1;" : "")};
   cursor: pointer;
 
   &:hover {

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -87,9 +87,9 @@ const leftBorderRadius = `${endRadii} 0px 0px ${endRadii}`;
 const rightBorderRadius = `0px ${endRadii} ${endRadii} 0px`;
 const centerBorderRadius = "var(--click-button-button-group-radii-center)";
 
-const Button = styled.button.attrs<ButtonProps>(
-  (props: ButtonProps) => ({"aria-pressed": props.$active})
-)`
+const Button = styled.button.attrs<ButtonProps>((props: ButtonProps) => ({
+  "aria-pressed": props.$active,
+}))`
   box-sizing: border-box;
   display: flex;
   flex-direction: row;
@@ -104,28 +104,38 @@ const Button = styled.button.attrs<ButtonProps>(
   font: ${({ theme }) => theme.click.button.group.typography.label.default};
   padding: ${({ theme }) => theme.click.button.basic.space.y}
     ${({ theme }) => theme.click.button.basic.space.x};
-  gap: ${({ theme }) => theme.click.button.basic.space.group};
-  ${({ $fillWidth = false }) => ($fillWidth ? "flex: 1;" : "")}
+  gap: ${({ theme }) => theme.click.button.basic.space.group}
+    ${({ $fillWidth = false }) => ($fillWidth ? "flex: 1;" : "")};
   cursor: pointer;
 
   &:hover {
     background: ${({ theme }) => theme.click.button.group.color.background.hover};
     font: ${({ theme }) => theme.click.button.group.typography.label.hover};
+    color: ${({ theme }) => theme.click.button.group.color.text.hover};
   }
 
   &:disabled {
     cursor: not-allowed;
     font: ${({ theme }) => theme.click.button.group.typography.label.disabled};
+    color: ${({ theme }) => theme.click.button.group.color.text.disabled};
     background: ${({ theme, $active }) =>
       theme.click.button.group.color.background[
         $active ? "disabled-active" : "disabled"
       ]};
+
+    &:active,
+    &:focus,
+    &[aria-pressed="true"] {
+      color: ${({ theme }) => theme.click.button.group.color.text.disabled};
+    }
   }
 
   &:active,
-  &:focus {
+  &:focus,
+  &[aria-pressed="true"] {
     background: ${({ theme }) => theme.click.button.group.color.background.active};
     font: ${({ theme }) => theme.click.button.group.typography.label.active};
+    color: ${({ theme }) => theme.click.button.group.color.text.active};
     &:disabled {
       background: ${({ theme }) =>
         theme.click.button.group.color.background["disabled-active"]};

--- a/src/components/Input/InputWrapper.tsx
+++ b/src/components/Input/InputWrapper.tsx
@@ -184,6 +184,11 @@ export const InputElement = styled.input`
     &::placeholder {
       color: ${theme.click.field.color.placeholder.default};
     }
+
+    &:disabled, &.disabled {
+      &::placeholder {
+      color: ${theme.click.field.color.placeholder.disabled};
+    }
   `}
 `;
 

--- a/src/styles/types.ts
+++ b/src/styles/types.ts
@@ -1309,7 +1309,8 @@
           "disabled": string
         },
         "placeholder": {
-          "default": string
+          "default": string,
+          "disabled": string
         }
       }
     },
@@ -2857,6 +2858,7 @@
       "400": string,
       "500": string,
       "600": string,
+      "650": string,
       "700": string,
       "712": string,
       "725": string,

--- a/src/styles/variables.dark.json
+++ b/src/styles/variables.dark.json
@@ -387,15 +387,15 @@
             "default": "rgba(0,0,0,0)",
             "hover": "#282828",
             "active": "lch(18.2 0 0)",
-            "disabled": "#414141",
-            "disabled-active": "lch(22 0 0)",
+            "disabled": "rgba(0,0,0,0)",
+            "disabled-active": "lch(0 0 0 / 0)",
             "panel": "rgba(0,0,0,0)"
           },
           "text": {
-            "default": "#ffffff",
-            "hover": "#ffffff",
+            "default": "#c0c0c0",
+            "hover": "#c0c0c0",
             "active": "#ffffff",
-            "disabled": "#808080",
+            "disabled": "#414141",
             "disabled-active": "#808080"
           },
           "stroke": {
@@ -605,7 +605,7 @@
           "default": "#ffffff",
           "hover": "#ffffff",
           "active": "#ffffff",
-          "disabled": "#a0a0a0"
+          "disabled": "#606060"
         }
       }
     },
@@ -707,21 +707,25 @@
           "default": "#b3b6bd",
           "hover": "#b3b6bd",
           "active": "#ffffff",
-          "disabled": "#a0a0a0",
+          "disabled": "#606060",
           "error": "#ffbaba"
         },
         "format": {
-          "default": "lch(72 4.18 268)",
-          "hover": "lch(72 4.18 268)",
-          "active": "lch(72 4.18 268)",
+          "default": "lch(62.9 0 0)",
+          "hover": "lch(62.9 0 0)",
+          "active": "lch(62.9 0 0)",
           "disabled": "#808080",
-          "error": "lch(72 4.18 268)"
+          "error": "lch(62.9 0 0)"
         },
         "genericLabel": {
           "default": "#ffffff",
           "hover": "#ffffff",
           "active": "#ffffff",
           "disabled": "#a0a0a0"
+        },
+        "placeholder": {
+          "default": "#808080",
+          "disabled": "#606060"
         }
       }
     },
@@ -742,11 +746,11 @@
             "disabled": "#414141"
           },
           "format": {
-            "default": "lch(72 4.18 268)",
-            "hover": "lch(72 4.18 268)",
-            "active": "lch(72 4.18 268)",
+            "default": "lch(62.9 0 0)",
+            "hover": "lch(62.9 0 0)",
+            "active": "lch(62.9 0 0)",
             "disabled": "#808080",
-            "error": "lch(72 4.18 268)"
+            "error": "lch(62.9 0 0)"
           },
           "stroke": {
             "default": "#323232"
@@ -785,7 +789,7 @@
       "autocomplete": {
         "color": {
           "placeholder": {
-            "default": "#9a9ea7"
+            "default": "#808080"
           },
           "searchTerm": {
             "default": "#ffffff"

--- a/src/styles/variables.json
+++ b/src/styles/variables.json
@@ -707,16 +707,16 @@
             "default": "rgba(0,0,0,0)",
             "hover": "#f6f7fa",
             "active": "lch(97.3 1.53 272)",
-            "disabled": "#dfdfdf",
-            "disabled-active": "lch(71.1 0 0)",
+            "disabled": "rgba(0,0,0,0)",
+            "disabled-active": "lch(77.8 1.22 272)",
             "panel": "rgba(0,0,0,0)"
           },
           "text": {
-            "default": "#161517",
-            "hover": "#161517",
+            "default": "#505050",
+            "hover": "#505050",
             "active": "#161517",
             "disabled": "#a0a0a0",
-            "disabled-active": "#808080"
+            "disabled-active": "#a0a0a0"
           },
           "stroke": {
             "default": "rgba(0,0,0,0)",
@@ -1308,7 +1308,8 @@
           "disabled": "#a0a0a0"
         },
         "placeholder": {
-          "default": "#9a9ea7"
+          "default": "#9a9ea7",
+          "disabled": "#b3b6bd"
         }
       }
     },
@@ -2856,6 +2857,7 @@
       "400": "#a0a0a0",
       "500": "#808080",
       "600": "#606060",
+      "650": "#505050",
       "700": "#414141",
       "712": "#323232",
       "725": "#282828",

--- a/src/styles/variables.light.json
+++ b/src/styles/variables.light.json
@@ -387,16 +387,16 @@
             "default": "rgba(0,0,0,0)",
             "hover": "#f6f7fa",
             "active": "lch(97.3 1.53 272)",
-            "disabled": "#dfdfdf",
-            "disabled-active": "lch(71.1 0 0)",
+            "disabled": "rgba(0,0,0,0)",
+            "disabled-active": "lch(77.8 1.22 272)",
             "panel": "rgba(0,0,0,0)"
           },
           "text": {
-            "default": "#161517",
-            "hover": "#161517",
+            "default": "#505050",
+            "hover": "#505050",
             "active": "#161517",
             "disabled": "#a0a0a0",
-            "disabled-active": "#808080"
+            "disabled-active": "#a0a0a0"
           },
           "stroke": {
             "default": "rgba(0,0,0,0)",
@@ -718,7 +718,8 @@
           "disabled": "#a0a0a0"
         },
         "placeholder": {
-          "default": "#9a9ea7"
+          "default": "#9a9ea7",
+          "disabled": "#b3b6bd"
         }
       }
     },


### PR DESCRIPTION
### Summary
This PR improves the colours for the button group in light and dark modes. It also improves the field colours. Previously, the disabled options for both we quite confusing:

#### Before
![CleanShot 2024-06-13 at 09 55 45@2x](https://github.com/ClickHouse/click-ui/assets/305167/b3901a15-8f2e-4cf2-958a-9edff3d36779)
![CleanShot 2024-06-13 at 09 56 15@2x](https://github.com/ClickHouse/click-ui/assets/305167/96cfe469-ced0-451c-bb6d-cbf1409750a9)


#### After
##### Button Groups

https://github.com/ClickHouse/click-ui/assets/305167/d822e4de-b5cb-4be4-b3fd-baf07426d7ee


https://github.com/ClickHouse/click-ui/assets/305167/7532d589-47fd-4f00-a24e-397e930e9679


##### Fields
![CleanShot 2024-06-13 at 09 35 34@2x](https://github.com/ClickHouse/click-ui/assets/305167/dd66edd1-daf6-45a0-820a-437370f02d2c)
![CleanShot 2024-06-13 at 09 32 44@2x](https://github.com/ClickHouse/click-ui/assets/305167/32b172b4-34a6-4485-bf94-27bf64e13caf)
