### PR TITLE
fix(Dropdown): don't show scrollbar when not needed

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -94,7 +94,7 @@ const DropdownMenuContent = styled(GenericMenuPanel)`
   min-width: ${({ theme }) => theme.click.genericMenu.item.size.minWidth};
   flex-direction: column;
   z-index: 1;
-  overflow-y: scroll;
+  overflow-y: auto;
   max-height: calc(
     (var(--radix-${({ $type }) => $type}-content-available-height) - 100px)
   );


### PR DESCRIPTION
`overflow: scroll` forces scrollbars to always show:
![image](https://github.com/user-attachments/assets/7691290a-2918-4c9b-beed-c74e1083041c)

this is with `overflow: auto`
![image](https://github.com/user-attachments/assets/66a0083a-fc88-48a3-bdcd-3bd23ec6d990)

`auto` is usually the way to go when you need scrolling, scrollbars will appear when the limit is reached
`scroll` is almost never necessary

on Mac, to see if scrollbars appear, you can go to System Settings → Appearance → Show scroll bars → Always
on Windows they are visible by default without the option to hide them