### PR TITLE
fix(Select): display label for empty string value

### DIFF
--- a/src/components/Select/SingleSelect.test.tsx
+++ b/src/components/Select/SingleSelect.test.tsx
@@ -138,6 +138,46 @@ describe("Select", () => {
     expect(getByTestId("select-trigger")).toHaveTextContent("Content0");
   });
 
+  it("should render initially selected option with empty value", () => {
+    const OPTION_TEXT = "Empty option";
+
+    const { getByTestId } = renderSelect({
+      value: "",
+      options: [
+        {
+          value: "",
+          label: OPTION_TEXT,
+        },
+      ],
+    });
+
+    const selectedValue = getByTestId("select-trigger");
+    expect(selectedValue.textContent).toBe(OPTION_TEXT);
+  });
+
+  it("should render manually selected option with empty value", () => {
+    const OPTION_TEXT = "Empty option";
+
+    const { queryByText, getByTestId } = renderSelect({
+      options: [
+        {
+          value: "",
+          label: OPTION_TEXT,
+        },
+      ],
+    });
+
+    const selectTrigger = getByTestId("select-trigger");
+    expect(selectTrigger).not.toBeNull();
+    expect(selectTrigger.textContent).toBe("Select an option");
+    selectTrigger && fireEvent.click(selectTrigger);
+
+    const item = queryByText(OPTION_TEXT);
+    expect(item).not.toBeNull();
+    item && fireEvent.click(item);
+    expect(selectTrigger.textContent).toBe(OPTION_TEXT);
+  });
+
   it("should close select on selecting item", () => {
     const { queryByText } = renderSelect({});
     const selectTrigger = queryByText("Select an option");

--- a/src/components/Select/SingleSelect.tsx
+++ b/src/components/Select/SingleSelect.tsx
@@ -29,7 +29,11 @@ export const Select = ({
   ...props
 }: SelectProps) => {
   const [selectedValues, setSelectedValues] = useState<Array<string>>(
-    valueProp ? [valueProp] : defaultValue ? [defaultValue] : []
+    typeof valueProp === "string"
+      ? [valueProp]
+      : typeof defaultValue === "string"
+      ? [defaultValue]
+      : []
   );
   const [open, setOpen] = useState(false);
 
@@ -69,7 +73,7 @@ export const Select = ({
   );
 
   useUpdateEffect(() => {
-    setSelectedValues(valueProp ? [valueProp] : []);
+    setSelectedValues(typeof valueProp === "string" ? [valueProp] : []);
   }, [valueProp]);
 
   const conditionalProps: Partial<SelectOptionProp> = {};
@@ -82,7 +86,7 @@ export const Select = ({
   return (
     <InternalSelect
       onChange={onChange}
-      value={valueProp ? [valueProp] : selectedValues}
+      value={typeof valueProp === "string" ? [valueProp] : selectedValues}
       open={open}
       onOpenChange={onOpenChange}
       onSelect={onSelect}

--- a/src/components/Select/SingleSelectValue.tsx
+++ b/src/components/Select/SingleSelectValue.tsx
@@ -20,6 +20,10 @@ const SingleSelectValue = ({
   valueNode?: SelectItemProps;
   value: string;
 }) => {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
   const { icon, iconDir, children, label } = valueNode ?? {};
 
   return (

--- a/src/components/Select/SingleSelectValue.tsx
+++ b/src/components/Select/SingleSelectValue.tsx
@@ -21,9 +21,6 @@ const SingleSelectValue = ({
   value: string;
 }) => {
   const { icon, iconDir, children, label } = valueNode ?? {};
-  if (!value) {
-    return null;
-  }
 
   return (
     <SelectValueContainer>


### PR DESCRIPTION
Resolves #490 

## Why

Putting empty string as a value of `Select.Item` results in an empty Select:
![image](https://github.com/user-attachments/assets/5e6a3e7c-4cc6-495e-9469-e0fa8a15e107)

## What

The `value` prop of `SingleSelectValue` is typed as required. Also by usage, it gets rendered only when `selectedValues` array is not empty. Thus in normal circumstances it can't be undefined or null. Seems like the emptiness check just causes the bug while not doing anything else.