### PR TITLE
Fix and reimplement: Expand cell height if there is only one row (Original #537, Revert #548)

### DIFF
--- a/src/components/Grid/Cell.tsx
+++ b/src/components/Grid/Cell.tsx
@@ -59,13 +59,11 @@ export const Cell = memo(
     const cellRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
-      if (!rowAutoHeight) {
+      if (!rowAutoHeight || !cellRef.current) {
         return;
       }
-      if (cellRef.current) {
-        const height = cellRef.current.getBoundingClientRect().height;
-        updateRowHeight(rowIndex, height);
-      }
+      const height = cellRef.current.getBoundingClientRect().height;
+      updateRowHeight(rowIndex, height);
     }, [updateRowHeight, rowIndex, rowAutoHeight]);
 
     const styleWithHeight = {

--- a/src/components/Grid/Cell.tsx
+++ b/src/components/Grid/Cell.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useEffect, useRef } from "react";
 import { GridChildComponentProps, areEqual } from "react-window";
 import { ItemDataType } from "./types";
 import { StyledCell } from "./StyledCell";
@@ -19,6 +19,8 @@ export const Cell = memo(
       showHeader,
       rowHeight,
       rowStart,
+      rowAutoHeight,
+      updateRowHeight,
     } = data;
 
     const currentRowIndex = rowIndex + rowStart;
@@ -54,11 +56,29 @@ export const Cell = memo(
     const selectionBorderLeft = rightOfSelectionBorder || rightOfFocus || isFocused;
     const selectionBorderTop = belowSelectionBorder || belowFocus || isFocused;
 
+    const cellRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+      if (!rowAutoHeight) {
+        return;
+      }
+      if (cellRef.current) {
+        const height = cellRef.current.getBoundingClientRect().height;
+        updateRowHeight(rowIndex, height);
+      }
+    }, [updateRowHeight, rowIndex, rowAutoHeight]);
+
+    const styleWithHeight = {
+      ...style,
+      height: "auto",
+    };
+
     return (
       <div
-        style={style}
+        style={styleWithHeight}
         data-row={currentRowIndex}
         data-column={columnIndex}
+        ref={cellRef}
       >
         <StyledCell
           as={CellData}
@@ -79,6 +99,7 @@ export const Cell = memo(
           data-grid-row={currentRowIndex}
           data-grid-column={columnIndex}
           $showBorder
+          $rowAutoHeight={rowAutoHeight}
           {...props}
         />
       </div>

--- a/src/components/Grid/Grid.stories.tsx
+++ b/src/components/Grid/Grid.stories.tsx
@@ -27,6 +27,7 @@ interface Props {
     row: number;
     column: number;
   };
+  rowAutoHeight?: boolean;
 }
 const Grid = ({ columnCount, rowCount, focus: focusProp, ...props }: Props) => {
   const [focus, setFocus] = useState(focusProp);
@@ -78,6 +79,7 @@ const Grid = ({ columnCount, rowCount, focus: focusProp, ...props }: Props) => {
           });
         }}
         getMenuOptions={getMenuOptions}
+        rowAutoHeight={props.rowAutoHeight}
         {...props}
       />
     </div>

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -213,7 +213,6 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
       onCopyCallback,
     ]);
 
-    // const rowHeightsRef = useRef(new Map());
     const [rowHeights, setRowHeights] = useState<{ [key: number]: number }>({});
 
     const getRowHeight = useCallback(
@@ -245,33 +244,6 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
       },
       [rowAutoHeight]
     );
