### PR TITLE
Grid: Persist column width and position

### DIFF
--- a/src/components/Grid/Header.tsx
+++ b/src/components/Grid/Header.tsx
@@ -186,7 +186,7 @@ const Header = ({
   getColumnHorizontalPosition,
   getResizerPosition,
   showBorder,
-  resizingState
+  resizingState,
 }: HeaderProps) => {
   const selectedAllType = getSelectionType({
     type: "all",

--- a/src/components/Grid/Header.tsx
+++ b/src/components/Grid/Header.tsx
@@ -130,7 +130,7 @@ const Column = ({
     (leftSelectionType === "selectDirect" || isSelected) &&
     leftSelectionType !== selectionType;
 
-  const columnWidth = getColumnWidth(columnIndex)
+  const columnWidth = getColumnWidth(columnIndex);
   return (
     <HeaderCellContainer
       $width={columnWidth}

--- a/src/components/Grid/useColumns.test.ts
+++ b/src/components/Grid/useColumns.test.ts
@@ -1,0 +1,126 @@
+import { renderHook, act } from "@testing-library/react";
+import useColumns from "./useColumns";
+import { VariableSizeGrid, VariableSizeGridProps } from "react-window";
+import { ReactInstance, RefObject } from "react";
+
+describe("useColumns", () => {
+    let mockGridRef: RefObject<VariableSizeGrid>;
+    let mockOuterGridRef: { current: HTMLDivElement };
+
+    beforeEach(() => {
+        mockGridRef = {
+                current: { resetAfterColumnIndex: vi.fn(),
+                   scrollTo: () => {},
+                   scrollToItem: () => {},
+                   resetAfterIndices: () => {},
+                   resetAfterRowIndex: () => {},
+                   context: () => {},
+                   setState: () => {},
+                   forceUpdate: () => {},
+                   render: () => void {},
+                   props: {} as Readonly<VariableSizeGridProps<unknown>>,
+                   state: () => {},
+                   refs: {} as { [key: string]: ReactInstance; },
+                 }
+            };
+        mockOuterGridRef = { current: document.createElement("div") };
+        vi.clearAllMocks();
+    });
+
+    const renderColumnHook = (props = {}) => renderHook(() => useColumns({
+        columnCount: 3,
+        outerGridRef: mockOuterGridRef,
+        gridRef: mockGridRef,
+        ...props
+    }));
+
+    describe("initColumnSize", () => {
+        it("initializes columns with default width and positions of 100px", () => {
+            const { result } = renderColumnHook();
+
+            act(() => {
+                result.current.initColumnSize(300);
+            });
+
+            const expectedPositions = [0, 100, 200];
+            expectedPositions.forEach((position, index) => {
+                expect(result.current.getColumnHorizontalPosition(index)).toBe(position);
+                expect(result.current.columnWidth(index)).toEqual(100);
+            });
+        });
+
+        it("returns default column width when the container is smaller than the sum of column widths", () => {
+            const columnCount = 5;
+            const { result } = renderColumnHook({ columnCount: 5 });
+
+            act(() => {
+                result.current.initColumnSize(200);
+            });
+
+            
+            Array.from({ length: columnCount }).forEach((_, index) => {
+                expect(result.current.columnWidth(index)).toBe(100);
+            });
+        });
+    });
+
+    describe("onColumnResize", () => {
+        it("handles manual column resizing after initialization", () => {
+            const { result } = renderColumnHook();
+
+            act(() => {
+                result.current.initColumnSize(300);
+                result.current.onColumnResize(1, 150, "manual");
+            });
+
+            const expectedPositions = [0, 100, 250];
+            expectedPositions.forEach((position, index) => {
+                expect(result.current.getColumnHorizontalPosition(index)).toBe(position);
+            });
+
+            expect(result.current.columnWidth(1)).toBe(150);
+        });
+
+        it("resizes columns using columnWidthProp", () => {
+            const expectedWidths = [150, 200, 250];
+            const columnWidthProp = (index: number) => expectedWidths[index] || 100;
+            const { result } = renderColumnHook({ columnWidth: columnWidthProp, columnCount: expectedWidths.length });
+        
+            act(() => {
+                result.current.initColumnSize(600);
+            });
+        
+            let accumulatedWidth = 0;
+            expectedWidths.forEach((expectedWidth, index) => {
+                expect(result.current.getColumnHorizontalPosition(index)).toBe(accumulatedWidth);
+                expect(result.current.columnWidth(index)).toBe(expectedWidth);
+                accumulatedWidth += expectedWidth;
+            });
+        
+            expect(mockGridRef.current?.resetAfterColumnIndex).toHaveBeenCalledWith(0);
+        });
+        
+
+        it("handles auto-width resizing using measureColumnWidth", () => {
+            const mockCells = [
+                { style: { width: "" }, scrollWidth: 110 },
+                { style: { width: "" }, scrollWidth: 120 },
+                { style: { width: "" }, scrollWidth: 115 }
+            ];
+            const mockQuerySelector = vi.fn().mockReturnValue(mockCells);
+            const customMockOuterGridRef = { 
+                current: { querySelectorAll: mockQuerySelector }
+            };
+
+            const { result } = renderColumnHook({ outerGridRef: customMockOuterGridRef as unknown });
+
+            act(() => {
+                result.current.initColumnSize(300);
+                result.current.onColumnResize(1, 0, "auto");
+            });
+
+            expect(mockQuerySelector).toHaveBeenCalledWith("[data-grid-column=\"1\"]");
+            expect(result.current.columnWidth(1)).toBe(122);
+        });
+    });
+});

--- a/src/components/Grid/useColumns.test.ts
+++ b/src/components/Grid/useColumns.test.ts
@@ -4,123 +4,130 @@ import { VariableSizeGrid, VariableSizeGridProps } from "react-window";
 import { ReactInstance, RefObject } from "react";
 
 describe("useColumns", () => {
-    let mockGridRef: RefObject<VariableSizeGrid>;
-    let mockOuterGridRef: { current: HTMLDivElement };
+  let mockGridRef: RefObject<VariableSizeGrid>;
+  let mockOuterGridRef: { current: HTMLDivElement };
 
-    beforeEach(() => {
-        mockGridRef = {
-                current: { resetAfterColumnIndex: vi.fn(),
-                   scrollTo: () => {},
-                   scrollToItem: () => {},
-                   resetAfterIndices: () => {},
-                   resetAfterRowIndex: () => {},
-                   context: () => {},
-                   setState: () => {},
-                   forceUpdate: () => {},
-                   render: () => void {},
-                   props: {} as Readonly<VariableSizeGridProps<unknown>>,
-                   state: () => {},
-                   refs: {} as { [key: string]: ReactInstance; },
-                 }
-            };
-        mockOuterGridRef = { current: document.createElement("div") };
-        vi.clearAllMocks();
-    });
+  beforeEach(() => {
+    mockGridRef = {
+      current: {
+        resetAfterColumnIndex: vi.fn(),
+        scrollTo: () => {},
+        scrollToItem: () => {},
+        resetAfterIndices: () => {},
+        resetAfterRowIndex: () => {},
+        context: () => {},
+        setState: () => {},
+        forceUpdate: () => {},
+        render: () => void {},
+        props: {} as Readonly<VariableSizeGridProps<unknown>>,
+        state: () => {},
+        refs: {} as { [key: string]: ReactInstance },
+      },
+    };
+    mockOuterGridRef = { current: document.createElement("div") };
+    vi.clearAllMocks();
+  });
 
-    const renderColumnHook = (props = {}) => renderHook(() => useColumns({
+  const renderColumnHook = (props = {}) =>
+    renderHook(() =>
+      useColumns({
         columnCount: 3,
         outerGridRef: mockOuterGridRef,
         gridRef: mockGridRef,
-        ...props
-    }));
+        ...props,
+      })
+    );
 
-    describe("initColumnSize", () => {
-        it("initializes columns with default width and positions of 100px", () => {
-            const { result } = renderColumnHook();
+  describe("initColumnSize", () => {
+    it("initializes columns with default width and positions of 100px", () => {
+      const { result } = renderColumnHook();
 
-            act(() => {
-                result.current.initColumnSize(300);
-            });
+      act(() => {
+        result.current.initColumnSize(300);
+      });
 
-            const expectedPositions = [0, 100, 200];
-            expectedPositions.forEach((position, index) => {
-                expect(result.current.getColumnHorizontalPosition(index)).toBe(position);
-                expect(result.current.columnWidth(index)).toEqual(100);
-            });
-        });
-
-        it("returns default column width when the container is smaller than the sum of column widths", () => {
-            const columnCount = 5;
-            const { result } = renderColumnHook({ columnCount: 5 });
-
-            act(() => {
-                result.current.initColumnSize(200);
-            });
-
-            
-            Array.from({ length: columnCount }).forEach((_, index) => {
-                expect(result.current.columnWidth(index)).toBe(100);
-            });
-        });
+      const expectedPositions = [0, 100, 200];
+      expectedPositions.forEach((position, index) => {
+        expect(result.current.getColumnHorizontalPosition(index)).toBe(position);
+        expect(result.current.columnWidth(index)).toEqual(100);
+      });
     });
 
-    describe("onColumnResize", () => {
-        it("handles manual column resizing after initialization", () => {
-            const { result } = renderColumnHook();
+    it("returns default column width when the container is smaller than the sum of column widths", () => {
+      const columnCount = 5;
+      const { result } = renderColumnHook({ columnCount: 5 });
 
-            act(() => {
-                result.current.initColumnSize(300);
-                result.current.onColumnResize(1, 150, "manual");
-            });
+      act(() => {
+        result.current.initColumnSize(200);
+      });
 
-            const expectedPositions = [0, 100, 250];
-            expectedPositions.forEach((position, index) => {
-                expect(result.current.getColumnHorizontalPosition(index)).toBe(position);
-            });
-
-            expect(result.current.columnWidth(1)).toBe(150);
-        });
-
-        it("resizes columns using columnWidthProp", () => {
-            const expectedWidths = [150, 200, 250];
-            const columnWidthProp = (index: number) => expectedWidths[index] || 100;
-            const { result } = renderColumnHook({ columnWidth: columnWidthProp, columnCount: expectedWidths.length });
-        
-            act(() => {
-                result.current.initColumnSize(600);
-            });
-        
-            let accumulatedWidth = 0;
-            expectedWidths.forEach((expectedWidth, index) => {
-                expect(result.current.getColumnHorizontalPosition(index)).toBe(accumulatedWidth);
-                expect(result.current.columnWidth(index)).toBe(expectedWidth);
-                accumulatedWidth += expectedWidth;
-            });
-        
-            expect(mockGridRef.current?.resetAfterColumnIndex).toHaveBeenCalledWith(0);
-        });
-        
-
-        it("handles auto-width resizing using measureColumnWidth", () => {
-            const mockCells = [
-                { style: { width: "" }, scrollWidth: 110 },
-                { style: { width: "" }, scrollWidth: 120 },
-                { style: { width: "" }, scrollWidth: 115 }
-            ];
-            const mockQuerySelector = vi.fn().mockReturnValue(mockCells);
-            const customMockOuterGridRef = { 
-                current: { querySelectorAll: mockQuerySelector }
-            };
-
-            const { result } = renderColumnHook({ outerGridRef: customMockOuterGridRef as unknown });
-
-            act(() => {
-                result.current.initColumnSize(300);
-                result.current.onColumnResize(1, 0, "auto");
-            });
-
-            expect(mockQuerySelector).toHaveBeenCalledWith("[data-grid-column=\"1\"]");
-            expect(result.current.columnWidth(1)).toBe(122);
-        });
+      Array.from({ length: columnCount }).forEach((_, index) => {
+        expect(result.current.columnWidth(index)).toBe(100);
+      });
     });
+  });
+
+  describe("onColumnResize", () => {
+    it("handles manual column resizing after initialization", () => {
+      const { result } = renderColumnHook();
+
+      act(() => {
+        result.current.initColumnSize(300);
+        result.current.onColumnResize(1, 150, "manual");
+      });
+
+      const expectedPositions = [0, 100, 250];
+      expectedPositions.forEach((position, index) => {
+        expect(result.current.getColumnHorizontalPosition(index)).toBe(position);
+      });
+
+      expect(result.current.columnWidth(1)).toBe(150);
+    });
+
+    it("resizes columns using columnWidthProp", () => {
+      const expectedWidths = [150, 200, 250];
+      const columnWidthProp = (index: number) => expectedWidths[index] || 100;
+      const { result } = renderColumnHook({
+        columnWidth: columnWidthProp,
+        columnCount: expectedWidths.length,
+      });
+
+      act(() => {
+        result.current.initColumnSize(600);
+      });
+
+      let accumulatedWidth = 0;
+      expectedWidths.forEach((expectedWidth, index) => {
+        expect(result.current.getColumnHorizontalPosition(index)).toBe(accumulatedWidth);
+        expect(result.current.columnWidth(index)).toBe(expectedWidth);
+        accumulatedWidth += expectedWidth;
+      });
+
+      expect(mockGridRef.current?.resetAfterColumnIndex).toHaveBeenCalledWith(0);
+    });
+
+    it("handles auto-width resizing using measureColumnWidth", () => {
+      const mockCells = [
+        { style: { width: "" }, scrollWidth: 110 },
+        { style: { width: "" }, scrollWidth: 120 },
+        { style: { width: "" }, scrollWidth: 115 },
+      ];
+      const mockQuerySelector = vi.fn().mockReturnValue(mockCells);
+      const customMockOuterGridRef = {
+        current: { querySelectorAll: mockQuerySelector },
+      };
+
+      const { result } = renderColumnHook({
+        outerGridRef: customMockOuterGridRef as unknown,
+      });
+
+      act(() => {
+        result.current.initColumnSize(300);
+        result.current.onColumnResize(1, 0, "auto");
+      });
+
+      expect(mockQuerySelector).toHaveBeenCalledWith("[data-grid-column=\"1\"]");
+      expect(result.current.columnWidth(1)).toBe(122);
+    });
+  });
 });

--- a/src/components/Grid/useColumns.ts
+++ b/src/components/Grid/useColumns.ts
@@ -70,7 +70,7 @@ const useColumns = ({
       if (columnResized.current) {
         return;
       }
-
+      console.log("New width: ", newWidth)
       const getWidth = (index: number) => {
         if (typeof columnWidthProp === "function") {
           return columnWidthProp(index);

--- a/src/components/Grid/useColumns.ts
+++ b/src/components/Grid/useColumns.ts
@@ -79,20 +79,17 @@ const useColumns = ({
       };
 
       const columnWidthList = [...Array(columnCount).keys()];
-      const array: Array<number> = [];
+      
       setColumnHorizontalPosition(() => {
-        return columnWidthList.reduce((acc, index) => {
-          const width = getWidth(index);
-          prevWidth.current[index.toString()] = width;
-          columnWidthRefs.current[index] = width;
-          if (index !== 0) {
-            acc.push(width + acc[index - 1]);
-          } else {
-            acc.push(0);
-          }
+        return columnWidthList.reduce((acc, _, i) => {
+          const newWidth = getWidth(i);
+          prevWidth.current[i] = newWidth;
+          columnWidthRefs.current[i] = newWidth;
+          acc.push(acc[i] + newWidth);
           return acc;
-        }, array);
-      });
+        }, [0]);
+      })
+
       gridRef.current?.resetAfterColumnIndex(0);
     },
     [columnCount, columnWidthProp, gridRef]
@@ -100,6 +97,7 @@ const useColumns = ({
 
   const onColumnResize: ColumnResizeFn = useCallback(
     (columnIndex, newWidth, type) => {
+
       columnResized.current = true;
       if (type === "auto") {
         const widthIndex = autoWidthIndices.current.findIndex(
@@ -145,7 +143,6 @@ const useColumns = ({
       if (columnWidthProp) {
         return columnWidthProp(columnIndex);
       }
-
       return columnWidthRefs.current[columnIndex] ?? DEFAULT_WIDTH;
     },
     [columnWidthProp]

--- a/src/components/Grid/useColumns.ts
+++ b/src/components/Grid/useColumns.ts
@@ -70,7 +70,6 @@ const useColumns = ({
       if (columnResized.current) {
         return;
       }
-      console.log("New width: ", newWidth)
       const getWidth = (index: number) => {
         if (typeof columnWidthProp === "function") {
           return columnWidthProp(index);
@@ -79,16 +78,19 @@ const useColumns = ({
       };
 
       const columnWidthList = [...Array(columnCount).keys()];
-      
+
       setColumnHorizontalPosition(() => {
-        return columnWidthList.reduce((acc, _, index) => {
-          const width = getWidth(index);
-          prevWidth.current[index.toString()] = width;
-          columnWidthRefs.current[index] = width;
-          acc.push(acc[index] + width);
-          return acc;
-        }, [0]);
-      })
+        return columnWidthList.reduce(
+          (acc, _, index) => {
+            const width = getWidth(index);
+            prevWidth.current[index.toString()] = width;
+            columnWidthRefs.current[index] = width;
+            acc.push(acc[index] + width);
+            return acc;
+          },
+          [0]
+        );
+      });
       gridRef.current?.resetAfterColumnIndex(0);
     },
     [columnCount, columnWidthProp, gridRef]
@@ -96,7 +98,6 @@ const useColumns = ({
 
   const onColumnResize: ColumnResizeFn = useCallback(
     (columnIndex, newWidth, type) => {
-
       columnResized.current = true;
       if (type === "auto") {
         const widthIndex = autoWidthIndices.current.findIndex(

--- a/src/components/Grid/useColumns.ts
+++ b/src/components/Grid/useColumns.ts
@@ -81,15 +81,14 @@ const useColumns = ({
       const columnWidthList = [...Array(columnCount).keys()];
       
       setColumnHorizontalPosition(() => {
-        return columnWidthList.reduce((acc, _, i) => {
-          const newWidth = getWidth(i);
-          prevWidth.current[i] = newWidth;
-          columnWidthRefs.current[i] = newWidth;
-          acc.push(acc[i] + newWidth);
+        return columnWidthList.reduce((acc, _, index) => {
+          const width = getWidth(index);
+          prevWidth.current[index.toString()] = width;
+          columnWidthRefs.current[index] = width;
+          acc.push(acc[index] + width);
           return acc;
         }, [0]);
       })
-
       gridRef.current?.resetAfterColumnIndex(0);
     },
     [columnCount, columnWidthProp, gridRef]


### PR DESCRIPTION
# Why
Column width is not persisted on query rerun or page refresh.

# What
Persists the (header) column width and position across rerenders. Data column persistence was already implemented.


https://github.com/user-attachments/assets/50de4db9-5d0b-441f-a924-6587a2f61adb

