### PR TITLE
Select: add useFullWidthItems to allow dropdown with to expand

### DIFF
--- a/src/components/Select/SingleSelect.stories.tsx
+++ b/src/components/Select/SingleSelect.stories.tsx
@@ -1,7 +1,10 @@
-import { Select, SelectProps } from "./SingleSelect";
 import { Preview } from "@storybook/react";
-import { selectOptions } from "./selectOptions";
+import { Select, SelectProps } from "@/components/Select/SingleSelect";
+import { selectOptions } from "@/components/Select/selectOptions";
 import { useEffect, useState } from "react";
+import { Container } from "@/components/Container/Container";
+import { Panel } from "@/components/Panel/Panel";
+import { Title } from "@/components/Typography/Title/Title";
 interface Props extends SelectProps {
   childrenType: "children" | "options";
 }
@@ -122,4 +125,46 @@ ${
       },
     },
   },
+};
+
+export const UseFullWidth = {
+  args: {},
+  render: () => {
+    return (
+      <Container fillWidth>
+        <Panel width="200px">
+          <Title type="h2">Full width items</Title>
+          <Select useFullWidthItems>
+            <Select.Item value="item 1">
+              Ask and it will be given to you; seek and you will find; knock and the door
+              will be opened to you.
+            </Select.Item>
+            <Select.Item value="item 2">
+              For everyone who asks receives; the one who seeks finds; and to the one who
+              knocks, the door will be opened.
+            </Select.Item>
+            <Select.Item value="item 3">
+              Which of you, if your son asks for bread, will give him a stone?
+            </Select.Item>
+          </Select>
+
+          <Title type="h2">Not full width items</Title>
+          <Select>
+            <Select.Item value="item 1">
+              Ask and it will be given to you; seek and you will find; knock and the door
+              will be opened to you.
+            </Select.Item>
+            <Select.Item value="item 2">
+              For everyone who asks receives; the one who seeks finds; and to the one who
+              knocks, the door will be opened.
+            </Select.Item>
+            <Select.Item value="item 3">
+              Which of you, if your son asks for bread, will give him a stone?
+            </Select.Item>
+          </Select>
+        </Panel>
+      </Container>
+    );
+  },
+  tags: ["autodocs"],
 };

--- a/src/components/Select/SingleSelect.stories.tsx
+++ b/src/components/Select/SingleSelect.stories.tsx
@@ -70,6 +70,8 @@ export default {
     orientation: { control: "inline-radio", options: ["horizontal", "vertical"] },
     dir: { control: "inline-radio", options: ["start", "end"] },
     childrenType: { control: "inline-radio", options: ["children", "options"] },
+    useFullWidthItems: { control: "boolean" },
+    itemCharacterLimit: { control: "text" },
   },
 };
 
@@ -148,6 +150,24 @@ export const UseFullWidth = {
             </Select.Item>
           </Select>
 
+          <Title type="h2">Larger itemCharacterLimit</Title>
+          <Select
+            useFullWidthItems
+            itemCharacterLimit="90ch"
+          >
+            <Select.Item value="item 1">
+              Ask and it will be given to you; seek and you will find; knock and the door
+              will be opened to you.
+            </Select.Item>
+            <Select.Item value="item 2">
+              For everyone who asks receives; the one who seeks finds; and to the one who
+              knocks, the door will be opened.
+            </Select.Item>
+            <Select.Item value="item 3">
+              Which of you, if your son asks for bread, will give him a stone?
+            </Select.Item>
+          </Select>
+
           <Title type="h2">Not full width items</Title>
           <Select>
             <Select.Item value="item 1">
@@ -166,5 +186,5 @@ export const UseFullWidth = {
       </Container>
     );
   },
-  tags: ["autodocs"],
+  tags: ["form-field", "select", "autodocs"],
 };

--- a/src/components/Select/SingleSelect.tsx
+++ b/src/components/Select/SingleSelect.tsx
@@ -13,6 +13,7 @@ export interface SelectProps
   placeholder?: string;
   onOpenChange?: (open: boolean) => void;
   useFullWidthItems?: boolean;
