### PR TITLE
Fix improper styled-components import in DatePicker. Fix import of tsx syntax

### DIFF
--- a/src/components/CodeBlock/CodeBlock.tsx
+++ b/src/components/CodeBlock/CodeBlock.tsx
@@ -7,7 +7,7 @@ import { EmptyButton } from "../commonElement";
 import sql from "react-syntax-highlighter/dist/cjs/languages/hljs/sql";
 import bash from "react-syntax-highlighter/dist/cjs/languages/hljs/bash";
 import json from "react-syntax-highlighter/dist/cjs/languages/hljs/json";
-import tsx from "react-syntax-highlighter/dist/cjs/languages/prism/typescript";
+import tsx from "react-syntax-highlighter/dist/cjs/languages/hljs/typescript"
 
 SyntaxHighlighter.registerLanguage("sql", sql);
 SyntaxHighlighter.registerLanguage("bash", bash);

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useId, useState } from "react";
 import { isSameDate, useCalendar, UseCalendarOptions } from "@h6s/calendar";
+import { styled } from "styled-components";
 import Dropdown from "../Dropdown/Dropdown";
 import { Icon } from "../Icon/Icon";
 import { InputElement, InputWrapper } from "../Input/InputWrapper";
 import { Container } from "../Container/Container";
-import styled from "styled-components";
 import { IconButton } from "../IconButton/IconButton";
 
 const locale = "en-US";


### PR DESCRIPTION
- Fixes warning `Language definition for 'tsx' could not be registered.`
- Fixes `TypeError: styled$1 is not a function` error importing versions > `0.0.169`