### PR TITLE
fix padding when label is shown next to the loading icon

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -40,6 +40,8 @@ export const Button = ({
     role="button"
     {...delegated}
   >
+    {!loading && (
+        <>
     {iconLeft && (
       <ButtonIcon
         name={iconLeft}
@@ -57,6 +59,8 @@ export const Button = ({
         size="sm"
       />
     )}
+        </>
+    )}
     {loading && (
       <LoadingIconWrapper data-testid="click-ui-loading-icon-wrapper">
         <Icon
@@ -71,7 +75,6 @@ export const Button = ({
 );
 
 const LoadingIconWrapper = styled.div`
-  position: absolute;
   background-color: inherit;
   top: 0;
   left: 0;


### PR DESCRIPTION
Before:

![Screenshot 2024-07-03 at 4 31 37 PM](https://github.com/ClickHouse/click-ui/assets/104740726/03b59a44-730c-4614-b1a9-755484edfb92)

After:
![Screenshot 2024-07-03 at 4 28 57 PM](https://github.com/ClickHouse/click-ui/assets/104740726/e842f62f-ff7b-4775-bfc7-54da74f1b6cd)
