### PR TITLE
[Table] Add `$isActive` prop to TableRow

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -18,6 +18,24 @@ const rows = [
       { label: "Mexico" },
     ],
   },
+  {
+    id: "row-3",
+    isActive: true,
+    items: [
+      { label: "Alfreds Futterkiste" },
+      { label: "Maria Anders" },
+      { label: "Germany" },
+    ],
+  },
+  {
+    id: "row-4",
+    isDeleted: true,
+    items: [
+      { label: "Centro comercial Moctezuma" },
+      { label: "Francisco Chang" },
+      { label: "Mexico" },
+    ],
+  },
 ];
 
 export default {

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -156,18 +156,23 @@ interface TableRowProps {
   $isSelectable?: boolean;
   $isDeleted?: boolean;
   $isDisabled?: boolean;
+  $isActive?: boolean;
   $showActions?: boolean;
   $rowHeight?: string;
 }
 
 const TableRow = styled.tr<TableRowProps>`
   overflow: hidden;
-  ${({ theme, $isDeleted, $isDisabled, $rowHeight }) => `
+  ${({ theme, $isDeleted, $isDisabled, $isActive, $rowHeight }) => `
     ${$rowHeight ? `height: ${$rowHeight};` : ""}
     background-color: ${theme.click.table.row.color.background.default};
     border-bottom: ${theme.click.table.cell.stroke} solid ${
-    theme.click.table.row.color.stroke.default
-  };
+      theme.click.table.row.color.stroke.default
+    };
+
+    ${$isActive &&
+      `background-color: ${theme.click.table.row.color.background.active};`}
+
     &:active {
       background-color: ${theme.click.table.row.color.background.active};
     }
@@ -366,6 +371,7 @@ export interface TableRowType
   items: Array<TableCellType>;
   isDisabled?: boolean;
   isDeleted?: boolean;
+  isActive?: boolean;
 }
 
 interface CommonTableProps
@@ -422,6 +428,7 @@ const TableBodyRow = ({
   onDelete,
   onEdit,
   isDeleted,
+  isActive,
   isDisabled,
   size,
   actionsList,
@@ -435,6 +442,7 @@ const TableBodyRow = ({
       $isSelectable={isSelectable}
       $isDeleted={isDeleted}
       $isDisabled={isDisabled}
+      $isActive={isActive}
       $showActions={isDeletable || isEditable}
       $rowHeight={rowHeight}
       {...rowProps}


### PR DESCRIPTION
Closes: https://github.com/ClickHouse/click-ui/issues/433


<img width="1127" alt="Screenshot 2024-09-08 at 12 14 54" src="https://github.com/user-attachments/assets/a3f0bf84-f3a2-416e-805a-6034fd55b094">
