### PR TITLE
Adding backgrounds to icons

### DIFF
--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -3,14 +3,22 @@ import { FlagList } from "../icons/Flags";
 import { PaymentList } from "../icons/Payments";
 import { Icon } from "./Icon";
 import { ICONS_MAP } from "./IconCommon";
+import { IconProps } from "./types";
+import { Container } from "../Container/Container";
 
 const IconNames = Object.keys(ICONS_MAP);
 const FlagNames = Object.keys(FlagList);
 const LogoNames = Object.keys(LogosLight);
 const PaymentNames = Object.keys(PaymentList);
 
+const IconWrapper = (props: IconProps) => (
+  <Container>
+    <Icon {...props} />
+  </Container>
+);
+
 export default {
-  component: Icon,
+  component: IconWrapper,
   title: "Display/Icon",
   tags: ["icon", "autodocs"],
   argTypes: {
@@ -19,7 +27,11 @@ export default {
       control: { type: "select" },
     },
     size: {
-      options: ["xs" , "sm" , "md" , "lg" , "xl" , "xxl"],
+      options: ["xs", "sm", "md", "lg", "xl", "xxl"],
+      control: { type: "select" },
+    },
+    state: {
+      options: ["default", "info", "success", "warning", "danger", "neutral"],
       control: { type: "select" },
     },
   },
@@ -29,6 +41,7 @@ export const Playground = {
   args: {
     name: "users",
     size: "md",
+    state: "default",
     width: "",
     height: "",
   },

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { IconName, IconProps, IconSize, ImageType } from "./types";
+import { IconName, IconProps, IconSize, IconState, ImageType } from "./types";
 import { ICONS_MAP } from "@/components/Icon/IconCommon";
 import Flags, { FlagList, FlagName } from "../icons/Flags";
 import { Logo } from "../Logos/Logo";
@@ -12,6 +12,7 @@ const SVGIcon = ({
   color,
   width,
   height,
+  state,
   className,
   size,
   ...props
@@ -29,6 +30,7 @@ const SVGIcon = ({
       $height={height}
       $size={size}
       className={className}
+      state={state}
     >
       <Component {...props} />
     </SvgWrapper>
@@ -40,6 +42,7 @@ const SvgWrapper = styled.div<{
   $width?: number | string;
   $height?: number | string;
   $size?: IconSize;
+  state?: IconState;
 }>`
   display: flex;
   align-items: center;
@@ -57,6 +60,13 @@ const SvgWrapper = styled.div<{
       width: ${$width || theme.click.image[$size || "md"].size.width || "24px"};
       height: ${$height || theme.click.image[$size || "md"].size.height || "24px"};
     }
+  `}
+
+  ${({ theme, $color = "currentColor", state = "default", $size = "md" }) => `
+    background: ${theme.click.icon.color.background[state]};
+    border-radius: ${theme.border.radii.full};
+    padding: ${state === "default" ? "none" : theme.click.icon.space[$size].all};
+    color: ${state === "default" ? $color : theme.click.icon.color.text[state]};
   `}
 `;
 

--- a/src/components/Icon/types.ts
+++ b/src/components/Icon/types.ts
@@ -5,6 +5,8 @@ import { LogoName } from "../Logos/types";
 import { PaymentName, PaymentProps } from "../icons/Payments";
 
 export type IconSize = "xs" | "sm" | "md" | "lg" | "xl" | "xxl";
+export type IconState = "default" | "success" | "warning" | "danger" | "info";
+
 export const ICON_NAMES = [
   "activity",
   "alarm",
@@ -149,6 +151,7 @@ export interface IconProps extends SVGAttributes<HTMLOrSVGElement> {
   name: IconName;
   color?: string;
   size?: IconSize;
+  state?: IconState;
 }
 
 type NoThemeType = {

--- a/src/styles/types.ts
+++ b/src/styles/types.ts
@@ -2652,6 +2652,54 @@
         "unset": string
       }
     },
+    "icon": {
+      "space": {
+        "xs": {
+          "all": string
+        },
+        "sm": {
+          "all": string
+        },
+        "md": {
+          "all": string
+        },
+        "lg": {
+          "all": string
+        },
+        "xl": {
+          "all": string
+        },
+        "xxl": {
+          "all": string
+        }
+      },
+      "color": {
+        "background": {
+          "default": string,
+          "success": string,
+          "neutral": string,
+          "danger": string,
+          "info": string,
+          "warning": string
+        },
+        "text": {
+          "default": string,
+          "success": string,
+          "neutral": string,
+          "danger": string,
+          "info": string,
+          "warning": string
+        },
+        "stroke": {
+          "default": string,
+          "success": string,
+          "neutral": string,
+          "danger": string,
+          "info": string,
+          "warning": string
+        }
+      }
+    },
     "global": {
       "color": {
         "background": {

--- a/src/styles/variables.dark.json
+++ b/src/styles/variables.dark.json
@@ -1310,6 +1310,34 @@
         }
       }
     },
+    "icon": {
+      "color": {
+        "background": {
+          "default": "rgba(0,0,0,0)",
+          "success": "rgb(20% 100% 26.7% / 0.2)",
+          "neutral": "rgb(62.7% 62.7% 62.7% / 0.2)",
+          "danger": "rgb(100% 13.7% 13.7% / 0.2)",
+          "info": "rgb(7.45% 35.7% 90.2% / 0.2)",
+          "warning": "rgb(100% 58% 8.63% / 0.2)"
+        },
+        "text": {
+          "default": "rgba(0,0,0,0)",
+          "success": "#CCFFD0",
+          "neutral": "#c0c0c0",
+          "danger": "#ffbaba",
+          "info": "#b5cdf9",
+          "warning": "#ffca8b"
+        },
+        "stroke": {
+          "default": "rgba(0,0,0,0)",
+          "success": "rgb(20% 100% 26.7% / 0.05)",
+          "neutral": "rgb(62.7% 62.7% 62.7% / 0.2)",
+          "danger": "rgb(100% 13.7% 13.7% / 0.05)",
+          "info": "rgb(7.45% 35.7% 90.2% / 0.05)",
+          "warning": "rgb(100% 58% 8.63% / 0.05)"
+        }
+      }
+    },
     "global": {
       "color": {
         "background": {

--- a/src/styles/variables.json
+++ b/src/styles/variables.json
@@ -2651,6 +2651,54 @@
         "unset": ""
       }
     },
+    "icon": {
+      "space": {
+        "xs": {
+          "all": "0.25rem"
+        },
+        "sm": {
+          "all": "0.25rem"
+        },
+        "md": {
+          "all": "0.365rem"
+        },
+        "lg": {
+          "all": "0.5rem"
+        },
+        "xl": {
+          "all": "0.75rem"
+        },
+        "xxl": {
+          "all": "1rem"
+        }
+      },
+      "color": {
+        "background": {
+          "default": "rgba(0,0,0,0)",
+          "success": "rgb(20% 100% 26.7% / 0.1)",
+          "neutral": "rgb(41.2% 43.1% 47.5% / 0.1)",
+          "danger": "rgb(100% 13.7% 13.7% / 0.1)",
+          "info": "rgb(7.45% 35.7% 90.2% / 0.1)",
+          "warning": "rgb(100% 58% 8.63% / 0.1)"
+        },
+        "text": {
+          "default": "rgba(0,0,0,0)",
+          "success": "#00990D",
+          "neutral": "#53575f",
+          "danger": "#c10000",
+          "info": "#135be6",
+          "warning": "#9e5600"
+        },
+        "stroke": {
+          "default": "rgba(0,0,0,0)",
+          "success": "rgb(20% 100% 26.7% / 0.05)",
+          "neutral": "rgb(41.2% 43.1% 47.5% / 0.1)",
+          "danger": "rgb(100% 13.7% 13.7% / 0.05)",
+          "info": "rgb(7.45% 35.7% 90.2% / 0.05)",
+          "warning": "rgb(100% 58% 8.63% / 0.05)"
+        }
+      }
+    },
     "global": {
       "color": {
         "background": {

--- a/src/styles/variables.light.json
+++ b/src/styles/variables.light.json
@@ -1303,6 +1303,34 @@
         }
       }
     },
+    "icon": {
+      "color": {
+        "background": {
+          "default": "rgba(0,0,0,0)",
+          "success": "rgb(20% 100% 26.7% / 0.1)",
+          "neutral": "rgb(41.2% 43.1% 47.5% / 0.1)",
+          "danger": "rgb(100% 13.7% 13.7% / 0.1)",
+          "info": "rgb(7.45% 35.7% 90.2% / 0.1)",
+          "warning": "rgb(100% 58% 8.63% / 0.1)"
+        },
+        "text": {
+          "default": "rgba(0,0,0,0)",
+          "success": "#00990D",
+          "neutral": "#53575f",
+          "danger": "#c10000",
+          "info": "#135be6",
+          "warning": "#9e5600"
+        },
+        "stroke": {
+          "default": "rgba(0,0,0,0)",
+          "success": "rgb(20% 100% 26.7% / 0.05)",
+          "neutral": "rgb(41.2% 43.1% 47.5% / 0.1)",
+          "danger": "rgb(100% 13.7% 13.7% / 0.05)",
+          "info": "rgb(7.45% 35.7% 90.2% / 0.05)",
+          "warning": "rgb(100% 58% 8.63% / 0.05)"
+        }
+      }
+    },
     "global": {
       "color": {
         "background": {


### PR DESCRIPTION
### Summary
As discussed with @rndD, the circular background for icons will likely become a fairly regular pattern in ClickHouse Cloud, due to this we felt it was important to make it native to Click UI. This PR does not effect the regular use of `Icon`, which would be a breaking change. What it does do is add a new prop that allows users to select an icon state. When a user sets a state, the circular background is added and the colours are updated to be consistent with alert, badge, feedback colours, aiding consistency.

Available options: `"default" | "success" | "warning" | "danger" | "info"; `

https://github.com/user-attachments/assets/4060aebf-e6c7-4b72-a57b-45adb6a81ff5

