### PR TITLE
Fix calculating minimum column width when it's larger than required

### DIFF
--- a/src/components/Grid/useColumns.ts
+++ b/src/components/Grid/useColumns.ts
@@ -137,7 +137,7 @@ const useColumns = ({
         onColumnResizeProp(columnIndex, newWidth);
       }
     },
-    [gridRef, onColumnResizeProp, outerGridRef, measureColumnWidth, columnCount]
+    [gridRef, onColumnResizeProp, outerGridRef, columnCount]
   );
 
   const columnWidth = useCallback(

--- a/src/components/Grid/useColumns.ts
+++ b/src/components/Grid/useColumns.ts
@@ -146,7 +146,7 @@ const useColumns = ({
         onColumnResizeProp(columnIndex, newWidth);
       }
     },
-    [columnCount, gridRef, onColumnResizeProp, measureColumnWidth]
+    [gridRef, onColumnResizeProp, outerGridRef, measureColumnWidth, columnCount]
   );
 
   const columnWidth = useCallback(

--- a/src/components/Grid/useColumns.ts
+++ b/src/components/Grid/useColumns.ts
@@ -9,10 +9,9 @@ const MIN_COLUMN_WIDTH = 32;
  * Measures the minimum width required to display all content in a column without wrapping or truncation.
  * Note. We cannot simply measure item.scrollWidth, because it will return the current width if it is larger than needed.
  * To workaround it, we temporary shrink the column width to MIN_COLUMN_WIDTH and measure the scrollWidth.
- * @param {number} columnIndex - The index of the column to measure
- * @param {HTMLDivElement} outerGrid - The grid element containing the column
- * @returns {number} The minimum width needed for the column's content (in pixels)
- *                   Returns MIN_COLUMN_WIDTH if outerGridRef is not available
+ * @param {number} columnIndex - The index of the column to measure.
+ * @param {HTMLDivElement} outerGrid - The grid element containing the column.
+ * @returns {number} The minimum width needed for the column's content (in pixels).
  */
 const measureColumnWidth = (columnIndex: number, outerGrid: HTMLDivElement): number => {
   // Store the original widths

--- a/src/examples/GridExample.tsx
+++ b/src/examples/GridExample.tsx
@@ -22,7 +22,7 @@ const Cell: CellProps = ({
       data-scrolling={isScrolling}
       {...props}
     >
-      {rowIndex} {columnIndex} - {type} {width}px
+      {rowIndex} {columnIndex} - {type} {Math.round(width)}px
     </span>
   );
 };


### PR DESCRIPTION
# Why

Double-clicking the Grid header resizer, when the column is larger than required, doesn't shrink the column to the minimum required size.

The reason was the required cell width calculation using `item.scrollWidth`, which returns current width when the cell is larger than needed.

# What

Added `measureColumnWidth` function that properly calculating minimum required width by shrinking the cell to 20x, and then using `item.scrollWidth`

# QA

* Run the click-ui example using `yarn dev`
* Go to http://localhost:5173/, scroll down to the grid.
* Resize one of the columns to make it too large.
* Double-click the resizer for that column

Expected:

* The column shrinks.