### PR TITLE
Add itemCount prop to Dropdown story to test long lists.

### DIFF
--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -2,14 +2,17 @@ import { DropdownMenuProps } from "@radix-ui/react-dropdown-menu";
 import { Dropdown } from "./Dropdown";
 import { GridCenter } from "../commonElement";
 import { Button } from "..";
+import { Key } from "react";
 
 interface Props extends DropdownMenuProps {
   disabled?: boolean;
   showArrow?: boolean;
   side: "top" | "right" | "left" | "bottom";
   type: "text" | "button";
+  itemCount: number
 }
-const DropdownExample = ({ showArrow, disabled, side, ...props }: Props) => {
+const DropdownExample = ({ showArrow, disabled, side, itemCount, ...props }: Props) => {
+  const items = Array.from({ length: itemCount }, (_, i) => `Item ${i + 1}`);
   return (
     <GridCenter>
       <Dropdown {...props}>
@@ -21,6 +24,9 @@ const DropdownExample = ({ showArrow, disabled, side, ...props }: Props) => {
           <Dropdown.Group>
             <Dropdown.Item data-state="checked">Content0</Dropdown.Item>
           </Dropdown.Group>
+          {items.map((item:string, index: Key | null | undefined) => (
+                <Dropdown.Item key={index}>{item}</Dropdown.Item>
+              ))}
           <Dropdown.Item icon="activity">Content1 long text content</Dropdown.Item>
           <Dropdown.Sub>
             <Dropdown.Trigger sub>Hover over</Dropdown.Trigger>
@@ -85,6 +91,7 @@ const DropdownExample = ({ showArrow, disabled, side, ...props }: Props) => {
     </GridCenter>
   );
 };
+
 export default {
   component: DropdownExample,
   title: "Display/Dropdown",
@@ -95,12 +102,16 @@ export default {
     defaultOpen: { control: "boolean" },
     showArrow: { control: "boolean" },
     side: { control: "select", options: ["top", "right", "left", "bottom"] },
-    type: { control: "inline-radio", options: ["text", "button"] },
+    itemCount: {
+      control: { type: "number", min: 0, max: 100, step: 1 },
+      description: "Number of items to display",
+    },
   },
 };
 
 export const Playground = {
   args: {
     side: "bottom",
+    itemCount: 0,
   },
 };


### PR DESCRIPTION
Closes https://github.com/ClickHouse/click-ui/issues/532

# Why
Currently the list of items in the Dropdown story is hardcoded and there's no easy way to check edge cases with longer lists of items.

# What
This adds a prop to generate a list of items to be added to the dropdown:

https://github.com/user-attachments/assets/280d9cd8-a8fe-4019-9017-04ff961b4127

