### PR TITLE
Support `widest` for flyout size

### DIFF
--- a/src/components/Flyout/Flyout.stories.tsx
+++ b/src/components/Flyout/Flyout.stories.tsx
@@ -7,7 +7,7 @@ interface Props extends FlyoutProps {
   alignBody: "default" | "top";
   align: "start" | "end";
   type: "default" | "inline";
-  size: "default" | "narrow" | "wide";
+  size: "default" | "narrow" | "wide" | "widest";
   width?: string;
 }
 
@@ -69,7 +69,7 @@ export default {
 
       description: "Align the flyout",
     },
-    size: { control: "select", options: ["default", "narrow", "wide"] },
+    size: { control: "select", options: ["default", "narrow", "wide", "widest"] },
     type: { control: "select", options: ["default", "inline"] },
     width: { control: "text" },
   },

--- a/src/components/Flyout/Flyout.tsx
+++ b/src/components/Flyout/Flyout.tsx
@@ -50,7 +50,7 @@ const Trigger = ({ children, ...props }: DialogTriggerProps) => {
 Trigger.displayName = "Flyout.Trigger";
 Flyout.Trigger = Trigger;
 
-type FlyoutSizeType = "default" | "narrow" | "wide";
+type FlyoutSizeType = "default" | "narrow" | "wide" | "widest";
 type Strategy = "relative" | "absolute" | "fixed";
 type FlyoutType = "default" | "inline";
 


### PR DESCRIPTION
Sometimes, we need a bit more space than `wide` for a flyout.
Added the `widest` token support in flyout sizes, updated story.
