### PR TITLE
Grid: Fix resizing in Firefox

### DIFF
--- a/src/components/Grid/ColumnResizer.tsx
+++ b/src/components/Grid/ColumnResizer.tsx
@@ -88,6 +88,7 @@ const ColumnResizer = ({
           resizeRef.current.setPointerCapture(pointerRef.current.pointerId);
           const width =
             header.scrollWidth + (e.clientX - pointerRef.current.initialClientX);
+
           setResizeCursorPosition(resizeRef.current, e.clientX, width, columnIndex);
           pointerRef.current.width = Math.max(width, 50);
         }
@@ -104,7 +105,12 @@ const ColumnResizer = ({
       onPointerUp={e => {
         e.preventDefault();
         e.stopPropagation();
-        if (resizeRef.current && pointerRef.current?.pointerId) {
+
+        if (
+          resizeRef.current &&
+          // 0 is a valid pointerId in Firefox
+          (pointerRef.current?.pointerId || pointerRef.current?.pointerId === 0)
+        ) {
           resizeRef.current.releasePointerCapture(pointerRef.current.pointerId);
           const shouldCallResize = e.clientX !== pointerRef.current.initialClientX;
           if (shouldCallResize) {

--- a/src/components/Grid/ColumnResizer.tsx
+++ b/src/components/Grid/ColumnResizer.tsx
@@ -48,6 +48,7 @@ const ColumnResizer = ({
     e => {
       e.preventDefault();
       e.stopPropagation();
+
       if (e.detail > 1) {
         onColumnResize(columnIndex, 0, "auto");
       }
@@ -87,7 +88,7 @@ const ColumnResizer = ({
         if (header) {
           resizeRef.current.setPointerCapture(pointerRef.current.pointerId);
           const width =
-            header.scrollWidth + (e.clientX - pointerRef.current.initialClientX);
+            header.clientWidth + (e.clientX - pointerRef.current.initialClientX);
 
           setResizeCursorPosition(resizeRef.current, e.clientX, width, columnIndex);
           pointerRef.current.width = Math.max(width, 50);

--- a/src/components/Grid/Grid.test.tsx
+++ b/src/components/Grid/Grid.test.tsx
@@ -90,7 +90,7 @@ describe("Grid", () => {
     expect(lastHeaderCell).toBeNull();
   });
 
-  it("should render focussed element", () => {
+  it("should render focused element", () => {
     const { queryByTestId, getByText } = renderGrid({});
     const rowNumber = getByText("1");
     expect(rowNumber).not.toBeNull();

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -110,6 +110,7 @@ const OuterElementType = forwardRef<HTMLDivElement>((props, ref) => (
   <div
     ref={ref}
     data-testid="grid-outer-element"
+    tabIndex={0}
     {...props}
   />
 ));

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -780,7 +780,7 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
           width={width}
         />
       );
-    }
+    };
 
     return (
       <ContextMenu


### PR DESCRIPTION
Helps with https://github.com/ClickHouse/control-plane/issues/9726
Helps with https://github.com/ClickHouse/click-ui/issues/422

#### There were several issues with the Grid in Firefox. This PR addresses three of them:
- Grid resizing just didn't happen in Firefox
- When attempting to resize, the drag handle woudl fly to the right and blow up the right scrollbar
- After fixing the above issues, the drag handle on Firefox was in a different location than Chrome

#### The fixes:
- There was a conditional check that didn't run when a value that could be 0 in Firefox came back as falsy, thus Firefox would never actually save the new column position. The fix was allowing 0 values in the `if` statement.
- Firefox calculated the size of the resize header based on `event.scrollWidth`. For some reason, in Firefox, this width was being calculated based on the previous width. This led to an exponential growth in Firefox when increasing the size of a header - the previous width would be used in the new width calculation, which would then be used in the next width calculation, which caused the right scroll bar to expand very quickly. This was fixed by calculating the width based on `event.clientWidth`, rather than `scrollWidth`. 
- Firefox was not properly applying the `:active` pseudo class, so the width calculation was incorrect. This was fixed by keeping track of the `active` state in React based on mouse presses and releases, and passing that value into `styledComponents`

There was also an a11y fix for `Scrollable region must have keyboard access`


#### New behavior in Firefox
https://github.com/user-attachments/assets/5083731e-be17-4619-ad3c-d73630b6572f


#### New behavior in Chrome
https://github.com/user-attachments/assets/1eff9c26-e5fe-429c-bf91-769844727a82

