### PR TITLE
Select: allow setting a z-index of the content popover

### DIFF
--- a/src/components/Select/common/InternalSelect.tsx
+++ b/src/components/Select/common/InternalSelect.tsx
@@ -127,6 +127,7 @@ export const InternalSelect = ({
   container,
   useFullWidthItems = false,
   itemCharacterLimit = "64ch",
+  zIndex = "auto",
   ...props
 }: SelectContainerProps) => {
   const defaultId = useId();
@@ -391,6 +392,7 @@ export const InternalSelect = ({
               align="start"
               $useFullWidthItems={useFullWidthItems}
               $itemCharacterLimit={itemCharacterLimit}
+              $zIndex={zIndex}
             >
               <SelectList>
                 <SearchBarContainer $showSearch={showSearch}>

--- a/src/components/Select/common/SelectStyled.tsx
+++ b/src/components/Select/common/SelectStyled.tsx
@@ -84,6 +84,7 @@ export const StyledSelectTrigger = styled(Trigger)<{ $error: boolean }>`
 export const SelectPopoverContent = styled(Content)<{
   $useFullWidthItems: boolean;
   $itemCharacterLimit?: string;
+  $zIndex?: string;
 }>`
   width: var(--radix-popover-trigger-width);
   max-height: var(--radix-popover-content-available-height);
@@ -114,6 +115,8 @@ export const SelectPopoverContent = styled(Content)<{
   padding: 0.5rem 0rem;
   align-items: flex-start;
   gap: 0.625rem;
+
+  z-index: ${({ $zIndex = "auto" }) => $zIndex};
 `;
 
 export const SearchBarContainer = styled.div<{ $showSearch: boolean }>`

--- a/src/components/Select/common/types.ts
+++ b/src/components/Select/common/types.ts
@@ -84,6 +84,7 @@ interface InternalSelectProps
   container?: HTMLElement;
   useFullWidthItems?: boolean;
   itemCharacterLimit?: string;
+  zIndex?: string;
 }
 
 export type SelectOptionProp = SelectOptionType | SelectChildrenType;


### PR DESCRIPTION
I have a `Select` in a sticky header. I need the sticky header's z-index to be > 0. Doing this causes the items in the select list to be under the header:

![Screenshot 2024-12-17 at 3 11 47 PM](https://github.com/user-attachments/assets/322cabb3-b7c9-4ce9-bff4-5ce0d8f3615e)

Here is how it looks when I can set the z-index to be higher than the sticky header (i.e. how it should look):

![Screenshot 2024-12-17 at 3 11 56 PM](https://github.com/user-attachments/assets/6035782f-7e5a-4497-a1c6-404c6b1076b6)
