### PR TITLE
Expand cell height if there is only one row

### DIFF
--- a/src/components/Grid/Cell.tsx
+++ b/src/components/Grid/Cell.tsx
@@ -5,16 +5,10 @@ import { StyledCell } from "./StyledCell";
 
 type CellProps = GridChildComponentProps<ItemDataType> & {
   width: number;
-}
+};
 
 export const Cell = memo(
-  ({
-    data,
-    rowIndex,
-    columnIndex,
-    style,
-    ...props
-  }: CellProps) => {
+  ({ data, rowIndex, columnIndex, style, ...props }: CellProps) => {
     const {
       cell: CellData,
       getSelectionType,
@@ -59,7 +53,7 @@ export const Cell = memo(
 
     const selectionBorderLeft = rightOfSelectionBorder || rightOfFocus || isFocused;
     const selectionBorderTop = belowSelectionBorder || belowFocus || isFocused;
-    console.log("Only row? ",rowCount === 1 )
+    console.log("Only row? ", rowCount === 1);
     return (
       <div
         style={style}

--- a/src/components/Grid/Cell.tsx
+++ b/src/components/Grid/Cell.tsx
@@ -59,7 +59,7 @@ export const Cell = memo(
 
     const selectionBorderLeft = rightOfSelectionBorder || rightOfFocus || isFocused;
     const selectionBorderTop = belowSelectionBorder || belowFocus || isFocused;
-
+    console.log("Only row? ",rowCount === 1 )
     return (
       <div
         style={style}
@@ -85,6 +85,7 @@ export const Cell = memo(
           data-grid-row={currentRowIndex}
           data-grid-column={columnIndex}
           $showBorder
+          $isOnlyRow={rowCount === 1}
           {...props}
         />
       </div>

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -777,14 +777,36 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
     }, [rowStart, onItemsRendered]);
 
     const CellWithWidth = (args: GridChildComponentProps<ItemDataType>): JSX.Element => {
-      const width = columnWidth(args.columnIndex);
-      return (
-        <Cell
-          {...args}
-          width={width}
-        />
-      );
-    };
+  const width = columnWidth(args.columnIndex);
+  return (
+    <Cell
+      {...args}
+      width={width}
+    />
+  );
+};
+
+    useEffect(() => {
+      if (gridRef.current) {
+        gridRef.current.resetAfterRowIndex(0);
+      }
+    }, [rowCount]);
+
+    const getRowHeight = useCallback(
+      (index: number, parentHeight: number): number => {
+        const headerHeight = 33;
+    
+        // For single data row case
+        if (rowCount === 1 && index === 0) {
+          console.log("Returning parentheight - headerheight", parentHeight, parentHeight - headerHeight)
+          return parentHeight - headerHeight*2;
+        }
+        
+        console.log("Returning rowheight ", rowHeight)
+        return rowHeight; // Default row height for multiple rows
+      },
+      [rowCount, rowHeight]
+    );
 
     return (
       <ContextMenu
@@ -814,33 +836,36 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
           $showBorder={showBorder}
         >
           <AutoSizer onResize={onResize}>
-            {({ height, width }) => (
-              <VariableSizeGrid
-                ref={forwardedGridRef ? mergeRefs([forwardedGridRef, gridRef]) : gridRef}
-                height={height}
-                width={width}
-                columnCount={columnCount}
-                rowHeight={() => rowHeight}
-                useIsScrolling={useIsScrolling}
-                innerElementType={InnerElementType}
-                itemData={data}
-                initialScrollTop={
-                  focus.row < rowStart
-                    ? focus.row * rowHeight
-                    : (focus.row - rowStart) * rowHeight
-                }
-                initialScrollLeft={getColumnHorizontalPosition(focus.column)}
-                columnWidth={columnWidth}
-                rowCount={rowCount}
-                onScroll={onScroll}
-                outerRef={outerRef}
-                outerElementType={OuterElementType}
-                onItemsRendered={onItemsRendered}
-                {...props}
-              >
-                {CellWithWidth}
-              </VariableSizeGrid>
-            )}
+            {({ height, width }) => {
+              console.log('Parent container height:', height);
+              return (
+                <VariableSizeGrid
+                  ref={forwardedGridRef ? mergeRefs([forwardedGridRef, gridRef]) : gridRef}
+                  height={height}
+                  width={width}
+                  columnCount={columnCount}
+                  rowHeight={index => getRowHeight(index, height)}
+                  useIsScrolling={useIsScrolling}
+                  innerElementType={InnerElementType}
+                  itemData={data}
+                  initialScrollTop={
+                    focus.row < rowStart
+                      ? focus.row * rowHeight
+                      : (focus.row - rowStart) * rowHeight
+                  }
+                  initialScrollLeft={getColumnHorizontalPosition(focus.column)}
+                  columnWidth={columnWidth}
+                  rowCount={rowCount}
+                  onScroll={onScroll}
+                  outerRef={outerRef}
+                  outerElementType={OuterElementType}
+                  onItemsRendered={onItemsRendered}
+                  {...props}
+                >
+                  {CellWithWidth}
+                </VariableSizeGrid>
+            )
+            }}
           </AutoSizer>
         </ContextMenuTrigger>
         <ContextMenu.Content>

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -777,15 +777,17 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
     }, [rowStart, onItemsRendered]);
 
     const CellWithWidth = (args: GridChildComponentProps<ItemDataType>): JSX.Element => {
-  const width = columnWidth(args.columnIndex);
-  return (
-    <Cell
-      {...args}
-      width={width}
-    />
-  );
-};
+      const width = columnWidth(args.columnIndex);
+      return (
+        <Cell
+          {...args}
+          width={width}
+        />
+      );
+    };
 
+    // Handles the case when rowCount changes, expanding the cell height
+    // to fit content if there is only one row.
     useEffect(() => {
       if (gridRef.current) {
         gridRef.current.resetAfterRowIndex(0);
@@ -794,11 +796,10 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
 
     const getRowHeight = useCallback(
       (index: number, parentHeight: number): number => {
-    
         if (rowCount === 1 && index === 0) {
-          return parentHeight - rowHeight*2;
+          return parentHeight - rowHeight * 2;
         }
-        
+
         return rowHeight;
       },
       [rowCount, rowHeight]
@@ -858,7 +859,7 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
               >
                 {CellWithWidth}
               </VariableSizeGrid>
-          )}
+            )}
           </AutoSizer>
         </ContextMenuTrigger>
         <ContextMenu.Content>

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -794,16 +794,12 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
 
     const getRowHeight = useCallback(
       (index: number, parentHeight: number): number => {
-        const headerHeight = 33;
     
-        // For single data row case
         if (rowCount === 1 && index === 0) {
-          console.log("Returning parentheight - headerheight", parentHeight, parentHeight - headerHeight)
-          return parentHeight - headerHeight*2;
+          return parentHeight - rowHeight*2;
         }
         
-        console.log("Returning rowheight ", rowHeight)
-        return rowHeight; // Default row height for multiple rows
+        return rowHeight;
       },
       [rowCount, rowHeight]
     );
@@ -836,36 +832,33 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
           $showBorder={showBorder}
         >
           <AutoSizer onResize={onResize}>
-            {({ height, width }) => {
-              console.log('Parent container height:', height);
-              return (
-                <VariableSizeGrid
-                  ref={forwardedGridRef ? mergeRefs([forwardedGridRef, gridRef]) : gridRef}
-                  height={height}
-                  width={width}
-                  columnCount={columnCount}
-                  rowHeight={index => getRowHeight(index, height)}
-                  useIsScrolling={useIsScrolling}
-                  innerElementType={InnerElementType}
-                  itemData={data}
-                  initialScrollTop={
-                    focus.row < rowStart
-                      ? focus.row * rowHeight
-                      : (focus.row - rowStart) * rowHeight
-                  }
-                  initialScrollLeft={getColumnHorizontalPosition(focus.column)}
-                  columnWidth={columnWidth}
-                  rowCount={rowCount}
-                  onScroll={onScroll}
-                  outerRef={outerRef}
-                  outerElementType={OuterElementType}
-                  onItemsRendered={onItemsRendered}
-                  {...props}
-                >
-                  {CellWithWidth}
-                </VariableSizeGrid>
-            )
-            }}
+            {({ height, width }) => (
+              <VariableSizeGrid
+                ref={forwardedGridRef ? mergeRefs([forwardedGridRef, gridRef]) : gridRef}
+                height={height}
+                width={width}
+                columnCount={columnCount}
+                rowHeight={index => getRowHeight(index, height)}
+                useIsScrolling={useIsScrolling}
+                innerElementType={InnerElementType}
+                itemData={data}
+                initialScrollTop={
+                  focus.row < rowStart
+                    ? focus.row * rowHeight
+                    : (focus.row - rowStart) * rowHeight
+                }
+                initialScrollLeft={getColumnHorizontalPosition(focus.column)}
+                columnWidth={columnWidth}
+                rowCount={rowCount}
+                onScroll={onScroll}
+                outerRef={outerRef}
+                outerElementType={OuterElementType}
+                onItemsRendered={onItemsRendered}
+                {...props}
+              >
+                {CellWithWidth}
+              </VariableSizeGrid>
+          )}
           </AutoSizer>
         </ContextMenuTrigger>
         <ContextMenu.Content>

--- a/src/components/Grid/StyledCell.tsx
+++ b/src/components/Grid/StyledCell.tsx
@@ -13,6 +13,7 @@ export const StyledCell = styled.div<{
   $height: number;
   $type?: "body" | "header";
   $showBorder: boolean;
+  $isOnlyRow?: boolean;
 }>`
   display: block;
   text-align: left;
@@ -34,8 +35,9 @@ export const StyledCell = styled.div<{
     $height,
     $type = "body",
     $showBorder,
+    $isOnlyRow
   }) => `
-    height: ${$height}px;
+    height: ${$isOnlyRow ? "100%" : `${$height}px`};
     background: ${theme.click.grid[$type].cell.color.background[$selectionType]};
     color: ${
       $type === "header"
@@ -95,10 +97,12 @@ export const StyledCell = styled.div<{
     $type = "body",
     $isSelectedTop,
     $isSelectedLeft,
+    $isOnlyRow
   }) =>
     $isSelectedTop ||
     $isSelectedLeft ||
-    ($selectionType === "selectDirect" && ($isLastRow || $isLastColumn))
+    ($selectionType === "selectDirect" && ($isLastRow || $isLastColumn)) ||
+    $isOnlyRow
       ? `
           &::before {
             content: "";

--- a/src/components/Grid/StyledCell.tsx
+++ b/src/components/Grid/StyledCell.tsx
@@ -35,9 +35,10 @@ export const StyledCell = styled.div<{
     $height,
     $type = "body",
     $showBorder,
-    $isOnlyRow
+    $isOnlyRow,
   }) => `
-    height: ${$isOnlyRow ? "100%" : `${$height}px`};
+    height: ${$isOnlyRow ? "auto" : `${$height}px`};
+    overflow-y: ${$isOnlyRow ? "auto" : "hidden"};
     background: ${theme.click.grid[$type].cell.color.background[$selectionType]};
     color: ${
       $type === "header"
@@ -88,6 +89,10 @@ export const StyledCell = styled.div<{
     `
         : "border-right: none;"
     }
+    ${
+      $isOnlyRow
+        && "border: none;"
+      }
   `}
   ${({
     theme,
@@ -130,6 +135,10 @@ export const StyledCell = styled.div<{
               $selectionType === "selectDirect" && $isLastColumn
                 ? `border-right: 1px solid ${theme.click.grid[$type].cell.color.stroke.selectDirect};`
                 : ""
+            }
+            ${
+              $isOnlyRow
+                && "border: none;"
             }
           }
         `

--- a/src/components/Grid/StyledCell.tsx
+++ b/src/components/Grid/StyledCell.tsx
@@ -89,10 +89,7 @@ export const StyledCell = styled.div<{
     `
         : "border-right: none;"
     }
-    ${
-      $isOnlyRow
-        && "border: none;"
-      }
+    ${$isOnlyRow && "border: none;"}
   `}
   ${({
     theme,
@@ -102,7 +99,7 @@ export const StyledCell = styled.div<{
     $type = "body",
     $isSelectedTop,
     $isSelectedLeft,
-    $isOnlyRow
+    $isOnlyRow,
   }) =>
     $isSelectedTop ||
     $isSelectedLeft ||
@@ -136,10 +133,7 @@ export const StyledCell = styled.div<{
                 ? `border-right: 1px solid ${theme.click.grid[$type].cell.color.stroke.selectDirect};`
                 : ""
             }
-            ${
-              $isOnlyRow
-                && "border: none;"
-            }
+            ${$isOnlyRow && "border: none;"}
           }
         `
       : ""};


### PR DESCRIPTION
Closes https://github.com/ClickHouse/control-plane/issues/12806

# Why

Currently if there is one row of data displayed, and it's something like a `SHOW CREATE TABLE` query, it is cut off by default:
![Screenshot 2025-02-03 at 5 44 29 PM](https://github.com/user-attachments/assets/7b29afb5-e579-41b1-bab8-8f0b6e4c7ff5)

# What
This adds an `isOnlyRow` prop to the cell and expands the cell's height to fit the content; if the content overflows y, it is set to scroll

https://github.com/user-attachments/assets/00983dd1-d66a-4c65-b947-cf3062def887

# Reproduce
Create the following table and show the create query:

```
CREATE TABLE random_user_events (
    user_id UInt32,
    event_time DateTime,
    event_type Enum8('click' = 1, 'view' = 2, 'purchase' = 3),
    item_id String,
    price Decimal(10,2),
    quantity UInt16
) ENGINE = MergeTree()
ORDER BY (user_id, event_time)
PARTITION BY toYYYYMM(event_time)
SETTINGS index_granularity = 8192;

show create table random_user_events;
```
