### PR TITLE
fix(Dropdown): remove hack, use prop for collision padding

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -95,9 +95,6 @@ const DropdownMenuContent = styled(GenericMenuPanel)`
   flex-direction: column;
   z-index: 1;
   overflow-y: auto;
-  max-height: calc(
-    (var(--radix-${({ $type }) => $type}-content-available-height) - 100px)
-  );
 `;
 
 const DropdownContent = ({
@@ -115,6 +112,7 @@ const DropdownContent = ({
         as={ContentElement}
         sideOffset={4}
         loop
+        collisionPadding={100}
         {...props}
       >
         {showArrow && (


### PR DESCRIPTION
fixes this:

https://github.com/user-attachments/assets/3a41d9d7-13fa-4842-8911-dcef4c9e58e7

after change:

https://github.com/user-attachments/assets/b31665b2-d0ef-404d-b3a3-11a1ba8b8c30

the reson for bug:
popper uses tons of internal calculations to position floating elements
implicitly changing elements size using css breaks them