### PR TITLE
MultiAccordion: Add background color

### DIFF
--- a/src/components/MultiAccordion/MultiAccordion.tsx
+++ b/src/components/MultiAccordion/MultiAccordion.tsx
@@ -201,6 +201,7 @@ const AccordionItem = styled(RadixAccordion.Item)<StyledAccordionItemProps>`
       $showBorder ? `1px solid ${theme.click.global.color.stroke.default}` : "none"
     };
     border-radius: ${theme.border.radii[1]};
+    background-color: ${theme.click.global.color.background.default}
   `};
   ${({ $fillWidth }) => $fillWidth && "width: 100%"};
 `;

--- a/src/components/MultiAccordion/MultiAccordion.tsx
+++ b/src/components/MultiAccordion/MultiAccordion.tsx
@@ -201,7 +201,7 @@ const AccordionItem = styled(RadixAccordion.Item)<StyledAccordionItemProps>`
       $showBorder ? `1px solid ${theme.click.global.color.stroke.default}` : "none"
     };
     border-radius: ${theme.border.radii[1]};
-    background-color: ${theme.click.global.color.background.default}
+    background-color: ${theme.click.global.color.background.default};
   `};
   ${({ $fillWidth }) => $fillWidth && "width: 100%"};
 `;


### PR DESCRIPTION
Closes https://github.com/ClickHouse/click-ui/issues/558

# Why

There is not enough contrast between the parent background color and multiAccordion background color:
<img width="565" alt="Screenshot 2025-03-13 at 12 11 54 PM" src="https://github.com/user-attachments/assets/498b98bc-4e84-42ae-a2af-da5a025184af" />

# What

This sets a default color for the multiAccordion to allow for better contrast in dark mode:
<img width="371" alt="Screenshot 2025-03-13 at 12 13 26 PM" src="https://github.com/user-attachments/assets/7879f703-cfbb-4c8b-a3c6-51fc4e688ec4" />

Light mode remains unchanged.
