### PR TITLE
Fix Select in Firefox

### DIFF
--- a/src/components/GenericMenu.tsx
+++ b/src/components/GenericMenu.tsx
@@ -72,6 +72,7 @@ export const Arrow = styled.svg`
 export const GenericMenuItem = styled.div`
   display: flex;
   width: 100%;
+  width: -moz-available;
   width: -webkit-fill-available;
   width: fill-available;
   width: stretch;

--- a/src/components/Select/common/SelectStyled.tsx
+++ b/src/components/Select/common/SelectStyled.tsx
@@ -193,7 +193,6 @@ export const HiddenSelectElement = styled.select`
 export const SelectGroupContainer = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
   justify-content: center;
   width: -webkit-fill-available;
   width: fill-available;


### PR DESCRIPTION
Noticed a few issues while browsing the console using Firefox.

## 1st fix — items are not full width in select groups
`align-items` is `stretch` by default, and it has the same alignment, along with items being full width
in the current version, `width: inherit` for grouped items apparently doesn't work

before: 
![grafik](https://github.com/user-attachments/assets/16777646-0420-4175-8782-9b9b9b0612bf)

with the fix:
![grafik](https://github.com/user-attachments/assets/0d2a4024-cf37-4755-b83c-9567cdb3c63d)

## 2nd fix — items are wider than needed
This is a weird issue, but I though this fix should be ok.
It only occurs in storybook, because in storybook there is no `box-sizing: border-box` applied. For some reason. While in the real app, it's there. A components lib should work properly without depending on external styles.

The simple fix is to use `width: -moz-available` along with the same value for chorme-based browsers. I saw a few other places where `-webkit-fill-available` is used without `-moz-available` being next to it. So I can assume similar issues exist for other components. But that's another story.

Before:
![grafik](https://github.com/user-attachments/assets/bbf405cc-02c0-4995-882a-cc75e68405cf)

with the fix:
![grafik](https://github.com/user-attachments/assets/c1ac33f4-9189-41b1-b38f-017512195a7d)