+  itemCharacterLimit?: string;
 }
 
 export const Select = ({

--- a/src/components/Select/SingleSelect.tsx
+++ b/src/components/Select/SingleSelect.tsx
@@ -12,6 +12,7 @@ export interface SelectProps
   value?: string;
   placeholder?: string;
   onOpenChange?: (open: boolean) => void;
+  useFullWidthItems?: boolean;
 }
 
 export const Select = ({

--- a/src/components/Select/common/InternalSelect.tsx
+++ b/src/components/Select/common/InternalSelect.tsx
@@ -119,6 +119,7 @@ export const InternalSelect = ({
   showSearch = false,
   container,
   useFullWidthItems = false,
+  itemCharacterLimit = "64ch",
   ...props
 }: SelectContainerProps) => {
   const defaultId = useId();
@@ -382,6 +383,7 @@ export const InternalSelect = ({
               }}
               align="start"
               $useFullWidthItems={useFullWidthItems}
+              $itemCharacterLimit={itemCharacterLimit}
             >
               <SelectList>
                 <SearchBarContainer $showSearch={showSearch}>

--- a/src/components/Select/common/InternalSelect.tsx
+++ b/src/components/Select/common/InternalSelect.tsx
@@ -118,6 +118,7 @@ export const InternalSelect = ({
   selectLabel,
   showSearch = false,
   container,
+  useFullWidthItems = false,
   ...props
 }: SelectContainerProps) => {
   const defaultId = useId();
@@ -380,6 +381,7 @@ export const InternalSelect = ({
                 setHighlighted(visibleList.current[0]);
               }}
               align="start"
+              $useFullWidthItems={useFullWidthItems}
             >
               <SelectList>
                 <SearchBarContainer $showSearch={showSearch}>

--- a/src/components/Select/common/SelectStyled.tsx
+++ b/src/components/Select/common/SelectStyled.tsx
@@ -88,7 +88,15 @@ export const SelectPopoverContent = styled(Content)<{ $useFullWidthItems: boolea
   pointer-events: auto;
 
   ${({ $useFullWidthItems }) => `
-    width: ${$useFullWidthItems ? "100%" : "var(--radix-popover-trigger-width)"};
+    ${
+      $useFullWidthItems
+        ? `
+      max-width: 64ch;
+      min-width: var(--radix-popover-trigger-width);
+      width: 100%;
+    `
+        : "width: var(--radix-popover-trigger-width)"
+    };
   `}
 
   ${({ theme }) => `

--- a/src/components/Select/common/SelectStyled.tsx
+++ b/src/components/Select/common/SelectStyled.tsx
@@ -81,11 +81,15 @@ export const StyledSelectTrigger = styled(Trigger)<{ $error: boolean }>`
   }
 `;
 
-export const SelectPopoverContent = styled(Content)`
+export const SelectPopoverContent = styled(Content)<{ $useFullWidthItems: boolean }>`
   width: var(--radix-popover-trigger-width);
   max-height: var(--radix-popover-content-available-height);
   border-radius: 0.25rem;
   pointer-events: auto;
+
+  ${({ $useFullWidthItems }) => `
+    width: ${$useFullWidthItems ? "100%" : "var(--radix-popover-trigger-width)"};
+  `}
 
   ${({ theme }) => `
     border: 1px solid ${theme.click.genericMenu.item.color.stroke.default};

--- a/src/components/Select/common/SelectStyled.tsx
+++ b/src/components/Select/common/SelectStyled.tsx
@@ -81,17 +81,20 @@ export const StyledSelectTrigger = styled(Trigger)<{ $error: boolean }>`
   }
 `;
 
-export const SelectPopoverContent = styled(Content)<{ $useFullWidthItems: boolean }>`
+export const SelectPopoverContent = styled(Content)<{
+  $useFullWidthItems: boolean;
+  $itemCharacterLimit?: string;
+}>`
   width: var(--radix-popover-trigger-width);
   max-height: var(--radix-popover-content-available-height);
   border-radius: 0.25rem;
   pointer-events: auto;
 
-  ${({ $useFullWidthItems }) => `
+  ${({ $useFullWidthItems, $itemCharacterLimit }) => `
     ${
       $useFullWidthItems
         ? `
-      max-width: 64ch;
+      max-width: ${$itemCharacterLimit};
       min-width: var(--radix-popover-trigger-width);
       width: 100%;
     `

--- a/src/components/Select/common/types.ts
+++ b/src/components/Select/common/types.ts
@@ -82,6 +82,7 @@ interface InternalSelectProps
   showSearch?: boolean;
   customText?: string;
   container?: HTMLElement;
+  useFullWidthItems?: boolean;
 }
 
 export type SelectOptionProp = SelectOptionType | SelectChildrenType;

--- a/src/components/Select/common/types.ts
+++ b/src/components/Select/common/types.ts
@@ -83,6 +83,7 @@ interface InternalSelectProps
   customText?: string;
   container?: HTMLElement;
   useFullWidthItems?: boolean;
+  itemCharacterLimit?: string;
 }
 
 export type SelectOptionProp = SelectOptionType | SelectChildrenType;


### PR DESCRIPTION
Helps with  https://github.com/ClickHouse/control-plane/issues/10057

- Adds `useFullWidthItems` to `Select` props
  - Tells the dropdown to expand its width to accommodate for long content
  - Has a max width of `64ch`, which is approximately 64 characters
  - Adds `itemCharacterLimit` which is only applied when `useFullWidtthItems` to allow overriding the default max widtth of `64ch`
  - Has a min width of the width of the dropdown selector, so that expanding the dropdown selector will cause the dropdown menu to be the same width as it, even if the content is shorter

### Example from the Database selector in Sql Console
#### Reasonable length content
![Screenshot 2024-08-12 at 9 59 09 AM](https://github.com/user-attachments/assets/1b722549-fc6a-4ee1-a994-a36c895349a8)
#### Very long content
![Screenshot 2024-08-12 at 12 09 20 PM](https://github.com/user-attachments/assets/6782511e-f77c-4065-8a17-2ae4b793cd96)
#### Ludicrously long content (clipped at 64 characters)
![Screenshot 2024-08-12 at 12 00 00 PM](https://github.com/user-attachments/assets/807967dd-5c63-4df4-96bc-1253c44a2687)
#### Minimum width of the dropdown selector
![Screenshot 2024-08-12 at 11 50 32 AM](https://github.com/user-attachments/assets/cf839892-161e-4c97-8ba1-0092b3566f08)
#### `itemCharacterLimit="32ch"`
![Screenshot 2024-08-12 at 12 34 52 PM](https://github.com/user-attachments/assets/b67a3f69-d6e7-47c3-a344-b18613d23510)
#### itemCharacterLimit="200ch" (can break things if not careful)
![Screenshot 2024-08-12 at 12 35 59 PM](https://github.com/user-attachments/assets/eff7cac2-5b9c-41bd-a97f-a3e5164ef5e8)
