### PR TITLE
Table: omit opacity on IconButton in TableRow

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -363,8 +363,9 @@ interface TableRowCloseButtonProps {
 const TableRowCloseButton = styled.button<TableRowCloseButtonProps>`
   svg {
     transition: transform 200ms;
-    ${({ $isDeleted }) => `
+    ${({ $isDeleted, theme }) => `
     ${$isDeleted ? "transform: rotate(45deg)" : ""};
+      color: ${$isDeleted ? theme.click.table.header.color.title.default : ""}
     `}
   }
   &:disabled {
@@ -498,7 +499,7 @@ const TableBodyRow = ({
                 as={IconButton}
                 disabled={isDisabled || !isDeletable}
                 $isDeleted={isDeleted}
-                type="primary"
+                type="ghost"
                 icon="cross"
                 onClick={onDelete}
                 data-testid="table-row-delete"


### PR DESCRIPTION
Closes https://github.com/ClickHouse/click-ui/issues/565
# Why
If a row is set to `isDisabled` or `isDeleted`, the opacity on the row is set to `0.5`. This causes all children of the `TableRow` to be greyed out and makes it unclear that the `TableRowCloseButton` icon is actionable:
<img width="816" alt="Screenshot 2025-03-12 at 11 29 21 AM" src="https://github.com/user-attachments/assets/21cf35e6-9c2c-4f46-96fb-7da409ea52bc" />

# What
- Sets the `TableRowCloseButton`  color to the default theme color
- Removes opacity styling from `TableRow`
- Adds conditional opacity to `SelectData` (checkbox) and `TableData`, while leaving `opacity: 1` on the `TableRowCloseButton`
<img width="1013" alt="Screenshot 2025-03-12 at 4 22 20 PM" src="https://github.com/user-attachments/assets/e81c2fa0-ee7f-4c9d-8375-b6448237e772" />

I left the `TableRowCloseButton` icon to use `type="ghost` because the `primary` button type has a different styling onclick:
https://github.com/user-attachments/assets/bdd0e16c-a92c-4286-9890-26ca087347ac
<img width="387" alt="Screenshot 2025-03-12 at 4 24 54 PM" src="https://github.com/user-attachments/assets/681b5865-5a1a-4186-a33f-e9de15ee76d7" />


