### PR TITLE
Pagination: sanitize input values so demicals don't cause crashes

### DIFF
--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Pagination } from "./Pagination";
 
 export default {
@@ -11,9 +12,25 @@ export default {
   },
 };
 
+const PaginationRenderer = () => {
+  const [currentPage, setCurrentPage] = useState<number>(1);
+
+  const handleChange = (page: number) => {
+    setCurrentPage(page);
+  };
+
+  return (
+    <Pagination
+      currentPage={currentPage}
+      onChange={handleChange}
+    />
+  );
+};
+
 export const Playground = {
   args: {
     currentPage: 1,
     options: [250, 500],
   },
+  render: () => <PaginationRenderer />,
 };

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -83,16 +83,16 @@ export const Pagination = ({
   };
 
   const onChange = (value: string) => {
-    const valueToNumber = Number(value);
+    const sanitizedValue = parseInt(value, 10);
     if (
-      valueToNumber < 1 ||
+      sanitizedValue < 1 ||
       inputRef.current?.disabled ||
-      (typeof totalPages !== "undefined" ? valueToNumber > totalPages : false)
+      (typeof totalPages !== "undefined" ? sanitizedValue > totalPages : false)
     ) {
       return;
     }
 
-    onChangeProp(valueToNumber);
+    onChangeProp(sanitizedValue);
   };
 
   const onPageSizeChange = (value: string) => {


### PR DESCRIPTION
Helps with: https://github.com/ClickHouse/control-plane/issues/9053

- The number input for Pagination's current behave is to cast using `Number()`. This will allow numbers like `1.1`/`3,3`, since those are valid numbers. However, all pagination calculations are based on this value, so a decimal causes weird behavior when paginating. In some cases, it causes entire crashes.
- The new behavior parses the number using `parseInt(number, 10)`, which converts `1.3` => `1`

- This also tweaks the pagination story to allow a proper demonstratin of pagination