### PR TITLE
Flyout with `align="start"` should have  shadow on the right side

### DIFF
--- a/src/components/Flyout/Flyout.stories.tsx
+++ b/src/components/Flyout/Flyout.stories.tsx
@@ -4,7 +4,8 @@ import { Flyout, FlyoutProps } from "./Flyout";
 interface Props extends FlyoutProps {
   title: string;
   description?: string;
-  align: "default" | "top";
+  alignBody: "default" | "top";
+  align: "start" | "end";
   type: "default" | "inline";
   size: "default" | "narrow" | "wide";
   width?: string;
@@ -13,10 +14,11 @@ interface Props extends FlyoutProps {
 const FlyoutExample = ({
   title,
   description,
-  align,
+  alignBody,
   type,
   size,
   width,
+  align,
   ...props
 }: Props) => {
   return (
@@ -26,6 +28,7 @@ const FlyoutExample = ({
       </Flyout.Trigger>
       <Flyout.Content
         strategy="fixed"
+        align={align}
         size={size}
         width={width}
       >
@@ -34,7 +37,7 @@ const FlyoutExample = ({
           title={title}
           description={description}
         />
-        <Flyout.Body align={align}>
+        <Flyout.Body align={alignBody}>
           <Flyout.Element type={type}>
             <Text>Flyout content belongs here.</Text>
           </Flyout.Element>
@@ -54,7 +57,18 @@ export default {
   argTypes: {
     title: { control: "text" },
     description: { control: "text" },
-    align: { control: "select", options: ["default", "top"] },
+    alignBody: {
+      control: "radio",
+      options: ["default", "top"],
+      defaultValue: "default",
+      description: "Align the content inside the flyout",
+    },
+    align: {
+      control: "radio",
+      options: ["start", "end"],
+
+      description: "Align the flyout",
+    },
     size: { control: "select", options: ["default", "narrow", "wide"] },
     type: { control: "select", options: ["default", "inline"] },
     width: { control: "text" },

--- a/src/components/Flyout/Flyout.tsx
+++ b/src/components/Flyout/Flyout.tsx
@@ -96,11 +96,15 @@ const FlyoutContent = styled(DialogContent)<{
     height: ${$strategy === "relative" ? "100%" : "auto"};
     padding: 0 ${theme.click.flyout.space[$type].x}
     gap: ${theme.click.flyout.space[$type].gap};
+    box-shadow: ${
+      $align === "start"
+        ? theme.click.flyout.shadow.reverse
+        : theme.click.flyout.shadow.default
+    };
     border-${$align === "start" ? "right" : "left"}: 1px solid ${
     theme.click.flyout.color.stroke.default
   };
     background: ${theme.click.flyout.color.background.default};
-    box-shadow: ${theme.click.flyout.shadow.default}};
 
     @media (max-width: 1024px) {
       ${


### PR DESCRIPTION
Closes #436

## Changes in the PR:
* Added align to storybook control
* Added new variable for shadow - `inverted`
* Use `inverted` shadow if `align === "start"`

## Result:
<img width="610" alt="image" src="https://github.com/ClickHouse/click-ui/assets/850302/995d73dc-f0d5-46a9-96e5-99153e4b10c0">
<img width="500" alt="image" src="https://github.com/ClickHouse/click-ui/assets/850302/31495cc2-3361-49d1-8e01-a1b58dc4c224">
