### PR TITLE
Fixing switch disabled state.

### DIFF
--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -41,7 +41,10 @@ export const Switch = forwardRef<HTMLButtonElement, SwitchProps>(
           checked={checked}
           {...props}
         >
-          <SwitchThumb $checked={checked} />
+          <SwitchThumb
+            $checked={checked}
+            $disabled={disabled}
+          />
         </SwitchRoot>
         {label && (
           <GenericLabel


### PR DESCRIPTION
### Summary
The `disabled` state was not being passed to the SwitchThumb and so the colour token was not being correctly applied. 