### PR TITLE
Table: align cell text vertically

### DIFF
--- a/src/components/EllipsisContent/EllipsisContent.tsx
+++ b/src/components/EllipsisContent/EllipsisContent.tsx
@@ -12,6 +12,7 @@ const EllipsisContainer = styled.div`
   display: inline-block;
   white-space: nowrap;
   text-overflow: ellipsis;
+  vertical-align: text-bottom;
   overflow: hidden;
   justify-content: flex-start;
   width: 100%;


### PR DESCRIPTION
# Why

The table cell text is slightly off center vertically and has more room on the bottom.
<img width="427" alt="Screenshot 2025-02-25 at 3 53 55 PM" src="https://github.com/user-attachments/assets/6f0019e8-34b1-435b-88d6-275ec070e4bf" />

# What

This aligns it vertically by moving it a little down.
<img width="411" alt="Screenshot 2025-02-25 at 3 53 29 PM" src="https://github.com/user-attachments/assets/49fe0a8e-b226-460f-93a3-ad7da79152c3" />

Closes https://github.com/ClickHouse/click-ui/issues/551