### PR TITLE
Add .prettierignore and ignore src/styles/types.ts

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+src/styles/types.ts

--- a/src/styles/types.ts
+++ b/src/styles/types.ts
@@ -1,3542 +1,3544 @@
-export interface Theme {
-  click: {
-    accordion: {
-      sm: {
-        icon: {
-          size: {
-            height: string;
-            width: string;
-          };
-        };
-        space: {
-          gap: string;
-        };
-        typography: {
-          label: {
-            default: string;
-            hover: string;
-            active: string;
-          };
-        };
-      };
-      md: {
-        icon: {
-          size: {
-            height: string;
-            width: string;
-          };
-        };
-        space: {
-          gap: string;
-        };
-        typography: {
-          label: {
-            default: string;
-            hover: string;
-            active: string;
-          };
-        };
-      };
-      lg: {
-        icon: {
-          size: {
-            height: string;
-            width: string;
-          };
-        };
-        space: {
-          gap: string;
-        };
-        typography: {
-          label: {
-            default: string;
-            hover: string;
-            active: string;
-          };
-        };
-      };
-      color: {
-        default: {
-          label: {
-            default: string;
-            hover: string;
-            active: string;
-          };
-          icon: {
-            default: string;
-            hover: string;
-            active: string;
-          };
-        };
-        link: {
-          label: {
-            default: string;
-            hover: string;
-            active: string;
-          };
-          icon: {
-            default: string;
-            hover: string;
-            active: string;
-          };
-        };
-      };
-    };
-    alert: {
-      medium: {
-        space: {
-          y: string;
-          x: string;
-          gap: string;
-        };
-        typography: {
-          title: {
-            default: string;
-          };
-          text: {
-            default: string;
-          };
-        };
-        icon: {
-          height: string;
-          width: string;
-        };
-      };
-      small: {
-        space: {
-          y: string;
-          x: string;
-          gap: string;
-        };
-        icon: {
-          height: string;
-          width: string;
-        };
-        typography: {
-          title: {
-            default: string;
-          };
-          text: {
-            default: string;
-          };
-        };
-      };
-      radii: {
-        center: string;
-        end: string;
-      };
-      color: {
-        background: {
-          default: string;
-          success: string;
-          neutral: string;
-          danger: string;
-          warning: string;
-          info: string;
-        };
-        text: {
-          default: string;
-          success: string;
-          neutral: string;
-          danger: string;
-          warning: string;
-          info: string;
-        };
-        iconBackground: {
-          default: string;
-          success: string;
-          neutral: string;
-          danger: string;
-          warning: string;
-          info: string;
-        };
-        iconForeground: {
-          default: string;
-          success: string;
-          neutral: string;
-          danger: string;
-          warning: string;
-          info: string;
-        };
-      };
-    };
-    avatar: {
-      typography: {
-        label: {
-          sm: {
-            default: string;
-            hover: string;
-            active: string;
-          };
-          md: {
-            default: string;
-            hover: string;
-            active: string;
-          };
-        };
-      };
-      size: {
-        label: {
-          width: string;
-        };
-        width: string;
-        height: string;
-      };
-      radii: {
-        all: string;
-      };
-      color: {
-        background: {
-          default: string;
-          hover: string;
-          active: string;
-        };
-        text: {
-          default: string;
-          hover: string;
-          active: string;
-        };
-      };
-    };
-    badge: {
-      space: {
-        md: {
-          x: string;
-          y: string;
-          gap: string;
-        };
-        sm: {
-          x: string;
-          y: string;
-          gap: string;
-        };
-      };
-      typography: {
-        label: {
-          md: {
-            default: string;
-          };
-          sm: {
-            default: string;
-          };
-        };
-      };
-      radii: {
-        all: string;
-      };
-      stroke: string;
-      icon: {
-        md: {
-          size: {
-            height: string;
-            width: string;
-          };
-        };
-        sm: {
-          size: {
-            height: string;
-            width: string;
-          };
-        };
-      };
-      opaque: {
-        color: {
-          background: {
-            default: string;
-            success: string;
-            neutral: string;
-            danger: string;
-            disabled: string;
-            info: string;
-            warning: string;
-          };
-          text: {
-            default: string;
-            success: string;
-            neutral: string;
-            danger: string;
-            disabled: string;
-            info: string;
-            warning: string;
-          };
-          stroke: {
-            default: string;
-            success: string;
-            neutral: string;
-            danger: string;
-            disabled: string;
-            info: string;
-            warning: string;
-          };
-        };
-      };
-      solid: {
-        color: {
-          background: {
-            default: string;
-            success: string;
-            neutral: string;
-            danger: string;
-            disabled: string;
-            info: string;
-            warning: string;
-          };
-          text: {
-            default: string;
-            success: string;
-            neutral: string;
-            danger: string;
-            disabled: string;
-            info: string;
-            warning: string;
-          };
-          stroke: {
-            default: string;
-            success: string;
-            neutral: string;
-            danger: string;
-            disabled: string;
-            info: string;
-            warning: string;
-          };
-        };
-      };
-    };
-    bigStat: {
-      space: {
-        all: string;
-        sm: {
-          gap: string;
-        };
-        lg: {
-          gap: string;
-        };
-      };
-      radii: {
-        all: string;
-      };
-      stroke: string;
-      typography: {
-        lg: {
-          label: {
-            default: string;
-            muted: string;
-          };
-          title: {
-            default: string;
-            muted: string;
-          };
-        };
-        sm: {
-          label: {
-            default: string;
-            muted: string;
-          };
-          title: {
-            default: string;
-            muted: string;
-          };
-        };
-      };
-      color: {
-        stroke: {
-          default: string;
-          muted: string;
-        };
-        background: {
-          default: string;
-          muted: string;
-        };
-        label: {
-          default: string;
-          muted: string;
-        };
-        title: {
-          default: string;
-          muted: string;
-        };
-      };
-    };
-    button: {
-      radii: {
-        all: string;
-      };
-      basic: {
-        space: {
-          x: string;
-          y: string;
-          gap: string;
-          group: string;
-        };
-        typography: {
-          label: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-          mobile: {
-            label: {
-              default: string;
-              hover: string;
-              active: string;
-            };
-          };
-        };
-        size: {
-          icon: {
-            height: string;
-            all: string;
-            width: string;
-          };
-        };
-        color: {
-          primary: {
-            background: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            text: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            stroke: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-          };
-          secondary: {
-            background: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            stroke: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            text: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-          };
-          danger: {
-            background: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            text: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            stroke: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-          };
-          empty: {
-            text: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            background: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            stroke: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-          };
-        };
-      };
-      iconButton: {
-        default: {
-          space: {
-            x: string;
-            y: string;
-          };
-        };
-        size: {
-          small: string;
-          medium: string;
-          large: string;
-        };
-        radii: {
-          all: string;
-        };
-        sm: {
-          space: {
-            x: string;
-            y: string;
-          };
-        };
-        xs: {
-          space: {
-            x: string;
-            y: string;
-          };
-        };
-        color: {
-          primary: {
-            background: {
-              default: string;
-              hover: string;
-              active: string;
-            };
-            stroke: {
-              default: string;
-              hover: string;
-              active: string;
-            };
-            text: {
-              default: string;
-              hover: string;
-              active: string;
-            };
-          };
-          secondary: {
-            background: {
-              default: string;
-              hover: string;
-              active: string;
-            };
-            stroke: {
-              default: string;
-              hover: string;
-              active: string;
-            };
-            text: {
-              default: string;
-              hover: string;
-              active: string;
-            };
-          };
-          disabled: {
-            background: {
-              default: string;
-            };
-            text: {
-              default: string;
-            };
-          };
-          danger: {
-            background: {
-              default: string;
-              hover: string;
-              active: string;
-            };
-            text: {
-              default: string;
-              hover: string;
-              active: string;
-            };
-            stroke: {
-              default: string;
-              hover: string;
-              active: string;
-            };
-          };
-          ghost: {
-            background: {
-              default: string;
-              hover: string;
-              active: string;
-            };
-            stroke: {
-              default: string;
-              hover: string;
-              active: string;
-            };
-            text: {
-              default: string;
-              hover: string;
-              active: string;
-            };
-          };
-          info: {
-            background: {
-              default: string;
-              hover: string;
-              active: string;
-            };
-            text: {
-              default: string;
-              hover: string;
-              active: string;
-            };
-            stroke: {
-              default: string;
-              hover: string;
-              active: string;
-            };
-          };
-        };
-      };
-      stroke: string;
-      split: {
-        icon: {
-          space: {
-            y: string;
-            x: string;
-          };
-        };
-        space: {
-          x: string;
-          y: string;
-          gap: string;
-        };
-        typography: {
-          label: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-          mobile: {
-            label: {
-              default: string;
-              hover: string;
-              active: string;
-            };
-          };
-        };
-        primary: {
-          background: {
-            main: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            action: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-          };
-          text: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-          stroke: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-          divide: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-        };
-        secondary: {
-          divide: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-          background: {
-            main: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            action: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-          };
-          text: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-          stroke: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-        };
-      };
-      mobile: {
-        button: {
-          space: {
-            x: string;
-            y: string;
-            gap: string;
-          };
-        };
-        basic: {
-          size: {
-            icon: {
-              all: string;
-            };
-          };
-        };
-      };
-      group: {
-        radii: {
-          all: string;
-          end: string;
-        };
-        typography: {
-          label: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-          mobile: {
-            label: {
-              default: string;
-              hover: string;
-              active: string;
-            };
-          };
-        };
-        space: {
-          gap: {
-            default: string;
-            borderless: string;
-          };
-        };
-        color: {
-          background: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-            "disabled-active": string;
-            panel: string;
-          };
-          text: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-            "disabled-active": string;
-          };
-          stroke: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-            "disabled-active": string;
-            panel: string;
-          };
-          panel: {
-            stroke: {
-              default: string;
-              borderless: string;
-            };
-          };
-        };
-      };
-      alignLeft: {
-        size: {
-          icon: {
-            all: string;
-          };
-        };
-        space: {
-          x: string;
-          y: string;
-          gap: string;
-        };
-        typography: {
-          label: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-          mobile: {
-            label: {
-              default: string;
-              hover: string;
-              active: string;
-            };
-          };
-        };
-      };
-      alignedLeft: {
-        color: {
-          background: {
-            default: string;
-            hover: string;
-            active: string;
-          };
-          stroke: {
-            default: string;
-            hover: string;
-            active: string;
-          };
-          text: {
-            default: string;
-            hover: string;
-            active: string;
-          };
-        };
-      };
-    };
-    card: {
-      secondary: {
-        space: {
-          all: string;
-          gap: string;
-          link: {
-            gap: string;
-          };
-        };
-        radii: {
-          all: string;
-        };
-        icon: {
-          size: {
-            all: string;
-          };
-        };
-        stroke: string;
-        color: {
-          background: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-          title: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-          description: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-          link: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-          stroke: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-        };
-      };
-      typography: {
-        title: {
-          default: string;
-          hover: string;
-          active: string;
-          disabled: string;
-        };
-        description: {
-          default: string;
-          hover: string;
-          active: string;
-          disabled: string;
-        };
-        link: {
-          default: string;
-          hover: string;
-          active: string;
-          disabled: string;
-        };
-      };
-      primary: {
-        size: {
-          icon: {
-            sm: {
-              all: string;
-            };
-            md: {
-              all: string;
-            };
-          };
-        };
-        space: {
-          md: {
-            y: string;
-            x: string;
-            gap: string;
-          };
-          sm: {
-            y: string;
-            x: string;
-            gap: string;
-          };
-        };
-        radii: {
-          all: string;
-        };
-        stroke: string;
-        color: {
-          background: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-          title: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-          description: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-          stroke: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-        };
-      };
-      shadow: string;
-      horizontal: {
-        radii: {
-          all: string;
-        };
-        typography: {
-          title: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-          description: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-        };
-        icon: {
-          size: {
-            all: string;
-          };
-        };
-        space: {
-          y: string;
-          x: string;
-          gap: string;
-        };
-        default: {
-          color: {
-            background: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            title: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            description: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            stroke: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-          };
-        };
-        muted: {
-          color: {
-            background: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            title: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            description: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            stroke: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-          };
-        };
-      };
-      promotion: {
-        radii: {
-          all: string;
-        };
-        typography: {
-          text: {
-            default: string;
-          };
-        };
-        space: {
-          y: string;
-          x: string;
-          gap: string;
-        };
-        icon: {
-          size: {
-            all: string;
-          };
-        };
-        color: {
-          text: {
-            default: string;
-            hover: string;
-            active: string;
-          };
-          icon: {
-            default: string;
-            hover: string;
-            active: string;
-          };
-          background: {
-            default: string;
-            hover: string;
-            active: string;
-          };
-          stroke: {
-            default: string;
-            hover: string;
-            active: string;
-            focus: string;
-          };
-        };
-      };
-    };
-    checkbox: {
-      radii: {
-        all: string;
-      };
-      space: {
-        all: string;
-        gap: string;
-      };
-      size: {
-        all: string;
-      };
-      typography: {
-        label: {
-          default: string;
-          hover: string;
-          active: string;
-          disabled: string;
-        };
-      };
-      color: {
-        variations: {
-          default: {
-            background: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            stroke: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            check: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            label: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-          };
-          var1: {
-            background: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            stroke: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            check: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-          };
-          var2: {
-            background: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            stroke: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            check: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-          };
-          var3: {
-            background: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            stroke: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            check: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-          };
-          var4: {
-            background: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            stroke: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            check: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-          };
-          var5: {
-            background: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            stroke: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            check: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-          };
-          var6: {
-            background: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            stroke: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-            check: {
-              default: string;
-              hover: string;
-              active: string;
-              disabled: string;
-            };
-          };
-        };
-        background: {
-          default: string;
-          hover: string;
-          active: string;
-          disabled: string;
-        };
-        stroke: {
-          default: string;
-          hover: string;
-          active: string;
-          disabled: string;
-        };
-        check: {
-          default: string;
-          hover: string;
-          active: string;
-          disabled: string;
-        };
-        label: {
-          default: string;
-          hover: string;
-          active: string;
-          disabled: string;
-        };
-      };
-    };
-    codeblock: {
-      space: {
-        x: string;
-        y: string;
-        gap: string;
-      };
-      radii: {
-        all: string;
-      };
-      stroke: string;
-      typography: {
-        text: {
-          default: string;
-        };
-      };
-      numbers: {
-        size: {
-          width: string;
-        };
-      };
-      darkMode: {
-        color: {
-          background: {
-            default: string;
-          };
-          text: {
-            default: string;
-          };
-          numbers: {
-            default: string;
-          };
-          button: {
-            background: {
-              default: string;
-              hover: string;
-            };
-            foreground: {
-              default: string;
-            };
-          };
-          stroke: {
-            default: string;
-          };
-        };
-      };
-      lightMode: {
-        color: {
-          background: {
-            default: string;
-          };
-          text: {
-            default: string;
-          };
-          numbers: {
-            default: string;
-          };
-          button: {
-            background: {
-              default: string;
-              hover: string;
-            };
-            foreground: {
-              default: string;
-            };
-          };
-          stroke: {
-            default: string;
-          };
-        };
-      };
-      monacoTheme: {
-        parameter: {
-          foreground: string;
-          background: string;
-        };
-      };
-    };
-    codeInline: {
-      space: {
-        x: string;
-      };
-      stroke: string;
-      typography: {
-        text: {
-          default: string;
-        };
-      };
-      radii: {
-        all: string;
-      };
-      color: {
-        background: {
-          default: string;
-        };
-        text: {
-          default: string;
-        };
-        stroke: {
-          default: string;
-        };
-      };
-    };
-    docs: {
-      typography: {
-        titles: {
-          lg: string;
-          md: string;
-          sm: string;
-        };
-        text: {
-          default: string;
-        };
-        breadcrumbs: {
-          default: string;
-          active: string;
-        };
-        toc: {
-          title: {
-            default: string;
-          };
-          item: {
-            default: string;
-            hover: string;
-            active: string;
-          };
-        };
-      };
-    };
-    field: {
-      typography: {
-        label: {
-          default: string;
-          hover: string;
-          active: string;
-          disabled: string;
-          error: string;
-        };
-        fieldText: {
-          default: string;
-          hover: string;
-          active: string;
-          disabled: string;
-          error: string;
-        };
-        placeholder: {
-          default: string;
-        };
-        format: {
-          default: string;
-          hover: string;
-          active: string;
-          disabled: string;
-          error: string;
-        };
-        genericLabel: {
-          default: string;
-          hover: string;
-          active: string;
-          disabled: string;
-          error: string;
-        };
-      };
-      type: {
-        mobile: {
-          label: string;
-          "field-value": string;
-        };
-      };
-      space: {
-        x: string;
-        y: string;
-        gap: string;
-      };
-      size: {
-        icon: string;
-      };
-      radii: {
-        all: string;
-      };
-      mobile: {
-        space: {
-          x: string;
-          y: string;
-          gap: string;
-        };
-      };
-      color: {
-        background: {
-          default: string;
-          hover: string;
-          active: string;
-          disabled: string;
-          error: string;
-        };
-        text: {
-          default: string;
-          hover: string;
-          active: string;
-          disabled: string;
-          error: string;
-        };
-        stroke: {
-          default: string;
-          hover: string;
-          active: string;
-          disabled: string;
-          error: string;
-        };
-        label: {
-          default: string;
-          hover: string;
-          active: string;
-          disabled: string;
-          error: string;
-        };
-        format: {
-          default: string;
-          hover: string;
-          active: string;
-          disabled: string;
-          error: string;
-        };
-        genericLabel: {
-          default: string;
-          hover: string;
-          active: string;
-          disabled: string;
-        };
-        placeholder: {
-          default: string;
-          disabled: string;
-        };
-      };
-    };
-    genericMenu: {
-      item: {
-        space: {
-          x: string;
-          y: string;
-          gap: string;
-        };
-        icon: {
-          size: {
-            height: string;
-            width: string;
-          };
-        };
-        typography: {
-          label: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-          sectionHeader: {
-            default: string;
-          };
-          subtext: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-        };
+
+      export interface Theme {
+  "click": {
+    "accordion": {
+      "sm": {
+        "icon": {
+          "size": {
+            "height": string,
+            "width": string
+          }
+        },
+        "space": {
+          "gap": string
+        },
+        "typography": {
+          "label": {
+            "default": string,
+            "hover": string,
+            "active": string
+          }
+        }
+      },
+      "md": {
+        "icon": {
+          "size": {
+            "height": string,
+            "width": string
+          }
+        },
+        "space": {
+          "gap": string
+        },
+        "typography": {
+          "label": {
+            "default": string,
+            "hover": string,
+            "active": string
+          }
+        }
+      },
+      "lg": {
+        "icon": {
+          "size": {
+            "height": string,
+            "width": string
+          }
+        },
+        "space": {
+          "gap": string
+        },
+        "typography": {
+          "label": {
+            "default": string,
+            "hover": string,
+            "active": string
+          }
+        }
+      },
+      "color": {
+        "default": {
+          "label": {
+            "default": string,
+            "hover": string,
+            "active": string
+          },
+          "icon": {
+            "default": string,
+            "hover": string,
+            "active": string
+          }
+        },
+        "link": {
+          "label": {
+            "default": string,
+            "hover": string,
+            "active": string
+          },
+          "icon": {
+            "default": string,
+            "hover": string,
+            "active": string
+          }
+        }
+      }
+    },
+    "alert": {
+      "medium": {
+        "space": {
+          "y": string,
+          "x": string,
+          "gap": string
+        },
+        "typography": {
+          "title": {
+            "default": string
+          },
+          "text": {
+            "default": string
+          }
+        },
+        "icon": {
+          "height": string,
+          "width": string
+        }
+      },
+      "small": {
+        "space": {
+          "y": string,
+          "x": string,
+          "gap": string
+        },
+        "icon": {
+          "height": string,
+          "width": string
+        },
+        "typography": {
+          "title": {
+            "default": string
+          },
+          "text": {
+            "default": string
+          }
+        }
+      },
+      "radii": {
+        "center": string,
+        "end": string
+      },
+      "color": {
+        "background": {
+          "default": string,
+          "success": string,
+          "neutral": string,
+          "danger": string,
+          "warning": string,
+          "info": string
+        },
+        "text": {
+          "default": string,
+          "success": string,
+          "neutral": string,
+          "danger": string,
+          "warning": string,
+          "info": string
+        },
+        "iconBackground": {
+          "default": string,
+          "success": string,
+          "neutral": string,
+          "danger": string,
+          "warning": string,
+          "info": string
+        },
+        "iconForeground": {
+          "default": string,
+          "success": string,
+          "neutral": string,
+          "danger": string,
+          "warning": string,
+          "info": string
+        }
+      }
+    },
+    "avatar": {
+      "typography": {
+        "label": {
+          "sm": {
+            "default": string,
+            "hover": string,
+            "active": string
+          },
+          "md": {
+            "default": string,
+            "hover": string,
+            "active": string
+          }
+        }
+      },
+      "size": {
+        "label": {
+          "width": string
+        },
+        "width": string,
+        "height": string
+      },
+      "radii": {
+        "all": string
+      },
+      "color": {
+        "background": {
+          "default": string,
+          "hover": string,
+          "active": string
+        },
+        "text": {
+          "default": string,
+          "hover": string,
+          "active": string
+        }
+      }
+    },
+    "badge": {
+      "space": {
+        "md": {
+          "x": string,
+          "y": string,
+          "gap": string
+        },
+        "sm": {
+          "x": string,
+          "y": string,
+          "gap": string
+        }
+      },
+      "typography": {
+        "label": {
+          "md": {
+            "default": string
+          },
+          "sm": {
+            "default": string
+          }
+        }
+      },
+      "radii": {
+        "all": string
+      },
+      "stroke": string,
+      "icon": {
+        "md": {
+          "size": {
+            "height": string,
+            "width": string
+          }
+        },
+        "sm": {
+          "size": {
+            "height": string,
+            "width": string
+          }
+        }
+      },
+      "opaque": {
+        "color": {
+          "background": {
+            "default": string,
+            "success": string,
+            "neutral": string,
+            "danger": string,
+            "disabled": string,
+            "info": string,
+            "warning": string
+          },
+          "text": {
+            "default": string,
+            "success": string,
+            "neutral": string,
+            "danger": string,
+            "disabled": string,
+            "info": string,
+            "warning": string
+          },
+          "stroke": {
+            "default": string,
+            "success": string,
+            "neutral": string,
+            "danger": string,
+            "disabled": string,
+            "info": string,
+            "warning": string
+          }
+        }
+      },
+      "solid": {
+        "color": {
+          "background": {
+            "default": string,
+            "success": string,
+            "neutral": string,
+            "danger": string,
+            "disabled": string,
+            "info": string,
+            "warning": string
+          },
+          "text": {
+            "default": string,
+            "success": string,
+            "neutral": string,
+            "danger": string,
+            "disabled": string,
+            "info": string,
+            "warning": string
+          },
+          "stroke": {
+            "default": string,
+            "success": string,
+            "neutral": string,
+            "danger": string,
+            "disabled": string,
+            "info": string,
+            "warning": string
+          }
+        }
+      }
+    },
+    "bigStat": {
+      "space": {
+        "all": string,
+        "sm": {
+          "gap": string
+        },
+        "lg": {
+          "gap": string
+        }
+      },
+      "radii": {
+        "all": string
+      },
+      "stroke": string,
+      "typography": {
+        "lg": {
+          "label": {
+            "default": string,
+            "muted": string
+          },
+          "title": {
+            "default": string,
+            "muted": string
+          }
+        },
+        "sm": {
+          "label": {
+            "default": string,
+            "muted": string
+          },
+          "title": {
+            "default": string,
+            "muted": string
+          }
+        }
+      },
+      "color": {
+        "stroke": {
+          "default": string,
+          "muted": string
+        },
+        "background": {
+          "default": string,
+          "muted": string
+        },
+        "label": {
+          "default": string,
+          "muted": string
+        },
+        "title": {
+          "default": string,
+          "muted": string
+        }
+      }
+    },
+    "button": {
+      "radii": {
+        "all": string
+      },
+      "basic": {
+        "space": {
+          "x": string,
+          "y": string,
+          "gap": string,
+          "group": string
+        },
+        "typography": {
+          "label": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          },
+          "mobile": {
+            "label": {
+              "default": string,
+              "hover": string,
+              "active": string
+            }
+          }
+        },
+        "size": {
+          "icon": {
+            "height": string,
+            "all": string,
+            "width": string
+          }
+        },
+        "color": {
+          "primary": {
+            "background": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "text": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "stroke": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            }
+          },
+          "secondary": {
+            "background": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "stroke": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "text": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            }
+          },
+          "danger": {
+            "background": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "text": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "stroke": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            }
+          },
+          "empty": {
+            "text": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "background": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "stroke": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            }
+          }
+        }
+      },
+      "iconButton": {
+        "default": {
+          "space": {
+            "x": string,
+            "y": string
+          }
+        },
+        "size": {
+          "small": string,
+          "medium": string,
+          "large": string
+        },
+        "radii": {
+          "all": string
+        },
+        "sm": {
+          "space": {
+            "x": string,
+            "y": string
+          }
+        },
+        "xs": {
+          "space": {
+            "x": string,
+            "y": string
+          }
+        },
+        "color": {
+          "primary": {
+            "background": {
+              "default": string,
+              "hover": string,
+              "active": string
+            },
+            "stroke": {
+              "default": string,
+              "hover": string,
+              "active": string
+            },
+            "text": {
+              "default": string,
+              "hover": string,
+              "active": string
+            }
+          },
+          "secondary": {
+            "background": {
+              "default": string,
+              "hover": string,
+              "active": string
+            },
+            "stroke": {
+              "default": string,
+              "hover": string,
+              "active": string
+            },
+            "text": {
+              "default": string,
+              "hover": string,
+              "active": string
+            }
+          },
+          "disabled": {
+            "background": {
+              "default": string
+            },
+            "text": {
+              "default": string
+            }
+          },
+          "danger": {
+            "background": {
+              "default": string,
+              "hover": string,
+              "active": string
+            },
+            "text": {
+              "default": string,
+              "hover": string,
+              "active": string
+            },
+            "stroke": {
+              "default": string,
+              "hover": string,
+              "active": string
+            }
+          },
+          "ghost": {
+            "background": {
+              "default": string,
+              "hover": string,
+              "active": string
+            },
+            "stroke": {
+              "default": string,
+              "hover": string,
+              "active": string
+            },
+            "text": {
+              "default": string,
+              "hover": string,
+              "active": string
+            }
+          },
+          "info": {
+            "background": {
+              "default": string,
+              "hover": string,
+              "active": string
+            },
+            "text": {
+              "default": string,
+              "hover": string,
+              "active": string
+            },
+            "stroke": {
+              "default": string,
+              "hover": string,
+              "active": string
+            }
+          }
+        }
+      },
+      "stroke": string,
+      "split": {
+        "icon": {
+          "space": {
+            "y": string,
+            "x": string
+          }
+        },
+        "space": {
+          "x": string,
+          "y": string,
+          "gap": string
+        },
+        "typography": {
+          "label": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          },
+          "mobile": {
+            "label": {
+              "default": string,
+              "hover": string,
+              "active": string
+            }
+          }
+        },
+        "primary": {
+          "background": {
+            "main": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "action": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            }
+          },
+          "text": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          },
+          "stroke": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          },
+          "divide": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          }
+        },
+        "secondary": {
+          "divide": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          },
+          "background": {
+            "main": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "action": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            }
+          },
+          "text": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          },
+          "stroke": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          }
+        }
+      },
+      "mobile": {
+        "button": {
+          "space": {
+            "x": string,
+            "y": string,
+            "gap": string
+          }
+        },
+        "basic": {
+          "size": {
+            "icon": {
+              "all": string
+            }
+          }
+        }
+      },
+      "group": {
+        "radii": {
+          "all": string,
+          "end": string
+        },
+        "typography": {
+          "label": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          },
+          "mobile": {
+            "label": {
+              "default": string,
+              "hover": string,
+              "active": string
+            }
+          }
+        },
+        "space": {
+          "gap": {
+            "default": string,
+            "borderless": string
+          }
+        },
+        "color": {
+          "background": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string,
+            "disabled-active": string,
+            "panel": string
+          },
+          "text": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string,
+            "disabled-active": string
+          },
+          "stroke": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string,
+            "disabled-active": string,
+            "panel": string
+          },
+          "panel": {
+            "stroke": {
+              "default": string,
+              "borderless": string
+            }
+          }
+        }
+      },
+      "alignLeft": {
+        "size": {
+          "icon": {
+            "all": string
+          }
+        },
+        "space": {
+          "x": string,
+          "y": string,
+          "gap": string
+        },
+        "typography": {
+          "label": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          },
+          "mobile": {
+            "label": {
+              "default": string,
+              "hover": string,
+              "active": string
+            }
+          }
+        }
+      },
+      "alignedLeft": {
+        "color": {
+          "background": {
+            "default": string,
+            "hover": string,
+            "active": string
+          },
+          "stroke": {
+            "default": string,
+            "hover": string,
+            "active": string
+          },
+          "text": {
+            "default": string,
+            "hover": string,
+            "active": string
+          }
+        }
+      }
+    },
+    "card": {
+      "secondary": {
+        "space": {
+          "all": string,
+          "gap": string,
+          "link": {
+            "gap": string
+          }
+        },
+        "radii": {
+          "all": string
+        },
+        "icon": {
+          "size": {
+            "all": string
+          }
+        },
+        "stroke": string,
+        "color": {
+          "background": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          },
+          "title": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          },
+          "description": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          },
+          "link": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          },
+          "stroke": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          }
+        }
+      },
+      "typography": {
+        "title": {
+          "default": string,
+          "hover": string,
+          "active": string,
+          "disabled": string
+        },
+        "description": {
+          "default": string,
+          "hover": string,
+          "active": string,
+          "disabled": string
+        },
+        "link": {
+          "default": string,
+          "hover": string,
+          "active": string,
+          "disabled": string
+        }
+      },
+      "primary": {
+        "size": {
+          "icon": {
+            "sm": {
+              "all": string
+            },
+            "md": {
+              "all": string
+            }
+          }
+        },
+        "space": {
+          "md": {
+            "y": string,
+            "x": string,
+            "gap": string
+          },
+          "sm": {
+            "y": string,
+            "x": string,
+            "gap": string
+          }
+        },
+        "radii": {
+          "all": string
+        },
+        "stroke": string,
+        "color": {
+          "background": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          },
+          "title": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          },
+          "description": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          },
+          "stroke": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          }
+        }
+      },
+      "shadow": string,
+      "horizontal": {
+        "radii": {
+          "all": string
+        },
+        "typography": {
+          "title": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          },
+          "description": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          }
+        },
+        "icon": {
+          "size": {
+            "all": string
+          }
+        },
+        "space": {
+          "y": string,
+          "x": string,
+          "gap": string
+        },
+        "default": {
+          "color": {
+            "background": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "title": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "description": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "stroke": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            }
+          }
+        },
+        "muted": {
+          "color": {
+            "background": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "title": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "description": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "stroke": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            }
+          }
+        }
+      },
+      "promotion": {
+        "radii": {
+          "all": string
+        },
+        "typography": {
+          "text": {
+            "default": string
+          }
+        },
+        "space": {
+          "y": string,
+          "x": string,
+          "gap": string
+        },
+        "icon": {
+          "size": {
+            "all": string
+          }
+        },
+        "color": {
+          "text": {
+            "default": string,
+            "hover": string,
+            "active": string
+          },
+          "icon": {
+            "default": string,
+            "hover": string,
+            "active": string
+          },
+          "background": {
+            "default": string,
+            "hover": string,
+            "active": string
+          },
+          "stroke": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "focus": string
+          }
+        }
+      }
+    },
+    "checkbox": {
+      "radii": {
+        "all": string
+      },
+      "space": {
+        "all": string,
+        "gap": string
+      },
+      "size": {
+        "all": string
+      },
+      "typography": {
+        "label": {
+          "default": string,
+          "hover": string,
+          "active": string,
+          "disabled": string
+        }
+      },
+      "color": {
+        "variations": {
+          "default": {
+            "background": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "stroke": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "check": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "label": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            }
+          },
+          "var1": {
+            "background": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "stroke": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "check": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            }
+          },
+          "var2": {
+            "background": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "stroke": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "check": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            }
+          },
+          "var3": {
+            "background": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "stroke": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "check": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            }
+          },
+          "var4": {
+            "background": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "stroke": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "check": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            }
+          },
+          "var5": {
+            "background": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "stroke": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "check": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            }
+          },
+          "var6": {
+            "background": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "stroke": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            },
+            "check": {
+              "default": string,
+              "hover": string,
+              "active": string,
+              "disabled": string
+            }
+          }
+        },
+        "background": {
+          "default": string,
+          "hover": string,
+          "active": string,
+          "disabled": string
+        },
+        "stroke": {
+          "default": string,
+          "hover": string,
+          "active": string,
+          "disabled": string
+        },
+        "check": {
+          "default": string,
+          "hover": string,
+          "active": string,
+          "disabled": string
+        },
+        "label": {
+          "default": string,
+          "hover": string,
+          "active": string,
+          "disabled": string
+        }
+      }
+    },
+    "codeblock": {
+      "space": {
+        "x": string,
+        "y": string,
+        "gap": string
+      },
+      "radii": {
+        "all": string
+      },
+      "stroke": string,
+      "typography": {
+        "text": {
+          "default": string
+        }
+      },
+      "numbers": {
+        "size": {
+          "width": string
+        }
+      },
+      "darkMode": {
+        "color": {
+          "background": {
+            "default": string
+          },
+          "text": {
+            "default": string
+          },
+          "numbers": {
+            "default": string
+          },
+          "button": {
+            "background": {
+              "default": string,
+              "hover": string
+            },
+            "foreground": {
+              "default": string
+            }
+          },
+          "stroke": {
+            "default": string
+          }
+        }
+      },
+      "lightMode": {
+        "color": {
+          "background": {
+            "default": string
+          },
+          "text": {
+            "default": string
+          },
+          "numbers": {
+            "default": string
+          },
+          "button": {
+            "background": {
+              "default": string,
+              "hover": string
+            },
+            "foreground": {
+              "default": string
+            }
+          },
+          "stroke": {
+            "default": string
+          }
+        }
+      },
+      "monacoTheme": {
+        "parameter": {
+          "foreground": string,
+          "background": string
+        }
+      }
+    },
+    "codeInline": {
+      "space": {
+        "x": string
+      },
+      "stroke": string,
+      "typography": {
+        "text": {
+          "default": string
+        }
+      },
+      "radii": {
+        "all": string
+      },
+      "color": {
+        "background": {
+          "default": string
+        },
+        "text": {
+          "default": string
+        },
+        "stroke": {
+          "default": string
+        }
+      }
+    },
+    "docs": {
+      "typography": {
+        "titles": {
+          "lg": string,
+          "md": string,
+          "sm": string
+        },
+        "text": {
+          "default": string
+        },
+        "breadcrumbs": {
+          "default": string,
+          "active": string
+        },
+        "toc": {
+          "title": {
+            "default": string
+          },
+          "item": {
+            "default": string,
+            "hover": string,
+            "active": string
+          }
+        }
+      }
+    },
+    "field": {
+      "typography": {
+        "label": {
+          "default": string,
+          "hover": string,
+          "active": string,
+          "disabled": string,
+          "error": string
+        },
+        "fieldText": {
+          "default": string,
+          "hover": string,
+          "active": string,
+          "disabled": string,
+          "error": string
+        },
+        "placeholder": {
+          "default": string
+        },
+        "format": {
+          "default": string,
+          "hover": string,
+          "active": string,
+          "disabled": string,
+          "error": string
+        },
+        "genericLabel": {
+          "default": string,
+          "hover": string,
+          "active": string,
+          "disabled": string,
+          "error": string
+        }
+      },
+      "type": {
+        "mobile": {
+          "label": string,
+          "field-value": string
+        }
+      },
+      "space": {
+        "x": string,
+        "y": string,
+        "gap": string
+      },
+      "size": {
+        "icon": string
+      },
+      "radii": {
+        "all": string
+      },
+      "mobile": {
+        "space": {
+          "x": string,
+          "y": string,
+          "gap": string
+        }
+      },
+      "color": {
+        "background": {
+          "default": string,
+          "hover": string,
+          "active": string,
+          "disabled": string,
+          "error": string
+        },
+        "text": {
+          "default": string,
+          "hover": string,
+          "active": string,
+          "disabled": string,
+          "error": string
+        },
+        "stroke": {
+          "default": string,
+          "hover": string,
+          "active": string,
+          "disabled": string,
+          "error": string
+        },
+        "label": {
+          "default": string,
+          "hover": string,
+          "active": string,
+          "disabled": string,
+          "error": string
+        },
+        "format": {
+          "default": string,
+          "hover": string,
+          "active": string,
+          "disabled": string,
+          "error": string
+        },
+        "genericLabel": {
+          "default": string,
+          "hover": string,
+          "active": string,
+          "disabled": string
+        },
+        "placeholder": {
+          "default": string,
+          "disabled": string
+        }
+      }
+    },
+    "genericMenu": {
+      "item": {
+        "space": {
+          "x": string,
+          "y": string,
+          "gap": string
+        },
+        "icon": {
+          "size": {
+            "height": string,
+            "width": string
+          }
+        },
+        "typography": {
+          "label": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          },
+          "sectionHeader": {
+            "default": string
+          },
+          "subtext": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          }
+        },
         "two-lines": {
-          space: {
-            x: string;
-            y: string;
-            gap: string;
-          };
-        };
-        size: {
-          minWidth: string;
-        };
-        color: {
-          text: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-            muted: string;
-          };
-          background: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-          format: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-            error: string;
-          };
-          stroke: {
-            default: string;
-          };
-          subtext: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-        };
-      };
-      itemCustom: {
-        typography: {
-          label: {
-            sm: string;
-            lg: string;
-          };
-        };
-      };
-      button: {
-        space: {
-          gap: string;
-          y: string;
-        };
-        typography: {
-          label: {
-            default: string;
-            hover: string;
-            active: string;
-          };
-        };
-        color: {
-          background: {
-            default: string;
-          };
-          label: {
-            default: string;
-          };
-          stroke: {
-            default: string;
-          };
-        };
-      };
-      panel: {
-        radii: {
-          all: string;
-        };
-        shadow: {
-          default: string;
-        };
-        color: {
-          background: {
-            default: string;
-          };
-          stroke: {
-            default: string;
-          };
-        };
-      };
-      autocomplete: {
-        typography: {
-          results: {
-            label: {
-              default: string;
-            };
-          };
-          search: {
-            placeholder: {
-              default: string;
-            };
-            term: {
-              default: string;
-            };
-          };
-        };
-        search: {
-          stroke: {
-            default: string;
-          };
-        };
-        color: {
-          placeholder: {
-            default: string;
-          };
-          searchTerm: {
-            default: string;
-          };
-          background: {
-            default: string;
-          };
-          stroke: {
-            default: string;
-          };
-        };
-      };
-      sectionHeader: {
-        space: {
-          bottom: string;
-          top: string;
-        };
-      };
-      placeholder: {
-        space: {
-          gap: string;
-        };
-      };
-    };
-    image: {
-      sm: {
-        size: {
-          height: string;
-          width: string;
-        };
-      };
-      xs: {
-        size: {
-          height: string;
-          width: string;
-        };
-      };
-      md: {
-        size: {
-          height: string;
-          width: string;
-        };
-      };
-      lg: {
-        size: {
-          height: string;
-          width: string;
-        };
-      };
-      xl: {
-        size: {
-          height: string;
-          width: string;
-        };
-      };
-      xxl: {
-        size: {
-          height: string;
-          width: string;
-        };
-      };
-      color: {
-        stroke: string;
-      };
-    };
-    panel: {
-      strokeWidth: {
-        default: string;
-      };
-      radii: {
-        none: string;
-        sm: string;
-        md: string;
-        lg: string;
-      };
-      stroke: {
-        default: string;
-      };
-      shadow: {
-        default: string;
-      };
-      space: {
-        y: {
-          none: string;
-          xs: string;
-          sm: string;
-          md: string;
-          lg: string;
-          xl: string;
-        };
-        x: {
-          none: string;
-          xs: string;
-          sm: string;
-          md: string;
-          lg: string;
-          xl: string;
-        };
-        gap: {
-          none: string;
-          xs: string;
-          sm: string;
-          md: string;
-          lg: string;
-          xl: string;
-        };
-      };
-      color: {
-        background: {
-          default: string;
-          muted: string;
-          transparent: string;
-        };
-        stroke: {
-          default: string;
-        };
-      };
-    };
-    popover: {
-      space: {
-        y: string;
-        x: string;
-        gap: string;
-      };
-      radii: {
-        all: string;
-      };
-      shadow: {
-        default: string;
-      };
-      icon: {
-        size: {
-          height: string;
-          width: string;
-        };
-      };
-      color: {
-        panel: {
-          background: {
-            default: string;
-          };
-          stroke: {
-            default: string;
-          };
-        };
-      };
-    };
-    radio: {
-      radii: {
-        all: string;
-      };
-      typography: {
-        label: {
-          default: string;
-          hover: string;
-          active: string;
-          disabled: string;
-        };
-      };
-      color: {
-        background: {
-          default: string;
-          hover: string;
-          active: string;
-          disabled: string;
-        };
-        stroke: {
-          default: string;
-          hover: string;
-          active: string;
-          disabled: string;
-        };
-        indicator: {
-          default: string;
-          hover: string;
-          active: string;
-          disabled: string;
-        };
-      };
-    };
-    separator: {
-      horizontal: {
-        space: {
-          y: {
-            xs: string;
-            sm: string;
-            md: string;
-            ml: string;
-            lg: string;
-            xl: string;
-            xxl: string;
-          };
-          x: {
-            all: string;
-          };
-        };
-      };
-      vertical: {
-        space: {
-          x: {
-            xs: string;
-            sm: string;
-            md: string;
-            lg: string;
-            xl: string;
-            xxl: string;
-          };
-          y: {
-            all: string;
-          };
-        };
-      };
-      color: {
-        stroke: {
-          default: string;
-        };
-      };
-    };
-    sidebar: {
-      navigation: {
-        item: {
-          radii: {
-            all: string;
-          };
-          default: {
-            space: {
-              right: string;
-              y: string;
-              gap: string;
-              left: string;
-            };
-          };
-          typography: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-          mobile: {
-            typography: {
-              default: string;
-              hover: string;
-              active: string;
-            };
-            space: {
-              left: string;
-              right: string;
-              y: string;
-              gap: string;
-            };
-          };
-          collapsible: {
-            space: {
-              left: string;
-              right: string;
-              y: string;
-              gap: string;
-            };
-          };
-          icon: {
-            size: {
-              height: string;
-              width: string;
-            };
-          };
-          global: {
-            gap: string;
-          };
-        };
-        title: {
-          typography: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-        };
-        subItem: {
-          default: {
-            space: {
-              left: string;
-              right: string;
-              y: string;
-            };
-          };
-          mobile: {
-            space: {
-              left: string;
-              right: string;
-              y: string;
-              gap: string;
-            };
-            typography: {
-              default: string;
-              hover: string;
-              active: string;
-            };
-          };
-          radii: {
-            all: string;
-          };
-          typography: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-          };
-        };
-        dragControl: {
-          separator: {
-            size: {
-              height: string;
-            };
-          };
-        };
-      };
-      main: {
-        color: {
-          background: {
-            default: string;
-          };
-          text: {
-            default: string;
-            muted: string;
-          };
-          stroke: {
-            default: string;
-          };
-        };
-        navigation: {
-          item: {
-            color: {
-              background: {
-                active: string;
-                hover: string;
-                default: string;
-              };
-              text: {
-                default: string;
-                hover: string;
-                active: string;
-                muted: string;
-                disabled: string;
-              };
-              icon: {
-                default: string;
-                disabled: string;
-              };
-            };
-          };
-          title: {
-            color: {
-              default: string;
-              hover: string;
-              active: string;
-            };
-          };
-          subItem: {
-            color: {
-              text: {
-                default: string;
-                disabled: string;
-                hover: string;
-                active: string;
-              };
-              background: {
-                default: string;
-                disabled: string;
-                hover: string;
-                active: string;
-              };
-              icon: {
-                default: string;
-                disabled: string;
-              };
-            };
-          };
-          dragControl: {
-            separator: {
-              color: {
-                default: string;
-              };
-            };
-          };
-        };
-      };
-      sqlSidebar: {
-        color: {
-          background: {
-            default: string;
-          };
-          stroke: {
-            default: string;
-          };
-        };
-        navigation: {
-          item: {
-            color: {
-              background: {
-                active: string;
-                hover: string;
-                default: string;
-              };
-              text: {
-                default: string;
-                hover: string;
-                active: string;
-                muted: string;
-                disabled: string;
-              };
-              icon: {
-                default: string;
-                disabled: string;
-              };
-            };
-          };
-          subItem: {
-            color: {
-              text: {
-                disabled: string;
-                default: string;
-                hover: string;
-                active: string;
-              };
-              background: {
-                default: string;
-                hover: string;
-                active: string;
-              };
-            };
-          };
-          title: {
-            color: {
-              default: string;
-              hover: string;
-              active: string;
-            };
-          };
-          dragControl: {
-            separator: {
-              color: {
-                default: string;
-              };
-            };
-          };
-        };
-      };
-    };
-    spacer: {
-      horizontal: {
-        space: {
-          y: {
-            xs: string;
-            sm: string;
-            md: string;
-            ml: string;
-            lg: string;
-            xl: string;
-            xxl: string;
-          };
-          x: {
-            all: string;
-          };
-        };
-      };
-    };
-    stepper: {
-      vertical: {
-        numbered: {
-          connector: {
-            size: {
-              width: string;
-            };
-            stroke: {
-              default: string;
-            };
-            color: {
-              stroke: {
-                incomplete: string;
-                complete: string;
-                active: string;
-              };
-            };
-          };
-          typography: {
-            title: {
-              default: string;
-            };
-          };
-          step: {
-            typography: {
+          "space": {
+            "x": string,
+            "y": string,
+            "gap": string
+          }
+        },
+        "size": {
+          "minWidth": string
+        },
+        "color": {
+          "text": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string,
+            "muted": string
+          },
+          "background": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          },
+          "format": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string,
+            "error": string
+          },
+          "stroke": {
+            "default": string
+          },
+          "subtext": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          }
+        }
+      },
+      "itemCustom": {
+        "typography": {
+          "label": {
+            "sm": string,
+            "lg": string
+          }
+        }
+      },
+      "button": {
+        "space": {
+          "gap": string,
+          "y": string
+        },
+        "typography": {
+          "label": {
+            "default": string,
+            "hover": string,
+            "active": string
+          }
+        },
+        "color": {
+          "background": {
+            "default": string
+          },
+          "label": {
+            "default": string
+          },
+          "stroke": {
+            "default": string
+          }
+        }
+      },
+      "panel": {
+        "radii": {
+          "all": string
+        },
+        "shadow": {
+          "default": string
+        },
+        "color": {
+          "background": {
+            "default": string
+          },
+          "stroke": {
+            "default": string
+          }
+        }
+      },
+      "autocomplete": {
+        "typography": {
+          "results": {
+            "label": {
+              "default": string
+            }
+          },
+          "search": {
+            "placeholder": {
+              "default": string
+            },
+            "term": {
+              "default": string
+            }
+          }
+        },
+        "search": {
+          "stroke": {
+            "default": string
+          }
+        },
+        "color": {
+          "placeholder": {
+            "default": string
+          },
+          "searchTerm": {
+            "default": string
+          },
+          "background": {
+            "default": string
+          },
+          "stroke": {
+            "default": string
+          }
+        }
+      },
+      "sectionHeader": {
+        "space": {
+          "bottom": string,
+          "top": string
+        }
+      },
+      "placeholder": {
+        "space": {
+          "gap": string
+        }
+      }
+    },
+    "image": {
+      "sm": {
+        "size": {
+          "height": string,
+          "width": string
+        }
+      },
+      "xs": {
+        "size": {
+          "height": string,
+          "width": string
+        }
+      },
+      "md": {
+        "size": {
+          "height": string,
+          "width": string
+        }
+      },
+      "lg": {
+        "size": {
+          "height": string,
+          "width": string
+        }
+      },
+      "xl": {
+        "size": {
+          "height": string,
+          "width": string
+        }
+      },
+      "xxl": {
+        "size": {
+          "height": string,
+          "width": string
+        }
+      },
+      "color": {
+        "stroke": string
+      }
+    },
+    "panel": {
+      "strokeWidth": {
+        "default": string
+      },
+      "radii": {
+        "none": string,
+        "sm": string,
+        "md": string,
+        "lg": string
+      },
+      "stroke": {
+        "default": string
+      },
+      "shadow": {
+        "default": string
+      },
+      "space": {
+        "y": {
+          "none": string,
+          "xs": string,
+          "sm": string,
+          "md": string,
+          "lg": string,
+          "xl": string
+        },
+        "x": {
+          "none": string,
+          "xs": string,
+          "sm": string,
+          "md": string,
+          "lg": string,
+          "xl": string
+        },
+        "gap": {
+          "none": string,
+          "xs": string,
+          "sm": string,
+          "md": string,
+          "lg": string,
+          "xl": string
+        }
+      },
+      "color": {
+        "background": {
+          "default": string,
+          "muted": string,
+          "transparent": string
+        },
+        "stroke": {
+          "default": string
+        }
+      }
+    },
+    "popover": {
+      "space": {
+        "y": string,
+        "x": string,
+        "gap": string
+      },
+      "radii": {
+        "all": string
+      },
+      "shadow": {
+        "default": string
+      },
+      "icon": {
+        "size": {
+          "height": string,
+          "width": string
+        }
+      },
+      "color": {
+        "panel": {
+          "background": {
+            "default": string
+          },
+          "stroke": {
+            "default": string
+          }
+        }
+      }
+    },
+    "radio": {
+      "radii": {
+        "all": string
+      },
+      "typography": {
+        "label": {
+          "default": string,
+          "hover": string,
+          "active": string,
+          "disabled": string
+        }
+      },
+      "color": {
+        "background": {
+          "default": string,
+          "hover": string,
+          "active": string,
+          "disabled": string
+        },
+        "stroke": {
+          "default": string,
+          "hover": string,
+          "active": string,
+          "disabled": string
+        },
+        "indicator": {
+          "default": string,
+          "hover": string,
+          "active": string,
+          "disabled": string
+        }
+      }
+    },
+    "separator": {
+      "horizontal": {
+        "space": {
+          "y": {
+            "xs": string,
+            "sm": string,
+            "md": string,
+            "ml": string,
+            "lg": string,
+            "xl": string,
+            "xxl": string
+          },
+          "x": {
+            "all": string
+          }
+        }
+      },
+      "vertical": {
+        "space": {
+          "x": {
+            "xs": string,
+            "sm": string,
+            "md": string,
+            "lg": string,
+            "xl": string,
+            "xxl": string
+          },
+          "y": {
+            "all": string
+          }
+        }
+      },
+      "color": {
+        "stroke": {
+          "default": string
+        }
+      }
+    },
+    "sidebar": {
+      "navigation": {
+        "item": {
+          "radii": {
+            "all": string
+          },
+          "default": {
+            "space": {
+              "right": string,
+              "y": string,
+              "gap": string,
+              "left": string
+            }
+          },
+          "typography": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          },
+          "mobile": {
+            "typography": {
+              "default": string,
+              "hover": string,
+              "active": string
+            },
+            "space": {
+              "left": string,
+              "right": string,
+              "y": string,
+              "gap": string
+            }
+          },
+          "collapsible": {
+            "space": {
+              "left": string,
+              "right": string,
+              "y": string,
+              "gap": string
+            }
+          },
+          "icon": {
+            "size": {
+              "height": string,
+              "width": string
+            }
+          },
+          "global": {
+            "gap": string
+          }
+        },
+        "title": {
+          "typography": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          }
+        },
+        "subItem": {
+          "default": {
+            "space": {
+              "left": string,
+              "right": string,
+              "y": string
+            }
+          },
+          "mobile": {
+            "space": {
+              "left": string,
+              "right": string,
+              "y": string,
+              "gap": string
+            },
+            "typography": {
+              "default": string,
+              "hover": string,
+              "active": string
+            }
+          },
+          "radii": {
+            "all": string
+          },
+          "typography": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string
+          }
+        },
+        "dragControl": {
+          "separator": {
+            "size": {
+              "height": string
+            }
+          }
+        }
+      },
+      "main": {
+        "color": {
+          "background": {
+            "default": string
+          },
+          "text": {
+            "default": string,
+            "muted": string
+          },
+          "stroke": {
+            "default": string
+          }
+        },
+        "navigation": {
+          "item": {
+            "color": {
+              "background": {
+                "active": string,
+                "hover": string,
+                "default": string
+              },
+              "text": {
+                "default": string,
+                "hover": string,
+                "active": string,
+                "muted": string,
+                "disabled": string
+              },
+              "icon": {
+                "default": string,
+                "disabled": string
+              }
+            }
+          },
+          "title": {
+            "color": {
+              "default": string,
+              "hover": string,
+              "active": string
+            }
+          },
+          "subItem": {
+            "color": {
+              "text": {
+                "default": string,
+                "disabled": string,
+                "hover": string,
+                "active": string
+              },
+              "background": {
+                "default": string,
+                "disabled": string,
+                "hover": string,
+                "active": string
+              },
+              "icon": {
+                "default": string,
+                "disabled": string
+              }
+            }
+          },
+          "dragControl": {
+            "separator": {
+              "color": {
+                "default": string
+              }
+            }
+          }
+        }
+      },
+      "sqlSidebar": {
+        "color": {
+          "background": {
+            "default": string
+          },
+          "stroke": {
+            "default": string
+          }
+        },
+        "navigation": {
+          "item": {
+            "color": {
+              "background": {
+                "active": string,
+                "hover": string,
+                "default": string
+              },
+              "text": {
+                "default": string,
+                "hover": string,
+                "active": string,
+                "muted": string,
+                "disabled": string
+              },
+              "icon": {
+                "default": string,
+                "disabled": string
+              }
+            }
+          },
+          "subItem": {
+            "color": {
+              "text": {
+                "disabled": string,
+                "default": string,
+                "hover": string,
+                "active": string
+              },
+              "background": {
+                "default": string,
+                "hover": string,
+                "active": string
+              }
+            }
+          },
+          "title": {
+            "color": {
+              "default": string,
+              "hover": string,
+              "active": string
+            }
+          },
+          "dragControl": {
+            "separator": {
+              "color": {
+                "default": string
+              }
+            }
+          }
+        }
+      }
+    },
+    "spacer": {
+      "horizontal": {
+        "space": {
+          "y": {
+            "xs": string,
+            "sm": string,
+            "md": string,
+            "ml": string,
+            "lg": string,
+            "xl": string,
+            "xxl": string
+          },
+          "x": {
+            "all": string
+          }
+        }
+      }
+    },
+    "stepper": {
+      "vertical": {
+        "numbered": {
+          "connector": {
+            "size": {
+              "width": string
+            },
+            "stroke": {
+              "default": string
+            },
+            "color": {
+              "stroke": {
+                "incomplete": string,
+                "complete": string,
+                "active": string
+              }
+            }
+          },
+          "typography": {
+            "title": {
+              "default": string
+            }
+          },
+          "step": {
+            "typography": {
               number: {
-                default: string;
-              };
-            };
-            size: {
-              height: string;
-              width: string;
-              icon: {
-                height: string;
-                width: string;
-              };
-            };
-            stroke: {
-              default: string;
-            };
-            radii: {
-              default: string;
-            };
-            color: {
-              stroke: {
-                incomplete: string;
-                complete: string;
-                active: string;
-              };
-              background: {
-                incomplete: string;
-                complete: string;
-                active: string;
-              };
-              icon: {
-                incomplete: string;
-                complete: string;
-                active: string;
-              };
-            };
-          };
-          content: {
-            space: {
-              gap: {
-                x: string;
-                y: string;
-              };
-              left: string;
-              bottom: {
-                default: string;
-                active: string;
-              };
-            };
-          };
-          color: {
-            title: {
-              incomplete: string;
-              complete: string;
-              active: string;
-            };
-          };
-        };
-        bulleted: {
-          connector: {
-            size: {
-              width: string;
-            };
-            stroke: {
-              default: string;
-            };
-            color: {
-              stroke: {
-                incomplete: string;
-                complete: string;
-                active: string;
-              };
-            };
-          };
-          step: {
-            size: {
-              height: string;
-              width: string;
-              icon: {
-                height: string;
-                width: string;
-              };
-            };
-            radii: {
-              default: string;
-            };
-            stroke: {
-              default: string;
-            };
-            color: {
-              stroke: {
-                incomplete: string;
-                complete: string;
-                active: string;
-              };
-              background: {
-                incomplete: string;
-                complete: string;
-                active: string;
-              };
-              icon: {
-                incomplete: string;
-                complete: string;
-                active: string;
-              };
-            };
-          };
-          typography: {
-            title: {
-              default: string;
-            };
-          };
-          content: {
-            space: {
-              gap: {
-                x: string;
-                y: string;
-              };
-              left: string;
-              bottom: {
-                default: string;
-                active: string;
-              };
-            };
-          };
-          color: {
-            title: {
-              incomplete: string;
-              complete: string;
-              active: string;
-            };
-          };
-        };
-      };
-    };
-    switch: {
-      space: {
-        gap: string;
-      };
-      radii: {
-        all: string;
-      };
-      size: {
-        width: string;
-        height: string;
-      };
-      typography: {
-        label: {
-          default: string;
-          hover: string;
-          active: string;
-          disabled: string;
-        };
-      };
-      color: {
-        background: {
-          default: string;
-          active: string;
-          disabled: string;
-        };
-        stroke: {
-          default: string;
-          active: string;
-          disabled: string;
-        };
-        indicator: {
-          default: string;
-          active: string;
-          disabled: string;
-        };
-      };
-    };
-    table: {
-      header: {
-        title: {
-          default: string;
-        };
-        cell: {
-          space: {
-            md: {
-              y: string;
-              x: string;
-            };
-            sm: {
-              y: string;
-              x: string;
-            };
-          };
-        };
-        color: {
-          background: {
-            default: string;
-            hover: string;
-            active: string;
-          };
-          title: {
-            default: string;
-          };
-          icon: {
-            default: string;
-          };
-          checkbox: {
-            background: {
-              default: string;
-            };
-            border: {
-              default: string;
-            };
-          };
-        };
-      };
-      cell: {
-        text: {
-          default: string;
-        };
-        label: {
-          default: string;
-        };
-        stroke: string;
-      };
-      radii: {
-        all: string;
-      };
-      body: {
-        cell: {
-          space: {
-            md: {
-              y: string;
-              x: string;
-            };
-            sm: {
-              y: string;
-              x: string;
-            };
-          };
-        };
-      };
-      mobile: {
-        cell: {
-          space: {
-            y: string;
-            x: string;
-            gap: string;
-          };
-        };
-      };
-      row: {
-        color: {
-          background: {
-            default: string;
-            hover: string;
-            active: string;
-          };
-          stroke: {
-            default: string;
-          };
-          text: {
-            default: string;
-            disabled: string;
-          };
-          link: {
-            default: string;
-          };
-          label: {
-            default: string;
-          };
-        };
-      };
-      global: {
-        color: {
-          stroke: {
-            default: string;
-          };
-          background: {
-            default: string;
-          };
-        };
-      };
-    };
-    tabs: {
-      space: {
-        y: string;
-        x: string;
-      };
-      radii: {
-        all: string;
-      };
-      typography: {
-        label: {
-          default: string;
-          hover: string;
-          active: string;
-        };
-      };
-      basic: {
-        strokeWidth: {
-          default: string;
-          hover: string;
-          active: string;
-          global: string;
-        };
-        color: {
-          background: {
-            default: string;
-            hover: string;
-            active: string;
-          };
-          text: {
-            default: string;
-            hover: string;
-            active: string;
-          };
-          stroke: {
-            default: string;
-            hover: string;
-            active: string;
-          };
-          global: {
-            default: string;
-          };
-        };
-      };
-      fileTabs: {
-        icon: {
-          size: {
-            height: string;
-            width: string;
-          };
-        };
-        space: {
-          y: string;
-          x: string;
-          gap: string;
-        };
-        typography: {
-          label: {
-            default: string;
-            hover: string;
-            active: string;
-          };
-        };
-        radii: {
-          all: string;
-        };
-        color: {
-          background: {
-            default: string;
-            hover: string;
-            active: string;
-          };
-          text: {
-            default: string;
-            hover: string;
-            active: string;
-          };
-          stroke: {
-            default: string;
-            hover: string;
-            active: string;
-          };
-          closeButton: {
-            background: {
-              default: string;
-              hover: string;
-            };
-          };
-        };
-      };
-    };
-    toast: {
-      icon: {
-        size: {
-          height: string;
-          width: string;
-        };
-      };
-      space: {
-        title: {
-          gap: string;
-        };
-        y: string;
-        x: string;
-        gap: string;
-      };
-      radii: {
-        all: string;
-      };
-      shadow: string;
-      typography: {
-        title: {
-          default: string;
-        };
-        description: {
-          default: string;
-        };
-      };
-      size: {
-        width: string;
-      };
-      color: {
-        title: {
-          default: string;
-        };
-        description: {
-          default: string;
-        };
-        stroke: {
-          default: string;
-        };
-        icon: {
-          default: string;
-          success: string;
-          warning: string;
-          danger: string;
-        };
-      };
-    };
-    tooltip: {
-      radii: {
-        all: string;
-      };
-      space: {
-        x: string;
-        y: string;
-      };
-      typography: {
-        label: {
-          default: string;
-        };
-      };
-      color: {
-        background: {
-          default: string;
-        };
-        label: {
-          default: string;
-        };
-      };
-    };
-    dialog: {
-      space: {
-        y: string;
-        x: string;
-        gap: string;
-      };
-      title: {
-        space: {
-          gap: string;
-        };
-      };
-      radii: {
-        all: string;
-      };
-      shadow: {
-        default: string;
-      };
-      stroke: {
-        default: string;
-      };
-      typography: {
-        title: {
-          default: string;
-        };
-        description: {
-          default: string;
-        };
-      };
-      color: {
-        background: {
-          default: string;
-        };
-        title: {
-          default: string;
-        };
-        description: {
-          default: string;
-        };
-        opaqueBackground: {
-          default: string;
-        };
-      };
-    };
-    link: {
-      space: {
-        md: {
-          gap: string;
-        };
-        sm: {
-          gap: string;
-        };
-      };
-      icon: {
-        size: {
-          sm: {
-            height: string;
-            width: string;
-          };
-          md: {
-            height: string;
-            width: string;
-          };
-        };
-      };
-    };
-    flyout: {
-      space: {
-        default: {
-          x: string;
-          y: string;
-          gap: string;
-          top: string;
-          content: {
-            x: string;
-            y: string;
-            "row-gap": string;
-            "column-gap": string;
-          };
-        };
-        inline: {
-          x: string;
-          y: string;
-          gap: string;
-          top: string;
-          content: {
-            x: string;
-            y: string;
-            "row-gap": string;
-            "column-gap": string;
-          };
-        };
-      };
-      shadow: {
-        default: string;
-        reverse: string;
-      };
-      size: {
-        default: {
-          width: string;
-          height: string;
-        };
-        wide: {
-          width: string;
-          height: string;
-        };
-        narrow: {
-          width: string;
-          height: string;
-        };
-        widest: {
-          width: string;
-          height: string;
-        };
-      };
-      typography: {
-        default: {
-          description: {
-            default: string;
-          };
-          title: {
-            default: string;
-          };
-        };
-        inline: {
-          description: {
-            default: string;
-          };
-          title: {
-            default: string;
-          };
-        };
-      };
-      color: {
-        background: {
-          default: string;
-        };
-        title: {
-          default: string;
-        };
-        description: {
-          default: string;
-        };
-        opaqueBackground: {
-          default: string;
-        };
-        stroke: {
-          default: string;
-        };
-      };
-    };
-    grid: {
-      header: {
-        cell: {
-          space: {
-            y: string;
-            x: string;
-          };
-          size: {
-            height: string;
-          };
-          color: {
-            background: {
-              default: string;
-              selectIndirect: string;
-              selectDirect: string;
-            };
-            title: {
-              default: string;
-              selectIndirect: string;
-              selectDirect: string;
-            };
-            stroke: {
-              default: string;
-              selectIndirect: string;
-              selectDirect: string;
-            };
-          };
-        };
-        title: {
-          default: string;
-        };
-      };
-      body: {
-        cell: {
-          space: {
-            y: string;
-            x: string;
-          };
-          size: {
-            height: string;
-          };
-          color: {
-            background: {
-              default: string;
-              selectIndirect: string;
-              selectDirect: string;
-            };
-            stroke: {
-              default: string;
-              selectIndirect: string;
-              selectDirect: string;
-            };
-            text: {
-              default: string;
-              selectIndirect: string;
-              selectDirect: string;
-            };
-          };
-        };
-      };
-      cell: {
-        text: {
-          default: string;
-        };
-      };
-      radii: {
-        none: string;
-        sm: string;
-        md: string;
-        lg: string;
-      };
-      global: {
-        color: {
-          stroke: {
-            default: string;
-          };
-          background: {
-            default: string;
-          };
-        };
-      };
-    };
-    container: {
-      space: {
-        none: string;
-        xxs: string;
-        xs: string;
-        sm: string;
-        md: string;
-        lg: string;
-        xl: string;
-        xxl: string;
-      };
-      gap: {
-        none: string;
-        xxs: string;
-        xs: string;
-        sm: string;
-        md: string;
-        lg: string;
-        xl: string;
-        xxl: string;
-      };
-    };
-    gridContainer: {
-      gap: {
-        none: string;
-        xxs: string;
-        xs: string;
-        sm: string;
-        md: string;
-        lg: string;
-        xl: string;
-        xxl: string;
-        unset: string;
-      };
-    };
-    icon: {
-      space: {
-        xs: {
-          all: string;
-        };
-        sm: {
-          all: string;
-        };
-        md: {
-          all: string;
-        };
-        lg: {
-          all: string;
-        };
-        xl: {
-          all: string;
-        };
-        xxl: {
-          all: string;
-        };
-      };
-      color: {
-        background: {
-          default: string;
-          success: string;
-          neutral: string;
-          danger: string;
-          info: string;
-          warning: string;
-        };
-        text: {
-          default: string;
-          success: string;
-          neutral: string;
-          danger: string;
-          info: string;
-          warning: string;
-        };
-        stroke: {
-          default: string;
-          success: string;
-          neutral: string;
-          danger: string;
-          info: string;
-          warning: string;
-        };
-      };
-    };
-    datePicker: {
-      dateOption: {
-        space: {
-          gap: string;
-        };
-        radii: {
-          default: string;
-          range: string;
-        };
-        stroke: string;
-        size: {
-          height: string;
-          width: string;
-        };
-        typography: {
-          label: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-            range: string;
-          };
-        };
-        color: {
-          label: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-            range: string;
-          };
-          background: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-            range: string;
-          };
-          stroke: {
-            default: string;
-            hover: string;
-            active: string;
-            disabled: string;
-            range: string;
-          };
-        };
-      };
-      space: {
-        gap: string;
-      };
-      typography: {
-        daytitle: {
-          default: string;
-        };
-        title: {
-          default: string;
-        };
-      };
-      color: {
-        title: {
-          default: string;
-        };
-        daytitle: {
-          default: string;
-        };
-      };
-    };
-    global: {
-      color: {
-        background: {
-          default: string;
-          muted: string;
-        };
-        text: {
-          default: string;
-          muted: string;
-          disabled: string;
-          link: {
-            default: string;
-            hover: string;
-          };
-          danger: string;
-        };
-        stroke: {
-          default: string;
-          muted: string;
-          intense: string;
-        };
-        accent: {
-          default: string;
-        };
-        outline: {
-          default: string;
-        };
-        shadow: {
-          default: string;
-        };
-        title: {
-          default: string;
-          muted: string;
-        };
-      };
-    };
-    feedback: {
-      color: {
-        info: {
-          background: string;
-          foreground: string;
-        };
-        success: {
-          background: string;
-          foreground: string;
-        };
-        warning: {
-          background: string;
-          foreground: string;
-        };
-        danger: {
-          background: string;
-          foreground: string;
-        };
-        neutral: {
-          background: string;
-          foreground: string;
-          stroke: string;
-        };
-      };
-    };
-    storybook: {
-      global: {
-        background: string;
-      };
-    };
-    chart: {
-      bars: {
-        color: {
-          blue: string;
-          orange: string;
-          green: string;
-          fuchsia: string;
-          yellow: string;
-          violet: string;
-          babyblue: string;
-          red: string;
-          teal: string;
-          sunrise: string;
-          slate: string;
-        };
-      };
-      color: {
-        default: {
-          blue: string;
-          orange: string;
-          green: string;
-          fuchsia: string;
-          yellow: string;
-          violet: string;
-          babyblue: string;
-          red: string;
-          teal: string;
-          sunrise: string;
-          slate: string;
-        };
-        label: {
-          default: string;
-          deselected: string;
-        };
-      };
-    };
-    serviceCard: {
-      color: {
-        background: {
-          default: string;
-          hover: string;
-        };
-        stroke: {
-          default: string;
-          hover: string;
-        };
-      };
-    };
-  };
-  transition: {
-    default: string;
-    duration: {
-      slow: string;
-      smooth: string;
-      medium: string;
-      fast: string;
-    };
-    delay: {
-      slow: string;
-      fast: string;
-    };
-    function: {
-      ease: string;
-      "ease-in": string;
-      "ease-in-out": string;
-      linear: string;
-    };
-  };
-  grid: {
-    header: {
-      cell: {
-        borderWidth: {
-          default: string;
-          selectIndirect: string;
-          selectDirect: string;
-        };
-      };
-    };
-    body: {
-      cell: {
-        borderWidth: {
-          default: string;
-          selectIndirect: string;
-          selectDirect: string;
-        };
-      };
-    };
-  };
-  name: string;
-  global: {
-    color: {
-      background: {
-        default: string;
-        muted: string;
-        sidebar: string;
-        split: string;
-        muted_a: string;
-      };
-      text: {
-        default: string;
-        muted: string;
-        disabled: string;
-        link: {
-          default: string;
-          hover: string;
-        };
-      };
-      stroke: {
-        default: string;
-        muted: string;
-        intense: string;
-        split: string;
-      };
-      accent: {
-        default: string;
-      };
-      outline: {
-        default: string;
-      };
-      shadow: {
-        default: string;
-      };
-      feedback: {
-        info: {
-          background: string;
-          foreground: string;
-        };
-        success: {
-          background: string;
-          foreground: string;
-        };
-        warning: {
-          background: string;
-          foreground: string;
-        };
-        danger: {
-          background: string;
-          foreground: string;
-        };
-        neutral: {
-          background: string;
-          foreground: string;
-          stroke: string;
-        };
-      };
-      chart: {
-        bars: {
-          blue: string;
-          orange: string;
-          green: string;
-          fuchsia: string;
-          yellow: string;
-          violet: string;
-          babyblue: string;
-          danger: string;
-          teal: string;
-          sunrise: string;
-          slate: string;
-          red: string;
-        };
-        default: {
-          blue: string;
-          orange: string;
-          green: string;
-          fuchsia: string;
-          yellow: string;
-          violet: string;
-          babyblue: string;
-          danger: string;
-          teal: string;
-          sunrise: string;
-          slate: string;
-          red: string;
-        };
-        label: {
-          default: string;
-          deselected: string;
-        };
-      };
-      iconButton: {
-        badge: {
-          foreground: string;
-          background: string;
-        };
-      };
-      icon: {
-        background: string;
-      };
-      gradients: {
-        yellowToBlack: string;
-        whiteToBlack: string;
-      };
-    };
-  };
-  palette: {
-    brand: {
-      "50": string;
-      "100": string;
-      "200": string;
-      "300": string;
-      "400": string;
-      "500": string;
-      "600": string;
-      "700": string;
-      "800": string;
-      "900": string;
-      base: string;
-    };
-    neutral: {
-      "0": string;
-      "100": string;
-      "200": string;
-      "300": string;
-      "400": string;
-      "500": string;
-      "600": string;
-      "650": string;
-      "700": string;
-      "712": string;
-      "725": string;
-      "750": string;
-      "800": string;
-      "900": string;
-      base: string;
-    };
-    slate: {
-      "25": string;
-      "50": string;
-      "100": string;
-      "200": string;
-      "300": string;
-      "400": string;
-      "500": string;
-      "600": string;
-      "700": string;
-      "800": string;
-      "900": string;
-      base: string;
-      "50a": string;
-    };
-    indigo: {
-      "50": string;
-      "100": string;
-      "200": string;
-      "300": string;
-      "400": string;
-      "500": string;
-      "600": string;
-      "700": string;
-      "800": string;
-      "900": string;
-      base: string;
-    };
-    info: {
-      "50": string;
-      "100": string;
-      "200": string;
-      "300": string;
-      "400": string;
-      "500": string;
-      "600": string;
-      "650": string;
-      "700": string;
-      "800": string;
-      "900": string;
-      base: string;
-    };
-    success: {
-      "50": string;
-      "100": string;
-      "200": string;
-      "300": string;
-      "400": string;
-      "500": string;
-      "600": string;
-      "700": string;
-      "800": string;
-      "850": string;
-      "900": string;
-      base: string;
-    };
-    warning: {
-      "50": string;
-      "100": string;
-      "200": string;
-      "300": string;
-      "400": string;
-      "500": string;
-      "600": string;
-      "700": string;
-      "800": string;
-      "900": string;
-      base: string;
-    };
-    danger: {
-      "50": string;
-      "100": string;
-      "200": string;
-      "300": string;
-      "400": string;
-      "500": string;
-      "600": string;
-      "700": string;
-      "800": string;
-      "900": string;
-      base: string;
-    };
-    gradients: {
-      base: string;
-      yellowToblack: string;
-      whiteToblack: string;
-      transparent: string;
-    };
-    utility: {
-      transparent: string;
-    };
-    teal: {
-      "50": string;
-      "100": string;
-      "200": string;
-      "300": string;
-      "400": string;
-      "500": string;
-      "600": string;
-      "700": string;
-      "800": string;
-      "850": string;
-      "900": string;
-    };
-    violet: {
-      "50": string;
-      "100": string;
-      "200": string;
-      "300": string;
-      "400": string;
-      "500": string;
-      "600": string;
-      "700": string;
-      "800": string;
-      "850": string;
-      "900": string;
-    };
-    fuchsia: {
-      "50": string;
-      "100": string;
-      "200": string;
-      "300": string;
-      "400": string;
-      "500": string;
-      "600": string;
-      "700": string;
-      "800": string;
-      "850": string;
-      "900": string;
-    };
-    sunrise: {
-      "50": string;
-      "100": string;
-      "200": string;
-      "300": string;
-      "400": string;
-      "500": string;
-      "600": string;
-      "700": string;
-      "800": string;
-      "900": string;
-    };
-    babyblue: {
-      "50": string;
-      "100": string;
-      "200": string;
-      "300": string;
-      "400": string;
-      "500": string;
-      "600": string;
-      "700": string;
-      "800": string;
-      "900": string;
-    };
-  };
-  sizes: {
-    "0": string;
-    "1": string;
-    "2": string;
-    "3": string;
-    "4": string;
-    "5": string;
-    "6": string;
-    "7": string;
-    "8": string;
-    "9": string;
-    "10": string;
-    "11": string;
-  };
-  typography: {
-    font: {
-      families: {
-        regular: string;
-        mono: string;
-        display: string;
-      };
-      weights: {
-        "1": string;
-        "2": string;
-        "3": string;
-        "4": string;
-      };
-      sizes: {
-        "0": string;
-        "1": string;
-        "2": string;
-        "3": string;
-        "4": string;
-        "6": string;
-        base: string;
-      };
+                "default": string
+              }
+            },
+            "size": {
+              "height": string,
+              "width": string,
+              "icon": {
+                "height": string,
+                "width": string
+              }
+            },
+            "stroke": {
+              "default": string
+            },
+            "radii": {
+              "default": string
+            },
+            "color": {
+              "stroke": {
+                "incomplete": string,
+                "complete": string,
+                "active": string
+              },
+              "background": {
+                "incomplete": string,
+                "complete": string,
+                "active": string
+              },
+              "icon": {
+                "incomplete": string,
+                "complete": string,
+                "active": string
+              }
+            }
+          },
+          "content": {
+            "space": {
+              "gap": {
+                "x": string,
+                "y": string
+              },
+              "left": string,
+              "bottom": {
+                "default": string,
+                "active": string
+              }
+            }
+          },
+          "color": {
+            "title": {
+              "incomplete": string,
+              "complete": string,
+              "active": string
+            }
+          }
+        },
+        "bulleted": {
+          "connector": {
+            "size": {
+              "width": string
+            },
+            "stroke": {
+              "default": string
+            },
+            "color": {
+              "stroke": {
+                "incomplete": string,
+                "complete": string,
+                "active": string
+              }
+            }
+          },
+          "step": {
+            "size": {
+              "height": string,
+              "width": string,
+              "icon": {
+                "height": string,
+                "width": string
+              }
+            },
+            "radii": {
+              "default": string
+            },
+            "stroke": {
+              "default": string
+            },
+            "color": {
+              "stroke": {
+                "incomplete": string,
+                "complete": string,
+                "active": string
+              },
+              "background": {
+                "incomplete": string,
+                "complete": string,
+                "active": string
+              },
+              "icon": {
+                "incomplete": string,
+                "complete": string,
+                "active": string
+              }
+            }
+          },
+          "typography": {
+            "title": {
+              "default": string
+            }
+          },
+          "content": {
+            "space": {
+              "gap": {
+                "x": string,
+                "y": string
+              },
+              "left": string,
+              "bottom": {
+                "default": string,
+                "active": string
+              }
+            }
+          },
+          "color": {
+            "title": {
+              "incomplete": string,
+              "complete": string,
+              "active": string
+            }
+          }
+        }
+      }
+    },
+    "switch": {
+      "space": {
+        "gap": string
+      },
+      "radii": {
+        "all": string
+      },
+      "size": {
+        "width": string,
+        "height": string
+      },
+      "typography": {
+        "label": {
+          "default": string,
+          "hover": string,
+          "active": string,
+          "disabled": string
+        }
+      },
+      "color": {
+        "background": {
+          "default": string,
+          "active": string,
+          "disabled": string
+        },
+        "stroke": {
+          "default": string,
+          "active": string,
+          "disabled": string
+        },
+        "indicator": {
+          "default": string,
+          "active": string,
+          "disabled": string
+        }
+      }
+    },
+    "table": {
+      "header": {
+        "title": {
+          "default": string
+        },
+        "cell": {
+          "space": {
+            "md": {
+              "y": string,
+              "x": string
+            },
+            "sm": {
+              "y": string,
+              "x": string
+            }
+          }
+        },
+        "color": {
+          "background": {
+            "default": string,
+            "hover": string,
+            "active": string
+          },
+          "title": {
+            "default": string
+          },
+          "icon": {
+            "default": string
+          },
+          "checkbox": {
+            "background": {
+              "default": string
+            },
+            "border": {
+              "default": string
+            }
+          }
+        }
+      },
+      "cell": {
+        "text": {
+          "default": string
+        },
+        "label": {
+          "default": string
+        },
+        "stroke": string
+      },
+      "radii": {
+        "all": string
+      },
+      "body": {
+        "cell": {
+          "space": {
+            "md": {
+              "y": string,
+              "x": string
+            },
+            "sm": {
+              "y": string,
+              "x": string
+            }
+          }
+        }
+      },
+      "mobile": {
+        "cell": {
+          "space": {
+            "y": string,
+            "x": string,
+            "gap": string
+          }
+        }
+      },
+      "row": {
+        "color": {
+          "background": {
+            "default": string,
+            "hover": string,
+            "active": string
+          },
+          "stroke": {
+            "default": string
+          },
+          "text": {
+            "default": string,
+            "disabled": string
+          },
+          "link": {
+            "default": string
+          },
+          "label": {
+            "default": string
+          }
+        }
+      },
+      "global": {
+        "color": {
+          "stroke": {
+            "default": string
+          },
+          "background": {
+            "default": string
+          }
+        }
+      }
+    },
+    "tabs": {
+      "space": {
+        "y": string,
+        "x": string
+      },
+      "radii": {
+        "all": string
+      },
+      "typography": {
+        "label": {
+          "default": string,
+          "hover": string,
+          "active": string
+        }
+      },
+      "basic": {
+        "strokeWidth": {
+          "default": string,
+          "hover": string,
+          "active": string,
+          "global": string
+        },
+        "color": {
+          "background": {
+            "default": string,
+            "hover": string,
+            "active": string
+          },
+          "text": {
+            "default": string,
+            "hover": string,
+            "active": string
+          },
+          "stroke": {
+            "default": string,
+            "hover": string,
+            "active": string
+          },
+          "global": {
+            "default": string
+          }
+        }
+      },
+      "fileTabs": {
+        "icon": {
+          "size": {
+            "height": string,
+            "width": string
+          }
+        },
+        "space": {
+          "y": string,
+          "x": string,
+          "gap": string
+        },
+        "typography": {
+          "label": {
+            "default": string,
+            "hover": string,
+            "active": string
+          }
+        },
+        "radii": {
+          "all": string
+        },
+        "color": {
+          "background": {
+            "default": string,
+            "hover": string,
+            "active": string
+          },
+          "text": {
+            "default": string,
+            "hover": string,
+            "active": string
+          },
+          "stroke": {
+            "default": string,
+            "hover": string,
+            "active": string
+          },
+          "closeButton": {
+            "background": {
+              "default": string,
+              "hover": string
+            }
+          }
+        }
+      }
+    },
+    "toast": {
+      "icon": {
+        "size": {
+          "height": string,
+          "width": string
+        }
+      },
+      "space": {
+        "title": {
+          "gap": string
+        },
+        "y": string,
+        "x": string,
+        "gap": string
+      },
+      "radii": {
+        "all": string
+      },
+      "shadow": string,
+      "typography": {
+        "title": {
+          "default": string
+        },
+        "description": {
+          "default": string
+        }
+      },
+      "size": {
+        "width": string
+      },
+      "color": {
+        "title": {
+          "default": string
+        },
+        "description": {
+          "default": string
+        },
+        "stroke": {
+          "default": string
+        },
+        "icon": {
+          "default": string,
+          "success": string,
+          "warning": string,
+          "danger": string
+        }
+      }
+    },
+    "tooltip": {
+      "radii": {
+        "all": string
+      },
+      "space": {
+        "x": string,
+        "y": string
+      },
+      "typography": {
+        "label": {
+          "default": string
+        }
+      },
+      "color": {
+        "background": {
+          "default": string
+        },
+        "label": {
+          "default": string
+        }
+      }
+    },
+    "dialog": {
+      "space": {
+        "y": string,
+        "x": string,
+        "gap": string
+      },
+      "title": {
+        "space": {
+          "gap": string
+        }
+      },
+      "radii": {
+        "all": string
+      },
+      "shadow": {
+        "default": string
+      },
+      "stroke": {
+        "default": string
+      },
+      "typography": {
+        "title": {
+          "default": string
+        },
+        "description": {
+          "default": string
+        }
+      },
+      "color": {
+        "background": {
+          "default": string
+        },
+        "title": {
+          "default": string
+        },
+        "description": {
+          "default": string
+        },
+        "opaqueBackground": {
+          "default": string
+        }
+      }
+    },
+    "link": {
+      "space": {
+        "md": {
+          "gap": string
+        },
+        "sm": {
+          "gap": string
+        }
+      },
+      "icon": {
+        "size": {
+          "sm": {
+            "height": string,
+            "width": string
+          },
+          "md": {
+            "height": string,
+            "width": string
+          }
+        }
+      }
+    },
+    "flyout": {
+      "space": {
+        "default": {
+          "x": string,
+          "y": string,
+          "gap": string,
+          "top": string,
+          "content": {
+            "x": string,
+            "y": string,
+            "row-gap": string,
+            "column-gap": string
+          }
+        },
+        "inline": {
+          "x": string,
+          "y": string,
+          "gap": string,
+          "top": string,
+          "content": {
+            "x": string,
+            "y": string,
+            "row-gap": string,
+            "column-gap": string
+          }
+        }
+      },
+      "shadow": {
+        "default": string,
+        "reverse": string
+      },
+      "size": {
+        "default": {
+          "width": string,
+          "height": string
+        },
+        "wide": {
+          "width": string,
+          "height": string
+        },
+        "narrow": {
+          "width": string,
+          "height": string
+        },
+        "widest": {
+          "width": string,
+          "height": string
+        }
+      },
+      "typography": {
+        "default": {
+          "description": {
+            "default": string
+          },
+          "title": {
+            "default": string
+          }
+        },
+        "inline": {
+          "description": {
+            "default": string
+          },
+          "title": {
+            "default": string
+          }
+        }
+      },
+      "color": {
+        "background": {
+          "default": string
+        },
+        "title": {
+          "default": string
+        },
+        "description": {
+          "default": string
+        },
+        "opaqueBackground": {
+          "default": string
+        },
+        "stroke": {
+          "default": string
+        }
+      }
+    },
+    "grid": {
+      "header": {
+        "cell": {
+          "space": {
+            "y": string,
+            "x": string
+          },
+          "size": {
+            "height": string
+          },
+          "color": {
+            "background": {
+              "default": string,
+              "selectIndirect": string,
+              "selectDirect": string
+            },
+            "title": {
+              "default": string,
+              "selectIndirect": string,
+              "selectDirect": string
+            },
+            "stroke": {
+              "default": string,
+              "selectIndirect": string,
+              "selectDirect": string
+            }
+          }
+        },
+        "title": {
+          "default": string
+        }
+      },
+      "body": {
+        "cell": {
+          "space": {
+            "y": string,
+            "x": string
+          },
+          "size": {
+            "height": string
+          },
+          "color": {
+            "background": {
+              "default": string,
+              "selectIndirect": string,
+              "selectDirect": string
+            },
+            "stroke": {
+              "default": string,
+              "selectIndirect": string,
+              "selectDirect": string
+            },
+            "text": {
+              "default": string,
+              "selectIndirect": string,
+              "selectDirect": string
+            }
+          }
+        }
+      },
+      "cell": {
+        "text": {
+          "default": string
+        }
+      },
+      "radii": {
+        "none": string,
+        "sm": string,
+        "md": string,
+        "lg": string
+      },
+      "global": {
+        "color": {
+          "stroke": {
+            "default": string
+          },
+          "background": {
+            "default": string
+          }
+        }
+      }
+    },
+    "container": {
+      "space": {
+        "none": string,
+        "xxs": string,
+        "xs": string,
+        "sm": string,
+        "md": string,
+        "lg": string,
+        "xl": string,
+        "xxl": string
+      },
+      "gap": {
+        "none": string,
+        "xxs": string,
+        "xs": string,
+        "sm": string,
+        "md": string,
+        "lg": string,
+        "xl": string,
+        "xxl": string
+      }
+    },
+    "gridContainer": {
+      "gap": {
+        "none": string,
+        "xxs": string,
+        "xs": string,
+        "sm": string,
+        "md": string,
+        "lg": string,
+        "xl": string,
+        "xxl": string,
+        "unset": string
+      }
+    },
+    "icon": {
+      "space": {
+        "xs": {
+          "all": string
+        },
+        "sm": {
+          "all": string
+        },
+        "md": {
+          "all": string
+        },
+        "lg": {
+          "all": string
+        },
+        "xl": {
+          "all": string
+        },
+        "xxl": {
+          "all": string
+        }
+      },
+      "color": {
+        "background": {
+          "default": string,
+          "success": string,
+          "neutral": string,
+          "danger": string,
+          "info": string,
+          "warning": string
+        },
+        "text": {
+          "default": string,
+          "success": string,
+          "neutral": string,
+          "danger": string,
+          "info": string,
+          "warning": string
+        },
+        "stroke": {
+          "default": string,
+          "success": string,
+          "neutral": string,
+          "danger": string,
+          "info": string,
+          "warning": string
+        }
+      }
+    },
+    "datePicker": {
+      "dateOption": {
+        "space": {
+          "gap": string
+        },
+        "radii": {
+          "default": string,
+          "range": string
+        },
+        "stroke": string,
+        "size": {
+          "height": string,
+          "width": string
+        },
+        "typography": {
+          "label": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string,
+            "range": string
+          }
+        },
+        "color": {
+          "label": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string,
+            "range": string
+          },
+          "background": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string,
+            "range": string
+          },
+          "stroke": {
+            "default": string,
+            "hover": string,
+            "active": string,
+            "disabled": string,
+            "range": string
+          }
+        }
+      },
+      "space": {
+        "gap": string
+      },
+      "typography": {
+        "daytitle": {
+          "default": string
+        },
+        "title": {
+          "default": string
+        }
+      },
+      "color": {
+        "title": {
+          "default": string
+        },
+        "daytitle": {
+          "default": string
+        }
+      }
+    },
+    "global": {
+      "color": {
+        "background": {
+          "default": string,
+          "muted": string
+        },
+        "text": {
+          "default": string,
+          "muted": string,
+          "disabled": string,
+          "link": {
+            "default": string,
+            "hover": string
+          },
+          "danger": string
+        },
+        "stroke": {
+          "default": string,
+          "muted": string,
+          "intense": string
+        },
+        "accent": {
+          "default": string
+        },
+        "outline": {
+          "default": string
+        },
+        "shadow": {
+          "default": string
+        },
+        "title": {
+          "default": string,
+          "muted": string
+        }
+      }
+    },
+    "feedback": {
+      "color": {
+        "info": {
+          "background": string,
+          "foreground": string
+        },
+        "success": {
+          "background": string,
+          "foreground": string
+        },
+        "warning": {
+          "background": string,
+          "foreground": string
+        },
+        "danger": {
+          "background": string,
+          "foreground": string
+        },
+        "neutral": {
+          "background": string,
+          "foreground": string,
+          "stroke": string
+        }
+      }
+    },
+    "storybook": {
+      "global": {
+        "background": string
+      }
+    },
+    "chart": {
+      "bars": {
+        "color": {
+          "blue": string,
+          "orange": string,
+          "green": string,
+          "fuchsia": string,
+          "yellow": string,
+          "violet": string,
+          "babyblue": string,
+          "red": string,
+          "teal": string,
+          "sunrise": string,
+          "slate": string
+        }
+      },
+      "color": {
+        "default": {
+          "blue": string,
+          "orange": string,
+          "green": string,
+          "fuchsia": string,
+          "yellow": string,
+          "violet": string,
+          "babyblue": string,
+          "red": string,
+          "teal": string,
+          "sunrise": string,
+          "slate": string
+        },
+        "label": {
+          "default": string,
+          "deselected": string
+        }
+      }
+    },
+    "serviceCard": {
+      "color": {
+        "background": {
+          "default": string,
+          "hover": string
+        },
+        "stroke": {
+          "default": string,
+          "hover": string
+        }
+      }
+    }
+  },
+  "transition": {
+    "default": string,
+    "duration": {
+      "slow": string,
+      "smooth": string,
+      "medium": string,
+      "fast": string
+    },
+    "delay": {
+      "slow": string,
+      "fast": string
+    },
+    "function": {
+      "ease": string,
+      "ease-in": string,
+      "ease-in-out": string,
+      "linear": string
+    }
+  },
+  "grid": {
+    "header": {
+      "cell": {
+        "borderWidth": {
+          "default": string,
+          "selectIndirect": string,
+          "selectDirect": string
+        }
+      }
+    },
+    "body": {
+      "cell": {
+        "borderWidth": {
+          "default": string,
+          "selectIndirect": string,
+          "selectDirect": string
+        }
+      }
+    }
+  },
+  "name": string,
+  "global": {
+    "color": {
+      "background": {
+        "default": string,
+        "muted": string,
+        "sidebar": string,
+        "split": string,
+        "muted_a": string
+      },
+      "text": {
+        "default": string,
+        "muted": string,
+        "disabled": string,
+        "link": {
+          "default": string,
+          "hover": string
+        }
+      },
+      "stroke": {
+        "default": string,
+        "muted": string,
+        "intense": string,
+        "split": string
+      },
+      "accent": {
+        "default": string
+      },
+      "outline": {
+        "default": string
+      },
+      "shadow": {
+        "default": string
+      },
+      "feedback": {
+        "info": {
+          "background": string,
+          "foreground": string
+        },
+        "success": {
+          "background": string,
+          "foreground": string
+        },
+        "warning": {
+          "background": string,
+          "foreground": string
+        },
+        "danger": {
+          "background": string,
+          "foreground": string
+        },
+        "neutral": {
+          "background": string,
+          "foreground": string,
+          "stroke": string
+        }
+      },
+      "chart": {
+        "bars": {
+          "blue": string,
+          "orange": string,
+          "green": string,
+          "fuchsia": string,
+          "yellow": string,
+          "violet": string,
+          "babyblue": string,
+          "danger": string,
+          "teal": string,
+          "sunrise": string,
+          "slate": string,
+          "red": string
+        },
+        "default": {
+          "blue": string,
+          "orange": string,
+          "green": string,
+          "fuchsia": string,
+          "yellow": string,
+          "violet": string,
+          "babyblue": string,
+          "danger": string,
+          "teal": string,
+          "sunrise": string,
+          "slate": string,
+          "red": string
+        },
+        "label": {
+          "default": string,
+          "deselected": string
+        }
+      },
+      "iconButton": {
+        "badge": {
+          "foreground": string,
+          "background": string
+        }
+      },
+      "icon": {
+        "background": string
+      },
+      "gradients": {
+        "yellowToBlack": string,
+        "whiteToBlack": string
+      }
+    }
+  },
+  "palette": {
+    "brand": {
+      "50": string,
+      "100": string,
+      "200": string,
+      "300": string,
+      "400": string,
+      "500": string,
+      "600": string,
+      "700": string,
+      "800": string,
+      "900": string,
+      "base": string
+    },
+    "neutral": {
+      "0": string,
+      "100": string,
+      "200": string,
+      "300": string,
+      "400": string,
+      "500": string,
+      "600": string,
+      "650": string,
+      "700": string,
+      "712": string,
+      "725": string,
+      "750": string,
+      "800": string,
+      "900": string,
+      "base": string
+    },
+    "slate": {
+      "25": string,
+      "50": string,
+      "100": string,
+      "200": string,
+      "300": string,
+      "400": string,
+      "500": string,
+      "600": string,
+      "700": string,
+      "800": string,
+      "900": string,
+      "base": string,
+      "50a": string
+    },
+    "indigo": {
+      "50": string,
+      "100": string,
+      "200": string,
+      "300": string,
+      "400": string,
+      "500": string,
+      "600": string,
+      "700": string,
+      "800": string,
+      "900": string,
+      "base": string
+    },
+    "info": {
+      "50": string,
+      "100": string,
+      "200": string,
+      "300": string,
+      "400": string,
+      "500": string,
+      "600": string,
+      "650": string,
+      "700": string,
+      "800": string,
+      "900": string,
+      "base": string
+    },
+    "success": {
+      "50": string,
+      "100": string,
+      "200": string,
+      "300": string,
+      "400": string,
+      "500": string,
+      "600": string,
+      "700": string,
+      "800": string,
+      "850": string,
+      "900": string,
+      "base": string
+    },
+    "warning": {
+      "50": string,
+      "100": string,
+      "200": string,
+      "300": string,
+      "400": string,
+      "500": string,
+      "600": string,
+      "700": string,
+      "800": string,
+      "900": string,
+      "base": string
+    },
+    "danger": {
+      "50": string,
+      "100": string,
+      "200": string,
+      "300": string,
+      "400": string,
+      "500": string,
+      "600": string,
+      "700": string,
+      "800": string,
+      "900": string,
+      "base": string
+    },
+    "gradients": {
+      "base": string,
+      "yellowToblack": string,
+      "whiteToblack": string,
+      "transparent": string
+    },
+    "utility": {
+      "transparent": string
+    },
+    "teal": {
+      "50": string,
+      "100": string,
+      "200": string,
+      "300": string,
+      "400": string,
+      "500": string,
+      "600": string,
+      "700": string,
+      "800": string,
+      "850": string,
+      "900": string
+    },
+    "violet": {
+      "50": string,
+      "100": string,
+      "200": string,
+      "300": string,
+      "400": string,
+      "500": string,
+      "600": string,
+      "700": string,
+      "800": string,
+      "850": string,
+      "900": string
+    },
+    "fuchsia": {
+      "50": string,
+      "100": string,
+      "200": string,
+      "300": string,
+      "400": string,
+      "500": string,
+      "600": string,
+      "700": string,
+      "800": string,
+      "850": string,
+      "900": string
+    },
+    "sunrise": {
+      "50": string,
+      "100": string,
+      "200": string,
+      "300": string,
+      "400": string,
+      "500": string,
+      "600": string,
+      "700": string,
+      "800": string,
+      "900": string
+    },
+    "babyblue": {
+      "50": string,
+      "100": string,
+      "200": string,
+      "300": string,
+      "400": string,
+      "500": string,
+      "600": string,
+      "700": string,
+      "800": string,
+      "900": string
+    }
+  },
+  "sizes": {
+    "0": string,
+    "1": string,
+    "2": string,
+    "3": string,
+    "4": string,
+    "5": string,
+    "6": string,
+    "7": string,
+    "8": string,
+    "9": string,
+    "10": string,
+    "11": string
+  },
+  "typography": {
+    "font": {
+      "families": {
+        "regular": string,
+        "mono": string,
+        "display": string
+      },
+      "weights": {
+        "1": string,
+        "2": string,
+        "3": string,
+        "4": string
+      },
+      "sizes": {
+        "0": string,
+        "1": string,
+        "2": string,
+        "3": string,
+        "4": string,
+        "6": string,
+        "base": string
+      },
       "line-height": {
-        "1": number;
-        "2": number;
-        "3": number;
-        "4": number;
-      };
-    };
-    styles: {
-      product: {
-        titles: {
-          xs: string;
-          sm: string;
-          md: string;
-          lg: string;
-          xl: string;
-          "2xl": string;
-        };
-        text: {
-          normal: {
-            xs: string;
-            sm: string;
-            md: string;
-            lg: string;
-          };
-          medium: {
-            xs: string;
-            sm: string;
-            md: string;
-            lg: string;
-          };
-          semibold: {
-            xs: string;
-            sm: string;
-            md: string;
-            lg: string;
-          };
-          mono: {
-            xs: string;
-            sm: string;
-            md: string;
-            lg: string;
-          };
-          bold: {
-            xs: string;
-            sm: string;
-            md: string;
-            lg: string;
-          };
-        };
-      };
-      brand: {
-        titles: {
-          xs: string;
-          sm: string;
-          md: string;
-          lg: string;
-          xl: string;
-          "2xl": string;
-        };
-      };
-      field: {
-        md: string;
-      };
-    };
-  };
-  border: {
-    radii: {
-      "0": string;
-      "1": string;
-      "2": string;
-      "3": string;
-      full: string;
-    };
-    width: {
-      "1": string;
-      "2": string;
-    };
-  };
-  spaces: {
-    "0": string;
-    "1": string;
-    "2": string;
-    "3": string;
-    "4": string;
-    "5": string;
-    "6": string;
-    "7": string;
-    "8": string;
-  };
-  shadow: {
-    "1": string;
-    "2": string;
-    "3": string;
-    "4": string;
-    "5": string;
-  };
-  breakpoint: {
-    sizes: {
-      sm: string;
-      md: string;
-      lg: string;
-      xl: string;
-      "2xl": string;
-    };
-  };
+        "1": number,
+        "2": number,
+        "3": number,
+        "4": number
+      }
+    },
+    "styles": {
+      "product": {
+        "titles": {
+          "xs": string,
+          "sm": string,
+          "md": string,
+          "lg": string,
+          "xl": string,
+          "2xl": string
+        },
+        "text": {
+          "normal": {
+            "xs": string,
+            "sm": string,
+            "md": string,
+            "lg": string
+          },
+          "medium": {
+            "xs": string,
+            "sm": string,
+            "md": string,
+            "lg": string
+          },
+          "semibold": {
+            "xs": string,
+            "sm": string,
+            "md": string,
+            "lg": string
+          },
+          "mono": {
+            "xs": string,
+            "sm": string,
+            "md": string,
+            "lg": string
+          },
+          "bold": {
+            "xs": string,
+            "sm": string,
+            "md": string,
+            "lg": string
+          }
+        }
+      },
+      "brand": {
+        "titles": {
+          "xs": string,
+          "sm": string,
+          "md": string,
+          "lg": string,
+          "xl": string,
+          "2xl": string
+        }
+      },
+      "field": {
+        "md": string
+      }
+    }
+  },
+  "border": {
+    "radii": {
+      "0": string,
+      "1": string,
+      "2": string,
+      "3": string,
+      "full": string
+    },
+    "width": {
+      "1": string,
+      "2": string
+    }
+  },
+  "spaces": {
+    "0": string,
+    "1": string,
+    "2": string,
+    "3": string,
+    "4": string,
+    "5": string,
+    "6": string,
+    "7": string,
+    "8": string
+  },
+  "shadow": {
+    "1": string,
+    "2": string,
+    "3": string,
+    "4": string,
+    "5": string
+  },
+  "breakpoint": {
+    "sizes": {
+      "sm": string,
+      "md": string,
+      "lg": string,
+      "xl": string,
+      "2xl": string
+    }
+  }
 }
+    


### PR DESCRIPTION
Running `yarn generate-tokens` autogenerates the file `src/styles/types.ts`, but this wasn't in prettier's preferred format.

- adds a `.prettierignore` file and ignores `src/styles/types.ts`