### PR TITLE
Fix long list output in Dropdown

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -90,13 +90,14 @@ type DropdownSubContentProps = DropdownMenu.MenuSubContentProps &
   MainDropdownProps &
   ArrowProps;
 
-  console.log("Max height: ", )
 const DropdownMenuContent = styled(GenericMenuPanel)`
   min-width: ${({ theme }) => theme.click.genericMenu.item.size.minWidth};
   flex-direction: column;
   z-index: 1;
   overflow-y: scroll;
-  max-height: calc((var(--radix-${({ $type }) => $type}-content-available-height) - 100px))
+  max-height: calc(
+    (var(--radix-${({ $type }) => $type}-content-available-height) - 100px)
+  );
 `;
 
 const DropdownContent = ({

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -12,6 +12,7 @@ export const Dropdown = (props: DropdownMenu.DropdownMenuProps) => (
 const DropdownMenuItem = styled(GenericMenuItem)`
   position: relative;
   display: flex;
+  min-height: 32px;
   &[data-state="open"] {
     ${({ theme }) => `
       font: ${theme.click.genericMenu.item.typography.label.hover};
@@ -93,6 +94,7 @@ const DropdownMenuContent = styled(GenericMenuPanel)`
   min-width: ${({ theme }) => theme.click.genericMenu.item.size.minWidth};
   flex-direction: column;
   z-index: 1;
+  overflow-y: auto;
 `;
 
 const DropdownContent = ({

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -90,11 +90,13 @@ type DropdownSubContentProps = DropdownMenu.MenuSubContentProps &
   MainDropdownProps &
   ArrowProps;
 
+  console.log("Max height: ", )
 const DropdownMenuContent = styled(GenericMenuPanel)`
   min-width: ${({ theme }) => theme.click.genericMenu.item.size.minWidth};
   flex-direction: column;
   z-index: 1;
-  overflow-y: auto;
+  overflow-y: scroll;
+  max-height: calc((var(--radix-${({ $type }) => $type}-content-available-height) - 100px))
 `;
 
 const DropdownContent = ({


### PR DESCRIPTION
Closes https://github.com/ClickHouse/click-ui/issues/533

# Why
Currently lists over 15+ items in the Dropdown component do not display correctly:
<img width="1501" alt="Screenshot 2025-01-29 at 4 55 54 PM" src="https://github.com/user-attachments/assets/bf1e020c-2a58-41e1-9dd6-88edb2f48b0c" />

# What
This adds `overflow-y: auto` to the `Dropdown.Content` component to allow for scrolling and sets `min-height: 32px` on the `Dropdown.Item` to make sure it does not get compressed to less than the expected height. I got the `32px` from the computed height of other `Dropdown.Items` I looked at.

https://github.com/user-attachments/assets/13ff6239-dabd-451d-806f-566e05abbdc6





