### PR TITLE
Add story showing chart colors

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -69,6 +69,7 @@ const preview: Preview = {
           "Display",
           "Sidebar",
           "Typography",
+          "Colors",
           ["Title", "Text", "Link"],
         ],
       },

--- a/src/stories/chartColors.stories.tsx
+++ b/src/stories/chartColors.stories.tsx
@@ -1,0 +1,46 @@
+import { Container, Text } from "@/components";
+import styled, { useTheme } from "styled-components";
+
+const ColorBox = styled(Container)<{
+  $color: string;
+}>`
+  ${({ $color }): string => `
+    background-color: ${$color};
+  `};
+  border-radius: 4px;
+`;
+
+const defaultStory = {
+  title: "Colors/Chart Colors",
+  tags: ["autodocs"],
+  render: () => {
+    const theme = useTheme();
+    return (
+      <Container
+        gap="sm"
+        padding="sm"
+        orientation="horizontal"
+      >
+        {Object.entries(theme.global.color.chart.default).map(([name, hex]) => {
+          return (
+            <Container orientation="vertical">
+              <Text>{name}</Text>
+              <ColorBox
+                $color={hex}
+                maxWidth="40px"
+                padding="md"
+              />
+              <Text>{hex}</Text>
+            </Container>
+          );
+        })}
+      </Container>
+    );
+  },
+};
+
+export const Playground = {
+  ...defaultStory,
+};
+
+export default defaultStory;

--- a/src/stories/chartColors.stories.tsx
+++ b/src/stories/chartColors.stories.tsx
@@ -12,7 +12,7 @@ const ColorBox = styled(Container)<{
 
 const defaultStory = {
   title: "Colors/Chart Colors",
-  tags: ["autodocs"],
+  tags: ["autodocs", "color", "chart"],
   render: () => {
     const theme = useTheme();
     return (


### PR DESCRIPTION
- Adds a simple story showing the chart color names, their color, and their hex code.
- Adds a new sidebar heading for Colors

![Screenshot 2025-03-13 at 5 00 30 PM](https://github.com/user-attachments/assets/d7d88830-6965-4a2c-866b-8fe4b840c9e2)
