### PR TITLE
Add title font weights & adjust dots-vertical-double icon

### DIFF
--- a/src/components/Typography/Title/Title.stories.tsx
+++ b/src/components/Typography/Title/Title.stories.tsx
@@ -9,6 +9,10 @@ export default {
       options: ["xs", "sm", "md", "lg", "xl", "2xl"],
       control: { type: "select" },
     },
+    weight: {
+      options: ["1", "2", "3", "4"],
+      control: { type: "select" },
+    },
     type: {
       options: ["h1", "h2", "h3", "h4", "h5", "h6"],
       control: { type: "select" },
@@ -27,6 +31,7 @@ export default {
 export const Playground = {
   args: {
     size: "md",
+    weight: "inherit",
     type: "h1",
     family: "product",
     color: "default",

--- a/src/components/Typography/Title/Title.tsx
+++ b/src/components/Typography/Title/Title.tsx
@@ -6,6 +6,7 @@ export type TitleColor = "default" | "muted";
 export type TitleSize = "xs" | "sm" | "md" | "lg" | "xl";
 export type TitleFamily = "product" | "brand";
 export type TitleType = "h1" | "h2" | "h3" | "h4" | "h5" | "h6";
+export type TitleWeight = "1" | "2" | "3" | "4";
 
 export interface TitleProps extends HTMLAttributes<HTMLHeadingElement> {
   align?: TitleAlignment;
@@ -13,17 +14,19 @@ export interface TitleProps extends HTMLAttributes<HTMLHeadingElement> {
   size?: TitleSize;
   family?: TitleFamily;
   type: TitleType;
+  weight?: TitleWeight;
 }
 
 /** The `title` component allows you to easily add headings to your pages. They do not include built in margins. */
 export const Title = forwardRef<HTMLHeadingElement, TitleProps>(
-  ({ align, size, family, type, color, children, ...props }, ref) => (
+  ({ align, size, family, type, color, weight, children, ...props }, ref) => (
     <CuiTitle
       ref={ref}
       $align={align}
       $color={color}
       $size={size}
       $family={family}
+      $weight={weight}
       as={type}
       {...props}
     >
@@ -37,6 +40,7 @@ const CuiTitle = styled.div<{
   $color?: TitleColor;
   $size?: TitleSize;
   $family?: TitleFamily;
+  $weight?: TitleWeight;
 }>`
   font: ${({ $size = "md", $family = "product", theme }) =>
     theme.typography.styles[$family].titles[$size]};
@@ -45,6 +49,7 @@ const CuiTitle = styled.div<{
   padding: 0;
   font-style: inherit;
   text-align: ${({ $align = "left" }) => $align};
+  font-weight: ${({ $weight, theme }) => $weight ? theme.typography.font.weights[$weight] : "inherit"};
 
   a,
   a:visited {

--- a/src/components/icons/DotsVerticalDouble.tsx
+++ b/src/components/icons/DotsVerticalDouble.tsx
@@ -17,13 +17,13 @@ const DotsVerticalDouble = (props: SVGAttributes<SVGElement>) => (
     />
     <circle
       cx="8.5"
-      cy="12"
+      cy="13.5"
       r="1.5"
       fill="#161517"
     />
     <circle
       cx="8.5"
-      cy="17.5"
+      cy="20.5"
       r="1.5"
       fill="#161517"
     />
@@ -35,13 +35,13 @@ const DotsVerticalDouble = (props: SVGAttributes<SVGElement>) => (
     />
     <circle
       cx="15.5"
-      cy="12"
+      cy="13.5"
       r="1.5"
       fill="#161517"
     />
     <circle
       cx="15.5"
-      cy="17.5"
+      cy="20.5"
       r="1.5"
       fill="#161517"
     />


### PR DESCRIPTION
Helps with https://github.com/ClickHouse/control-plane/issues/12818

# Why

Currently we cannot define a font weight for the title component. The `dots-vertical-double` icon is slightly different from the design.

# What

This adds a font weight prop to the title component; having this prop will allow us to align closer with the initial design.
<img width="560" alt="Screenshot 2025-02-07 at 12 18 08 PM" src="https://github.com/user-attachments/assets/10463c7a-2c1f-4daa-98b6-0da4735eb972" />

This alters the `dots-vertical-double` icon slightly to better align with the current design:
<img width="531" alt="Screenshot 2025-02-07 at 12 14 11 PM" src="https://github.com/user-attachments/assets/f10a7b47-b7d9-44d7-ae51-c55754277545" />
