### PR TITLE
Link: export linkStyles to allow styling React Router Links

### DIFF
--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -8,9 +8,7 @@ import {
 } from "react";
 import { Icon, IconName } from "@/components";
 import { styled } from "styled-components";
-
-type TextSize = "xs" | "sm" | "md" | "lg";
-type TextWeight = "normal" | "medium" | "semibold" | "bold";
+import { linkStyles, TextSize, TextWeight } from "./common";
 
 export interface LinkProps<T extends ElementType = "a"> {
   size?: TextSize;
@@ -22,33 +20,7 @@ export interface LinkProps<T extends ElementType = "a"> {
 }
 
 const CuiLink = styled.a<{ $size: TextSize; $weight: TextWeight }>`
-  font: ${({ $size, $weight = "normal", theme }) =>
-    theme.typography.styles.product.text[$weight][$size]};
-  color: ${({ theme }) => theme.click.global.color.text.link.default};
-  margin: 0;
-  text-decoration: none;
-  display: inline-flex;
-  gap: ${({ $size, theme }) =>
-    $size === "xs" || $size === "sm"
-      ? theme.click.link.space.sm.gap
-      : theme.click.link.space.md.gap};
-  margin-right: ${({ $size, theme }) =>
-    $size === "xs" || $size === "sm"
-      ? theme.click.link.space.sm.gap
-      : theme.click.link.space.md.gap};
-  align-items: center;
-
-  &:hover,
-  &:focus {
-    color: ${({ theme }) => theme.click.global.color.text.link.hover};
-    transition: ${({ theme }) => theme.transition.default};
-    text-decoration: underline;
-    cursor: pointer;
-  }
-
-  &:visited {
-    color: ${({ theme }) => theme.click.global.color.text.link.default};
-  }
+  ${linkStyles}
 `;
 
 const IconWrapper = styled.span<{ $size: TextSize }>`

--- a/src/components/Link/common.ts
+++ b/src/components/Link/common.ts
@@ -1,0 +1,36 @@
+import { css } from "styled-components";
+
+export type TextSize = "xs" | "sm" | "md" | "lg";
+export type TextWeight = "normal" | "medium" | "semibold" | "bold";
+
+export type StyledLinkProps = { $size: TextSize; $weight: TextWeight };
+
+export const linkStyles = css<StyledLinkProps>`
+  font: ${({ $size, $weight = "normal", theme }) =>
+    theme.typography.styles.product.text[$weight][$size]};
+  color: ${({ theme }) => theme.click.global.color.text.link.default};
+  margin: 0;
+  text-decoration: none;
+  display: inline-flex;
+  gap: ${({ $size, theme }) =>
+    $size === "xs" || $size === "sm"
+      ? theme.click.link.space.sm.gap
+      : theme.click.link.space.md.gap};
+  margin-right: ${({ $size, theme }) =>
+    $size === "xs" || $size === "sm"
+      ? theme.click.link.space.sm.gap
+      : theme.click.link.space.md.gap};
+  align-items: center;
+
+  &:hover,
+  &:focus {
+    color: ${({ theme }) => theme.click.global.color.text.link.hover};
+    transition: ${({ theme }) => theme.transition.default};
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  &:visited {
+    color: ${({ theme }) => theme.click.global.color.text.link.default};
+  }
+`;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -34,6 +34,7 @@ export { default as Flags } from "./icons/Flags";
 export { Grid } from "./Grid/Grid";
 export { HoverCard } from "./HoverCard/HoverCard";
 export { Link } from "./Link/Link";
+export { linkStyles } from "./Link/common";
 export { Logo } from "./Logos/Logo";
 export { NumberField } from "./Input/NumberField";
 export { PasswordField } from "./Input/PasswordField";

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -58,6 +58,7 @@ export type {
   GridContextMenuItemProps,
   Rectangle,
 } from "./Grid/types";
+export type { StyledLinkProps } from "./Link/common";
 
 export type States = "default" | "active" | "disabled" | "error" | "hover";
 export type HorizontalDirection = "start" | "end";


### PR DESCRIPTION

In apps that use `ReactRouter` or a similar router to mimic `<a>` functionality, there are two unattractive ways to get links that look and feel like click-ui `Link`s:


   1. Wrap the click-ui `Link` in a `ReactRouter` `Link`, which will throw a `validateDOMNesting` warning about nesting an `<a>` inside an `<a>`. See screenshot below.
   2. Duplicate the existing click-ui styles

The warning shows up in many of the e2e tests because many of them go to the main page of the app where these nested anchor tags are.

### Screenshot of problem
(Application redacted; only console shown)
![Screenshot 2024-12-11 at 4 40 38 PM](https://github.com/user-attachments/assets/a4c00fdf-e3d2-4985-8b1e-a7803c3289de)

This PR fixes that by exporting the styles that click-ui `Link` uses.

### Usage:

```ts
import styled from 'styled-components';
import { linkStyles, StyledLinkProps } from '@clickhouse/click-ui';

const CuiStyledLink = styled(Link)<StyledLinkProps>`
  ${linkStyles}
`;

<CuiStyledLink to={myHref}>Click me to go places</CuiStyledLink>
```