### PR TITLE
Replace `none` by `auto`  for `min-width` css values

### DIFF
--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -133,7 +133,7 @@ const Wrapper = styled.div<{
   flex-wrap: ${({ $wrap = "nowrap" }) => $wrap};
   gap: ${({ theme, $gapSize }) => theme.click.container.gap[$gapSize]};
   max-width: ${({ $maxWidth }) => $maxWidth ?? "none"};
-  min-width: ${({ $minWidth }) => $minWidth ?? "none"};
+  min-width: ${({ $minWidth }) => $minWidth ?? "auto"};
   padding: ${({ theme, $paddingSize }) => theme.click.container.space[$paddingSize]};
   width: ${({ $fillWidth = true }) => ($fillWidth === true ? "100%" : "auto")};
   flex-direction: ${({ $orientation = "horizontal" }) =>


### PR DESCRIPTION
There is no `none` value for `min-width` according to [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/min-width). It is highlighted as the incorrect value in dev tools. 