### PR TITLE
Fix: respect defaultValue in Select and MultiSelect

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -29,5 +29,8 @@ module.exports = {
         singleReturnOnly: false,
       },
     ],
+    "react-hooks/exhaustive-deps": ["warn", {
+      "additionalHooks": "(useUpdateEffect)"
+    }]  
   },
 };

--- a/src/components/Select/MultiSelect.test.tsx
+++ b/src/components/Select/MultiSelect.test.tsx
@@ -83,6 +83,16 @@ describe("MultiSelect", () => {
     expect(queryByTestingText(selectTrigger, "Content3")).toBeNull();
   });
 
+  it("should respect given defaultValue in select", () => {
+    const { getByTestId } = renderSelect({
+      defaultValue: ["content0", "content2"],
+    });
+    const selectTrigger = getByTestId("select-trigger");
+    expect(selectTrigger).not.toBeNull();
+    expect(queryByTestingText(selectTrigger, "Content0")).not.toBeNull();
+    expect(queryByTestingText(selectTrigger, "Content2")).not.toBeNull();
+  });
+
   it("should show error", () => {
     const { queryByText } = renderSelect({
       error: "Select Error",

--- a/src/components/Select/MultiSelect.tsx
+++ b/src/components/Select/MultiSelect.tsx
@@ -1,4 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
+
+import {useUpdateEffect} from "@/hooks";
 
 import { SelectContainerProps, SelectOptionProp, SelectionType } from "./common/types";
 import {
@@ -43,7 +45,7 @@ export const MultiSelect = ({
     [onOpenChangeProp]
   );
 
-  useEffect(() => {
+  useUpdateEffect(() => {
     setSelectedValues(valueProp ?? []);
   }, [valueProp]);
 

--- a/src/components/Select/SingleSelect.test.tsx
+++ b/src/components/Select/SingleSelect.test.tsx
@@ -115,6 +115,14 @@ describe("Select", () => {
     expect(queryByTestingText(selectTrigger, "Content0")).not.toBeNull();
   });
 
+  it("should respect given defaultValue in select", () => {
+    const { getByTestId } = renderSelect({
+      defaultValue: "content0",
+    });
+    const selectedValue = getByTestId("select-trigger");
+    expect(selectedValue.textContent).toBe("Content0");
+  });
+
   it("should render options", () => {
     const { queryByText, getByTestId } = renderSelect({
       options: selectOptions,

--- a/src/components/Select/SingleSelect.tsx
+++ b/src/components/Select/SingleSelect.tsx
@@ -1,4 +1,7 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
+
+import { useUpdateEffect } from "@/hooks";
+
 import { SelectContainerProps, SelectOptionProp, SelectionType } from "./common/types";
 import { InternalSelect, SelectGroup, SelectItem } from "./common/InternalSelect";
 
@@ -65,7 +68,7 @@ export const Select = ({
     [selectedValues, onSelect]
   );
 
-  useEffect(() => {
+  useUpdateEffect(() => {
     setSelectedValues(valueProp ? [valueProp] : []);
   }, [valueProp]);
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from "./useUpdateEffect";

--- a/src/hooks/useUpdateEffect.ts
+++ b/src/hooks/useUpdateEffect.ts
@@ -1,0 +1,15 @@
+import { useEffect, useRef } from "react";
+
+export const useUpdateEffect: typeof useEffect = (effect, deps) => {
+    const isFirstMount = useRef(true);
+
+    useEffect(() => {
+        if (isFirstMount) {
+            isFirstMount.current = false;
+            return;
+        }
+
+        return effect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, deps);
+};


### PR DESCRIPTION
## Why
Currently, `defaultValue` in `Select` and `MultiSelect` doesn't work. The reason is the effect that tracks updates of the value prop. It runs on mount as well, clearing the state with selected values that should contain default value.

## What
- introduced a new hook, `useUpdateEffect`, that works exactly as `componentDidUpdate` in classical component lifecycle, i.e. runs every update, but not on the first render
- for tracking `value` props update, changed `useEffect` in `Select` and `MultiSelect` to `useUpdateEffect`
- covered the basic behavior of `defaultValue` with test cases