-
-    // const getRowHeight = useCallback(
-    //   (index: number) => {
-    //     if (rowAutoHeight && rowHeightsRef.current.get(index)) {
-    //       console.log('Rowheightref:', rowHeightsRef)
-    //       return rowHeightsRef.current.get(index) + rowHeight;
-    //     }
-    //     return rowHeight;
-    //   },
-    //   [rowHeight, rowAutoHeight]
-    // );
-
-    // const updateRowHeight = useCallback(
-    //   (rowIndex: number, height: number) => {
-    //     if (!rowAutoHeight) {
-    //       return;
-    //     }
-    //     const prevHeight = rowHeightsRef.current.get(rowIndex) ?? 0;
-    //     if (height > prevHeight) {
-    //       rowHeightsRef.current.set(rowIndex, height);
-    //       if (gridRef.current) {
-    //         gridRef.current.resetAfterRowIndex(rowIndex);
-    //       }
-    //     }
-    //   },
-    //   [rowAutoHeight]
-    // );
 
     const customOnCopy: () => Promise<void> = useMemo(() => {
       const result = async () => {

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -213,16 +213,17 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
       onCopyCallback,
     ]);
 
-    const rowHeightsRef = useRef(new Map());
+    // const rowHeightsRef = useRef(new Map());
+    const [rowHeights, setRowHeights] = useState<{ [key: number]: number }>({});
 
     const getRowHeight = useCallback(
       (index: number) => {
-        if (rowAutoHeight && rowHeightsRef.current.get(index)) {
-          return rowHeightsRef.current.get(index) + rowHeight;
+        if (rowAutoHeight && rowHeights[index] !== undefined) {
+          return rowHeights[index] + rowHeight;
         }
         return rowHeight;
       },
-      [rowHeight, rowAutoHeight]
+      [rowHeight, rowAutoHeight, rowHeights]
     );
 
     const updateRowHeight = useCallback(
@@ -230,16 +231,47 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
         if (!rowAutoHeight) {
           return;
         }
-        const prevHeight = rowHeightsRef.current.get(rowIndex) ?? 0;
-        if (height > prevHeight) {
-          rowHeightsRef.current.set(rowIndex, height);
-          if (gridRef.current) {
-            gridRef.current.resetAfterRowIndex(rowIndex);
+
+        setRowHeights(prevRowHeights => {
+          const newRowHeights = { ...prevRowHeights }; // Create a copy to avoid direct mutation
+          if (height > (newRowHeights[rowIndex] || 0)) {
+            newRowHeights[rowIndex] = height;
+            if (gridRef.current) {
+              gridRef.current.resetAfterRowIndex(rowIndex);
+            }
           }
-        }
+          return newRowHeights;
+        });
       },
       [rowAutoHeight]
     );
+
+    // const getRowHeight = useCallback(
+    //   (index: number) => {
+    //     if (rowAutoHeight && rowHeightsRef.current.get(index)) {
+    //       console.log('Rowheightref:', rowHeightsRef)
+    //       return rowHeightsRef.current.get(index) + rowHeight;
+    //     }
+    //     return rowHeight;
+    //   },
+    //   [rowHeight, rowAutoHeight]
+    // );
+
+    // const updateRowHeight = useCallback(
+    //   (rowIndex: number, height: number) => {
+    //     if (!rowAutoHeight) {
+    //       return;
+    //     }
+    //     const prevHeight = rowHeightsRef.current.get(rowIndex) ?? 0;
+    //     if (height > prevHeight) {
+    //       rowHeightsRef.current.set(rowIndex, height);
+    //       if (gridRef.current) {
+    //         gridRef.current.resetAfterRowIndex(rowIndex);
+    //       }
+    //     }
+    //   },
+    //   [rowAutoHeight]
+    // );
 
     const customOnCopy: () => Promise<void> = useMemo(() => {
       const result = async () => {

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -213,38 +213,6 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
       onCopyCallback,
     ]);
 
-    const [rowHeights, setRowHeights] = useState<{ [key: number]: number }>({});
-
-    const getRowHeight = useCallback(
-      (index: number) => {
-        if (rowAutoHeight && rowHeights[index] !== undefined) {
-          return rowHeights[index] + rowHeight;
-        }
-        return rowHeight;
-      },
-      [rowHeight, rowAutoHeight, rowHeights]
-    );
-
-    const updateRowHeight = useCallback(
-      (rowIndex: number, height: number) => {
-        if (!rowAutoHeight) {
-          return;
-        }
-
-        setRowHeights(prevRowHeights => {
-          const newRowHeights = { ...prevRowHeights }; // Create a copy to avoid direct mutation
-          if (height > (newRowHeights[rowIndex] || 0)) {
-            newRowHeights[rowIndex] = height;
-            if (gridRef.current) {
-              gridRef.current.resetAfterRowIndex(rowIndex);
-            }
-          }
-          return newRowHeights;
-        });
-      },
-      [rowAutoHeight]
-    );
-
     const customOnCopy: () => Promise<void> = useMemo(() => {
       const result = async () => {
         if (onCopyProp) {
@@ -293,6 +261,36 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
       [onSelectProp]
     );
     const resizingState = useResizingState();
+
+    const [rowHeights, setRowHeights] = useState<{ [key: number]: number }>({});
+
+    const getRowHeight = useCallback(
+      (index: number) => {
+        if (rowAutoHeight && rowHeights[index] !== undefined) {
+          return rowHeights[index] + rowHeight;
+        }
+        return rowHeight;
+      },
+      [rowHeight, rowAutoHeight, rowHeights]
+    );
+
+    const updateRowHeight = useCallback(
+      (rowIndex: number, height: number) => {
+        if (!rowAutoHeight) {
+          return;
+        }
+
+        setRowHeights(prevRowHeights => {
+          if (height > (prevRowHeights[rowIndex] || 0) && gridRef.current) {
+            const newRowHeights = { ...prevRowHeights, [rowIndex]: height };
+            gridRef.current.resetAfterRowIndex(rowIndex);
+            return newRowHeights;
+          }
+          return prevRowHeights;
+        });
+      },
+      [rowAutoHeight, gridRef]
+    );
 
     const onFocusChange = useCallback(
       (row: number, column: number) => {

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -149,6 +149,7 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
       onContextMenu: onContextMenuProp,
       forwardedGridRef,
       onItemsRendered: onItemsRenderedProp,
+      rowAutoHeight,
       ...props
     },
     forwardedRef
@@ -211,6 +212,34 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
       showToast,
       onCopyCallback,
     ]);
+
+    const rowHeightsRef = useRef(new Map());
+
+    const getRowHeight = useCallback(
+      (index: number) => {
+        if (rowAutoHeight && rowHeightsRef.current.get(index)) {
+          return rowHeightsRef.current.get(index) + rowHeight;
+        }
+        return rowHeight;
+      },
+      [rowHeight, rowAutoHeight]
+    );
+
+    const updateRowHeight = useCallback(
+      (rowIndex: number, height: number) => {
+        if (!rowAutoHeight) {
+          return;
+        }
+        const prevHeight = rowHeightsRef.current.get(rowIndex) ?? 0;
+        if (height > prevHeight) {
+          rowHeightsRef.current.set(rowIndex, height);
+          if (gridRef.current) {
+            gridRef.current.resetAfterRowIndex(rowIndex);
+          }
+        }
+      },
+      [rowAutoHeight]
+    );
 
     const customOnCopy: () => Promise<void> = useMemo(() => {
       const result = async () => {
@@ -405,6 +434,9 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
       headerHeight,
       rowNumberWidth,
       rowStart,
+      rowAutoHeight,
+      updateRowHeight,
+      getRowHeight,
     };
 
     const InnerElementType = forwardRef<HTMLDivElement, InnerElementTypeTypes>(
@@ -435,6 +467,7 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
                 showHeader={showHeader}
                 rowStart={rowStart}
                 showBorder={showBorder}
+                rowAutoHeight={rowAutoHeight}
               />
             )}
 
@@ -755,7 +788,6 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
     const onItemsRendered = useCallback(
       (props: GridOnItemsRenderedProps) => {
         lastItemsRenderedProps.current = props;
-
         return onItemsRenderedProp?.({
           ...props,
           visibleRowStartIndex: props.visibleRowStartIndex + rowStart,
@@ -785,6 +817,13 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
         />
       );
     };
+
+    // Handles the case when rowCount/columnCount changes, rerenders styles
+    useEffect(() => {
+      if (gridRef.current) {
+        gridRef.current.resetAfterRowIndex(0);
+      }
+    }, [rowCount, columnCount]);
 
     return (
       <ContextMenu
@@ -820,7 +859,7 @@ export const Grid = forwardRef<HTMLDivElement, GridProps>(
                 height={height}
                 width={width}
                 columnCount={columnCount}
-                rowHeight={() => rowHeight}
+                rowHeight={getRowHeight}
                 useIsScrolling={useIsScrolling}
                 innerElementType={InnerElementType}
                 itemData={data}

--- a/src/components/Grid/Header.tsx
+++ b/src/components/Grid/Header.tsx
@@ -99,6 +99,7 @@ const RowColumnContainer = styled(HeaderCellContainer)<{
 const RowColumn = styled(StyledCell)`
   width: 100%;
   text-align: right;
+  overflow: hidden;
 `;
 
 const Column = ({

--- a/src/components/Grid/RowNumberColumn.tsx
+++ b/src/components/Grid/RowNumberColumn.tsx
@@ -5,13 +5,14 @@ const RowNumberColumnContainer = styled.div<{
   $height: number;
   $width: number;
   $scrolledHorizontal: boolean;
+  $rowAutoHeight?: boolean;
 }>`
   position: sticky;
   left: 0;
   ${({ $height, $width }) => `
     top: ${$height}px;
     width: ${$width}px;
-    height: 100%;
+    height: 100%
   `}
 
   ${({ $scrolledHorizontal, theme }) =>
@@ -23,6 +24,7 @@ const RowNumberColumnContainer = styled.div<{
 const RowNumberCell = styled.div<{
   $height: number;
   $rowNumber: number;
+  $rowAutoHeight?: boolean;
 }>`
   position: absolute;
   left: 0;
@@ -30,9 +32,9 @@ const RowNumberCell = styled.div<{
   text-overflow: ellipsis;
   white-space: nowrap;
   width: 100%;
-  ${({ $height, $rowNumber }) => `
+  ${({ $height, $rowNumber, $rowAutoHeight }) => `
     top: ${$height * $rowNumber}px;
-    height: ${$height}px;
+    height: ${$rowAutoHeight ? "100%" : `${$height}px`};
   `}
 `;
 interface RowNumberColumnProps {
@@ -47,6 +49,7 @@ interface RowNumberColumnProps {
   scrolledHorizontal: boolean;
   rowStart: number;
   showBorder: boolean;
+  rowAutoHeight?: boolean;
 }
 interface RowNumberProps
   extends Pick<
@@ -56,6 +59,7 @@ interface RowNumberProps
   rowIndex: number;
   isLastRow: boolean;
   isFirstRow: boolean;
+  rowAutoHeight?: boolean;
 }
 const RowNumber = ({
   rowIndex,
@@ -65,6 +69,7 @@ const RowNumber = ({
   isFirstRow,
   showBorder,
   rowStart,
+  rowAutoHeight,
 }: RowNumberProps) => {
   const currentRowIndex = rowIndex + rowStart;
   const selectionType = getSelectionType({
@@ -84,6 +89,7 @@ const RowNumber = ({
     <RowNumberCell
       $rowNumber={rowIndex}
       $height={rowHeight}
+      $rowAutoHeight={rowAutoHeight}
     >
       <StyledCell
         $height={rowHeight}
@@ -96,6 +102,7 @@ const RowNumber = ({
         $isLastRow={isLastRow}
         $isSelectedLeft={isSelected}
         $isSelectedTop={isSelectedTop}
+        $rowAutoHeight={rowAutoHeight}
         data-selected={isSelected}
         data-grid-row={currentRowIndex}
         data-grid-column={-1}
@@ -121,12 +128,14 @@ const RowNumberColumn = ({
   scrolledHorizontal,
   rowStart = 0,
   showBorder,
+  rowAutoHeight,
 }: RowNumberColumnProps) => {
   return (
     <RowNumberColumnContainer
       $height={headerHeight}
       $width={rowWidth}
       $scrolledHorizontal={scrolledHorizontal}
+      $rowAutoHeight={rowAutoHeight}
     >
       {Array.from({ length: maxRow - minRow + 1 }, (_, index) => minRow + index).map(
         rowIndex => (
@@ -139,6 +148,7 @@ const RowNumberColumn = ({
             isFirstRow={!showHeader && rowIndex === 0}
             showBorder={showBorder}
             rowStart={rowStart}
+            rowAutoHeight={rowAutoHeight}
           />
         )
       )}

--- a/src/components/Grid/RowNumberColumn.tsx
+++ b/src/components/Grid/RowNumberColumn.tsx
@@ -12,7 +12,7 @@ const RowNumberColumnContainer = styled.div<{
   ${({ $height, $width }) => `
     top: ${$height}px;
     width: ${$width}px;
-    height: 100%
+    height: 100%;
   `}
 
   ${({ $scrolledHorizontal, theme }) =>

--- a/src/components/Grid/StyledCell.tsx
+++ b/src/components/Grid/StyledCell.tsx
@@ -13,6 +13,7 @@ export const StyledCell = styled.div<{
   $height: number;
   $type?: "body" | "header";
   $showBorder: boolean;
+  $rowAutoHeight?: boolean;
 }>`
   display: block;
   text-align: left;
@@ -34,8 +35,11 @@ export const StyledCell = styled.div<{
     $height,
     $type = "body",
     $showBorder,
+    $rowAutoHeight,
   }) => `
-    height: ${$height}px;
+    height: ${$rowAutoHeight ? "100%" : `${$height}px`};
+    min-height: ${$rowAutoHeight ? "auto" : ""};
+    overflow-y: ${$rowAutoHeight ? "auto" : ""};
     background: ${theme.click.grid[$type].cell.color.background[$selectionType]};
     color: ${
       $type === "header"
@@ -86,6 +90,7 @@ export const StyledCell = styled.div<{
     `
         : "border-right: none;"
     }
+    ${$rowAutoHeight && "border: none;"}
   `}
   ${({
     theme,
@@ -95,10 +100,12 @@ export const StyledCell = styled.div<{
     $type = "body",
     $isSelectedTop,
     $isSelectedLeft,
+    $rowAutoHeight,
   }) =>
     $isSelectedTop ||
     $isSelectedLeft ||
-    ($selectionType === "selectDirect" && ($isLastRow || $isLastColumn))
+    ($selectionType === "selectDirect" && ($isLastRow || $isLastColumn)) ||
+    $rowAutoHeight
       ? `
           &::before {
             content: "";
@@ -127,6 +134,7 @@ export const StyledCell = styled.div<{
                 ? `border-right: 1px solid ${theme.click.grid[$type].cell.color.stroke.selectDirect};`
                 : ""
             }
+            ${$rowAutoHeight && "border: none;"}
           }
         `
       : ""};

--- a/src/components/Grid/types.ts
+++ b/src/components/Grid/types.ts
@@ -157,6 +157,9 @@ export interface ItemDataType {
   headerHeight: number;
   rowNumberWidth: number;
   rowStart: number;
+  rowAutoHeight?: boolean;
+  updateRowHeight: (rowIndex: number, height: number) => void;
+  getRowHeight: (index: number) => number;
 }
 
 export interface GridContextMenuItemProps extends Omit<ContextMenuItemProps, "children"> {
@@ -204,6 +207,7 @@ export interface GridProps
   onCopyCallback?: (copied: boolean) => void;
   onContextMenu?: MouseEventHandler<HTMLDivElement>;
   forwardedGridRef?: MutableRefObject<VariableSizeGrid>;
+  rowAutoHeight?: boolean;
 }
 
 export type ResizerPosition = {


### PR DESCRIPTION
Closes https://github.com/ClickHouse/control-plane/issues/12806

# Why

If you run a command like `show create table example_table`, the row does not expand to show the full create table command.

# What

This reverts PR #537 and fixes a syntax bug. It expands the row to the full height of the content:
https://github.com/user-attachments/assets/a6b73b97-490f-4ccd-abe2-ba98832bf4c4


To reproduce:

```
CREATE TABLE random_user_events (
    user_id UInt32,
    event_time DateTime,
    event_type Enum8('click' = 1, 'view' = 2, 'purchase' = 3),
    item_id String,
    price Decimal(10,2),
    quantity UInt16
) ENGINE = MergeTree()
ORDER BY (user_id, event_time)
PARTITION BY toYYYYMM(event_time)
SETTINGS index_granularity = 8192;

show create table random_user_events;    
```
