### PR TITLE
Adding mcp to the list of icon-names

### DIFF
--- a/src/components/Icon/types.ts
+++ b/src/components/Icon/types.ts
@@ -110,6 +110,7 @@ export const ICON_NAMES = [
   "metrics",
   "metrics-alt",
   "minus",
+  "mcp",
   "moon",
   "no-cloud",
   "pause",


### PR DESCRIPTION
mcp was not being allowed to be used in the list of icon names.

This PR fixes it .