### PR TITLE
Fix: conflict with prettier and unit test.

### DIFF
--- a/src/components/Grid/useColumns.test.ts
+++ b/src/components/Grid/useColumns.test.ts
@@ -125,7 +125,7 @@ describe("useColumns", () => {
         result.current.initColumnSize(300);
         result.current.onColumnResize(1, 0, "auto");
       });
-
+      // prettier-ignore
       expect(mockQuerySelector).toHaveBeenCalledWith("[data-grid-column=\"1\"]");
       expect(result.current.columnWidth(1)).toBe(122);
     });


### PR DESCRIPTION
# Why
A test in `useColumns.test.ts` requires the use of nested double quotes. This conflicts with the current prettier config.

# What
This adds a `// prettier-ignore` above the specific test line to make sure neither the test or prettier fails.