### PR TITLE
Fix Inputs interactive area

### DIFF
--- a/src/components/AutoComplete/AutoComplete.test.tsx
+++ b/src/components/AutoComplete/AutoComplete.test.tsx
@@ -213,7 +213,7 @@ describe("AutoComplete", () => {
       expect(queryByText("Content3")).not.toBeNull();
       expect(queryByText("Content1 long text content")).toBeNull();
       expect(queryByText("Group label")).not.toBeVisible();
-      fireEvent.click(getByTestId("search-close"));
+      fireEvent.click(getByTestId("textfield-clear"));
       expect(queryByText("Group label")).toBeVisible();
       expect(queryByText("Content0")).not.toBeNull();
       expect(queryByText("Content1 long text content")).not.toBeNull();

--- a/src/components/DatePicker/Common.tsx
+++ b/src/components/DatePicker/Common.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { InputElement, InputWrapper } from "../Input/InputWrapper";
+import { InputElement, InputStartContent, InputWrapper } from "../Input/InputWrapper";
 import { ReactNode, useCallback, useId } from "react";
 import { Icon } from "../Icon/Icon";
 import { Container } from "../Container/Container";
@@ -53,8 +53,11 @@ export const DatePickerInput = ({
       disabled={disabled}
       id={id ?? defaultId}
     >
-      <Icon name="calendar" />
+      <InputStartContent>
+        <Icon name="calendar" />
+      </InputStartContent>
       <InputElement
+        $hasStartContent
         data-testid="datepicker-input"
         placeholder={placeholder}
         readOnly
@@ -120,8 +123,11 @@ export const DateRangePickerInput = ({
       disabled={disabled}
       id={id ?? defaultId}
     >
-      <Icon name="calendar" />
+      <InputStartContent>
+        <Icon name="calendar" />
+      </InputStartContent>
       <InputElement
+        $hasStartContent
         as="div"
         data-testid="daterangepicker-input"
       >

--- a/src/components/Input/InputWrapper.tsx
+++ b/src/components/Input/InputWrapper.tsx
@@ -59,7 +59,6 @@ const Wrapper = styled.div<{
       overflow: auto;
     `
     }
-    padding: 0 ${theme.click.field.space.x};
     ${
       $error
         ? `
@@ -191,7 +190,7 @@ export const InputElement = styled.input`
   color: inherit;
   font: inherit;
   ${({ theme }) => `
-    padding: ${theme.click.field.space.y} 0;
+    padding: ${theme.click.field.space.y} ${theme.click.field.space.x};
     &::placeholder {
       color: ${theme.click.field.color.placeholder.default};
     }
@@ -230,7 +229,7 @@ export const TextAreaElement = styled.textarea`
   font: inherit;
   resize: none;
   ${({ theme }) => `
-    padding: ${theme.click.field.space.y} 0;
+    padding: ${theme.click.field.space.y} ${theme.click.field.space.x};
     align-self: stretch;
     &::placeholder {
       color: ${theme.click.field.color.placeholder.default};

--- a/src/components/Input/InputWrapper.tsx
+++ b/src/components/Input/InputWrapper.tsx
@@ -251,9 +251,8 @@ export const IconButton = styled.button`
   &:not(:disabled) {
     cursor: pointer;
   }
-  ${({ theme, $show }) => `
+  ${({ theme }) => `
       padding: ${theme.click.field.space.y} 0;
-      visibility: ${$show ? "visible" : "hidden"};
   `}
 `;
 

--- a/src/components/Input/InputWrapper.tsx
+++ b/src/components/Input/InputWrapper.tsx
@@ -182,15 +182,20 @@ export const InputWrapper = ({
   );
 };
 
-export const InputElement = styled.input`
+export const InputElement = styled.input<{
+  $hasStartContent?: boolean;
+  $hasEndContent?: boolean;
+}>`
   background: transparent;
   border: none;
   outline: none;
   width: 100%;
   color: inherit;
   font: inherit;
-  ${({ theme }) => `
-    padding: ${theme.click.field.space.y} ${theme.click.field.space.x};
+  ${({ theme, $hasStartContent, $hasEndContent }) => `
+    padding: ${theme.click.field.space.y} 0;
+    padding-left: ${$hasStartContent ? "0" : theme.click.field.space.x};
+    padding-right: ${$hasEndContent ? "0" : theme.click.field.space.x};
     &::placeholder {
       color: ${theme.click.field.color.placeholder.default};
     }
@@ -260,5 +265,26 @@ export const IconWrapper = styled.svg`
     &:last-of-type {
       padding-right: ${theme.click.field.space.x};
     }
+  `}
+`;
+
+export const InputStartContent = styled.div`
+  ${({ theme }) => `
+    padding-left: ${theme.click.field.space.x};
+    cursor: text;
+    gap: ${theme.click.field.space.gap};
+    display: flex;
+    align-self: stretch;
+    align-items: center;
+  `}
+`;
+
+export const InputEndContent = styled.div`
+  ${({ theme }) => `
+    padding-right: ${theme.click.field.space.x};
+    gap: ${theme.click.field.space.gap};
+    display: flex;
+    align-self: stretch;
+    align-items: center;
   `}
 `;

--- a/src/components/Input/InputWrapper.tsx
+++ b/src/components/Input/InputWrapper.tsx
@@ -237,13 +237,7 @@ export const TextAreaElement = styled.textarea`
   `}
 `;
 
-export const TextAreaWrapper = styled(InputWrapper)`
-  resize: vertical;
-  overflow: auto;
-  color: red;
-`;
-
-export const IconButton = styled.button<{ $show?: boolean }>`
+export const IconButton = styled.button`
   background: transparent;
   color: inherit;
   border: none;

--- a/src/components/Input/PasswordField.stories.tsx
+++ b/src/components/Input/PasswordField.stories.tsx
@@ -1,46 +1,33 @@
 import { useEffect, useState } from "react";
-import { PasswordField as PasswordFieldInput, PasswordFieldProps } from "./PasswordField";
-import { Container } from "../Container/Container";
 
-const PasswordField = ({
-  value: valueProp,
-  ...props
-}: Omit<PasswordFieldProps, "onChange">) => {
-  const [value, setValue] = useState(valueProp);
-  useEffect(() => {
-    setValue(valueProp);
-  }, [valueProp]);
+import { Meta, StoryObj } from "@storybook/react";
 
-  return (
-    <Container maxWidth="75%">
-      <PasswordFieldInput
-        value={value}
-        onChange={(inputValue: string) => {
-          setValue(inputValue);
-        }}
-        {...props}
-      />
-    </Container>
-  );
-};
+import { PasswordField } from "./PasswordField";
 
-export default {
+const meta: Meta<typeof PasswordField> = {
   component: PasswordField,
   title: "Forms/Input/PasswordField",
   tags: ["form-field", "input", "autodocs"],
-  argTypes: {
-    value: { control: "text" },
-    label: { control: "text" },
-    error: { control: "text" },
-    disabled: { control: "boolean" },
-    placeholder: { control: "text" },
-    readOnly: { control: "boolean" },
-    orientation: { control: "inline-radio", options: ["horizontal", "vertical"] },
-    dir: { control: "inline-radio", options: ["start", "end"] },
+  render: ({ value: valueProp, ...props }) => {
+    const [value, setValue] = useState(valueProp);
+
+    useEffect(() => {
+      setValue(valueProp);
+    }, [valueProp]);
+
+    return (
+      <PasswordField
+        {...props}
+        value={value}
+        onChange={setValue}
+      />
+    );
   },
 };
 
-export const Playground = {
+export default meta;
+
+export const Playground: StoryObj<typeof PasswordField> = {
   args: {
     label: "Label",
     disabled: false,

--- a/src/components/Input/PasswordField.tsx
+++ b/src/components/Input/PasswordField.tsx
@@ -1,6 +1,12 @@
 import { ChangeEvent, InputHTMLAttributes, forwardRef, useId, useState } from "react";
 import { Icon } from "@/components";
-import { IconButton, InputElement, InputWrapper, WrapperProps } from "./InputWrapper";
+import {
+  IconButton,
+  InputElement,
+  InputEndContent,
+  InputWrapper,
+  WrapperProps,
+} from "./InputWrapper";
 export interface PasswordFieldProps
   extends Omit<WrapperProps, "id" | "children">,
     Omit<
@@ -49,6 +55,8 @@ export const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
         dir={dir}
       >
         <InputElement
+          $hasStartContent={false}
+          $hasEndContent={true}
           ref={ref}
           type={viewPassword ? "text" : "password"}
           id={id ?? defaultId}
@@ -57,16 +65,18 @@ export const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
           onChange={onChange}
           {...props}
         />
-        <IconButton
-          disabled={disabled}
-          onClick={togglePasswordViewer}
-          $show={value.length > 0}
-        >
-          <Icon
-            name={viewPassword ? "eye-closed" : "eye"}
-            size="md"
-          />
-        </IconButton>
+        <InputEndContent>
+          <IconButton
+            disabled={disabled}
+            onClick={togglePasswordViewer}
+            $show={value.length > 0}
+          >
+            <Icon
+              name={viewPassword ? "eye-closed" : "eye"}
+              size="md"
+            />
+          </IconButton>
+        </InputEndContent>
       </InputWrapper>
     );
   }

--- a/src/components/Input/PasswordField.tsx
+++ b/src/components/Input/PasswordField.tsx
@@ -45,6 +45,8 @@ export const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
       onChangeProp(e.target.value, e);
     };
 
+    const hasEndContent = value.length > 0;
+
     return (
       <InputWrapper
         disabled={disabled}
@@ -56,7 +58,7 @@ export const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
       >
         <InputElement
           $hasStartContent={false}
-          $hasEndContent={true}
+          $hasEndContent={hasEndContent}
           ref={ref}
           type={viewPassword ? "text" : "password"}
           id={id ?? defaultId}
@@ -65,18 +67,19 @@ export const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
           onChange={onChange}
           {...props}
         />
-        <InputEndContent>
-          <IconButton
-            disabled={disabled}
-            onClick={togglePasswordViewer}
-            $show={value.length > 0}
-          >
-            <Icon
-              name={viewPassword ? "eye-closed" : "eye"}
-              size="md"
-            />
-          </IconButton>
-        </InputEndContent>
+        {hasEndContent && (
+          <InputEndContent>
+            <IconButton
+              disabled={disabled}
+              onClick={togglePasswordViewer}
+            >
+              <Icon
+                name={viewPassword ? "eye-closed" : "eye"}
+                size="md"
+              />
+            </IconButton>
+          </InputEndContent>
+        )}
       </InputWrapper>
     );
   }

--- a/src/components/Input/SearchField.stories.tsx
+++ b/src/components/Input/SearchField.stories.tsx
@@ -1,56 +1,39 @@
 import { useEffect, useState } from "react";
-import { SearchField as SearchFieldInput, SearchFieldProps } from "./SearchField";
+
+import { Meta, StoryObj } from "@storybook/react";
+
 import { Container } from "../Container/Container";
 
-const SearchField = ({
-  value: valueProp,
-  ...props
-}: Omit<SearchFieldProps, "onChange">) => {
-  const [value, setValue] = useState(valueProp);
-  useEffect(() => {
-    setValue(valueProp);
-  }, [valueProp]);
+import { SearchField } from "./SearchField";
 
-  return (
-    <Container maxWidth="350px">
-      <SearchFieldInput
-        value={value}
-        onChange={(inputValue: string) => {
-          setValue(inputValue);
-        }}
-        {...props}
-      />
-    </Container>
-  );
-};
-
-export default {
+const meta: Meta<typeof SearchField> = {
   component: SearchField,
   title: "Forms/Input/SearchField",
   tags: ["form-field", "input", "autodocs"],
-  argTypes: {
-    value: { control: "text" },
-    clear: { control: "boolean" },
-    label: { control: "text" },
-    error: { control: "text" },
-    disabled: { control: "boolean" },
-    placeholder: { control: "text" },
-    readOnly: { control: "boolean" },
-    orientation: { control: "inline-radio", options: ["horizontal", "vertical"] },
-    dir: { control: "inline-radio", options: ["start", "end"] },
-    isFilter: { control: "boolean" },
+  render: ({ value: valueProp, ...props }) => {
+    const [value, setValue] = useState(valueProp);
+
+    useEffect(() => {
+      setValue(valueProp);
+    }, [valueProp]);
+
+    return (
+      <Container maxWidth="350px">
+        <SearchField
+          {...props}
+          value={value}
+          onChange={setValue}
+        />
+      </Container>
+    );
   },
 };
 
-export const Playground = {
+export default meta;
+
+export const Playground: StoryObj<typeof SearchField> = {
   args: {
     label: "Label",
-    disabled: false,
     placeholder: "Placeholder",
-    clear: false,
-    readOnly: false,
-    isFilter: false,
-    value: "",
-    error: "",
   },
 };

--- a/src/components/Input/SearchField.tsx
+++ b/src/components/Input/SearchField.tsx
@@ -1,94 +1,28 @@
-import { ChangeEvent, InputHTMLAttributes, forwardRef, useId, useRef } from "react";
-import { Icon } from "@/components";
-import { IconButton, InputElement, InputWrapper, WrapperProps } from "./InputWrapper";
-import { mergeRefs } from "@/utils/mergeRefs";
+import { forwardRef } from "react";
+
+import { Icon, TextField } from "@/components";
+
+import { TextFieldProps } from "./TextField";
 
 export interface SearchFieldProps
-  extends Omit<WrapperProps, "id" | "children">,
-    Omit<
-      InputHTMLAttributes<HTMLInputElement>,
-      "children" | "type" | "string" | "onChange" | "dir"
-    > {
-  loading?: boolean;
-  value?: string;
-  clear?: boolean;
-  onChange: (inputValue: string, e?: ChangeEvent<HTMLInputElement>) => void;
-  orientation?: "vertical" | "horizontal";
-  dir?: "start" | "end";
+  extends Omit<TextFieldProps, "type" | "startContent" | "endContent"> {
   isFilter?: boolean;
 }
 
 export const SearchField = forwardRef<HTMLInputElement, SearchFieldProps>(
-  (
-    {
-      disabled,
-      label,
-      error,
-      id,
-      loading,
-      clear = true,
-      value = "",
-      onChange: onChangeProp,
-      orientation,
-      dir,
-      isFilter = false,
-      ...props
-    },
-    ref
-  ) => {
-    const inputRef = useRef<HTMLInputElement>(null);
-    const defaultId = useId();
-    const onChange = (e: ChangeEvent<HTMLInputElement>) => {
-      onChangeProp(e.target.value, e);
-    };
-    const clearInput = () => {
-      onChangeProp("");
-    };
-
+  ({ isFilter = false, clear = true, ...props }, ref) => {
     return (
-      <InputWrapper
-        disabled={disabled}
-        id={id ?? defaultId}
-        label={label}
-        error={error}
-        orientation={orientation}
-        dir={dir}
-      >
-        <Icon
-          name={isFilter ? "filter" : "search"}
-          size="sm"
-        />
-
-        <InputElement
-          ref={mergeRefs([inputRef, ref])}
-          type="text"
-          id={id ?? defaultId}
-          disabled={disabled}
-          value={value}
-          onChange={onChange}
-          {...props}
-        />
-        {clear && (
-          <IconButton
-            disabled={disabled}
-            onClick={clearInput}
-            $show={value.length > 0}
-            aria-label="clear input"
-            data-testid="search-close"
-          >
-            <Icon
-              name="cross"
-              size="sm"
-            />
-          </IconButton>
-        )}
-        {loading && (
+      <TextField
+        startContent={
           <Icon
-            name="loading-animated"
+            name={isFilter ? "filter" : "search"}
             size="sm"
           />
-        )}
-      </InputWrapper>
+        }
+        clear={clear}
+        ref={ref}
+        {...props}
+      />
     );
   }
 );

--- a/src/components/Input/TextField.stories.tsx
+++ b/src/components/Input/TextField.stories.tsx
@@ -1,67 +1,45 @@
-import { ChangeEvent, useEffect, useState } from "react";
-import { TextField as TextFieldInput, TextFieldProps } from "./TextField";
-import { Container } from "../Container/Container";
+import { useEffect, useState } from "react";
 
-const TextField = ({ value: valueProp, ...props }: Omit<TextFieldProps, "onChange">) => {
-  const [value, setValue] = useState(valueProp);
-  useEffect(() => {
-    setValue(valueProp);
-  }, [valueProp]);
+import { Meta, StoryObj } from "@storybook/react";
 
-  return (
-    <Container maxWidth="75%">
-      <TextFieldInput
-        value={value}
-        onChange={(inputValue: string, e?: ChangeEvent<HTMLInputElement>) => {
-          if (e) {
-            e.preventDefault();
-          }
-          setValue(inputValue);
-        }}
-        {...props}
-      />
-    </Container>
-  );
-};
+import { TextField } from "./TextField";
 
-export default {
+const meta: Meta<typeof TextField> = {
   component: TextField,
   title: "Forms/Input/TextField",
   tags: ["form-field", "input", "autodocs"],
-  argTypes: {
-    type: {
-      control: "inline-radio",
-      options: ["text", "email", "tel", "url"],
-    },
-    value: { control: "text" },
-    clear: { control: "boolean" },
-    label: { control: "text" },
-    error: { control: "text" },
-    disabled: { control: "boolean" },
-    placeholder: { control: "text" },
-    readOnly: { control: "boolean" },
-    orientation: { control: "inline-radio", options: ["horizontal", "vertical"] },
-    dir: { control: "inline-radio", options: ["start", "end"] },
+  render: ({ value: valueProp, ...props }) => {
+    const [value, setValue] = useState(valueProp);
+
+    useEffect(() => {
+      setValue(valueProp);
+    }, [valueProp]);
+
+    return (
+      <TextField
+        {...props}
+        value={value}
+        onChange={setValue}
+      />
+    );
   },
 };
 
-export const Playground = {
+export default meta;
+
+export const Playground: StoryObj<typeof TextField> = {
   args: {
     label: "Label",
-    clear: false,
     type: "text",
-    disabled: false,
     placeholder: "Placeholder",
   },
 };
 
-export const LabelColor = {
+export const LabelColor: StoryObj<typeof TextField> = {
   args: {
     label: "Label",
     labelColor: "rgb(193, 0, 0)",
-    clear: false,
     type: "text",
-    disabled: false,
     placeholder: "Placeholder",
   },
 };

--- a/src/components/Input/TextField.tsx
+++ b/src/components/Input/TextField.tsx
@@ -115,6 +115,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
                 onClick={clearInput}
                 $show={value.length > 0}
                 aria-label="clear input"
+                data-testid="textfield-clear"
               >
                 <Icon
                   name="cross"

--- a/src/components/Input/TextField.tsx
+++ b/src/components/Input/TextField.tsx
@@ -1,6 +1,20 @@
-import { ChangeEvent, InputHTMLAttributes, forwardRef, useId, useRef } from "react";
+import {
+  ChangeEvent,
+  InputHTMLAttributes,
+  ReactNode,
+  forwardRef,
+  useId,
+  useRef,
+} from "react";
 import { Icon } from "@/components";
-import { IconButton, InputElement, InputWrapper, WrapperProps } from "./InputWrapper";
+import {
+  IconButton,
+  InputElement,
+  InputEndContent,
+  InputStartContent,
+  InputWrapper,
+  WrapperProps,
+} from "./InputWrapper";
 import { mergeRefs } from "@/utils/mergeRefs";
 
 export interface TextFieldProps
@@ -17,6 +31,14 @@ export interface TextFieldProps
   onChange: (inputValue: string, e?: ChangeEvent<HTMLInputElement>) => void;
   orientation?: "vertical" | "horizontal";
   dir?: "start" | "end";
+  /**
+   * Additional content to the left of the control
+   */
+  startContent?: ReactNode;
+  /**
+   * Additional content to the right of the control
+   */
+  endContent?: ReactNode;
 }
 
 export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
@@ -34,6 +56,8 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
       onChange: onChangeProp,
       orientation,
       dir,
+      startContent,
+      endContent,
       ...props
     },
     ref
@@ -47,6 +71,13 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
       onChangeProp("");
     };
 
+    const handleStartContentClick: React.MouseEventHandler<HTMLDivElement> = () => {
+      inputRef.current?.focus();
+    };
+
+    const hasStartContent = Boolean(startContent);
+    const hasEndContent = Boolean(clear || loading || endContent);
+
     return (
       <InputWrapper
         disabled={disabled}
@@ -57,7 +88,15 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         orientation={orientation}
         dir={dir}
       >
+        {startContent && (
+          <InputStartContent onClick={handleStartContentClick}>
+            {startContent}
+          </InputStartContent>
+        )}
+
         <InputElement
+          $hasStartContent={hasStartContent}
+          $hasEndContent={hasEndContent}
           ref={mergeRefs([inputRef, ref])}
           type={type}
           id={id ?? defaultId}
@@ -67,24 +106,29 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
           {...props}
         />
 
-        {clear && (
-          <IconButton
-            disabled={disabled}
-            onClick={clearInput}
-            $show={value.length > 0}
-            aria-label="clear input"
-          >
-            <Icon
-              name="cross"
-              size="sm"
-            />
-          </IconButton>
-        )}
-        {loading && (
-          <Icon
-            name="loading-animated"
-            size="sm"
-          />
+        {hasEndContent && (
+          <InputEndContent>
+            {endContent ? endContent : null}
+            {clear && (
+              <IconButton
+                disabled={disabled}
+                onClick={clearInput}
+                $show={value.length > 0}
+                aria-label="clear input"
+              >
+                <Icon
+                  name="cross"
+                  size="sm"
+                />
+              </IconButton>
+            )}
+            {loading && (
+              <Icon
+                name="loading-animated"
+                size="sm"
+              />
+            )}
+          </InputEndContent>
         )}
       </InputWrapper>
     );

--- a/src/components/Input/TextField.tsx
+++ b/src/components/Input/TextField.tsx
@@ -76,7 +76,9 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
     };
 
     const hasStartContent = Boolean(startContent);
-    const hasEndContent = Boolean(clear || loading || endContent);
+
+    const hasClear = clear && value.length > 0;
+    const hasEndContent = Boolean(hasClear || loading || endContent);
 
     return (
       <InputWrapper
@@ -109,11 +111,10 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         {hasEndContent && (
           <InputEndContent>
             {endContent ? endContent : null}
-            {clear && (
+            {hasClear && (
               <IconButton
                 disabled={disabled}
                 onClick={clearInput}
-                $show={value.length > 0}
                 aria-label="clear input"
                 data-testid="textfield-clear"
               >


### PR DESCRIPTION
### Why

Horizontal space in Inputs appear interactive, and should be interactive, but is not.
Clicking anywhere within visible input area should activate the field.

https://github.com/user-attachments/assets/6033411d-1252-45dd-adaa-0360fc8e2c93

### What
To address the issue:
- Changed Inputs layout
- `TextField`: introduced props `startContent` and `endContent`, that accept any `ReactNode` and render extra content before or after input control
- `SearchField`: removed all code and remade the component on top of `TextField`, because they are exactly the same; SearchField now uses `startContent` to render its icon
- `PasswordField`: used the same utility component to render the eye button as `TextField` uses to render `endContent`
- Changed how icons/buttons placed inside Inputs behave:
  - before: hidden icons still occupy space
  - after: hidden icons are not rendered at all
  - why: hidden icons obscure interaction with the field in the same way; clicking any empty space should activate the field, but with hidden icons it's not the case

Also:
- Updated stories for `TextField`, `SearchField`, and `PasswordField` to be auto-generated; now they are more informative and up-to-date with the actual components API.
  - before: https://click-ui.vercel.app/?path=/docs/forms-input-textfield--docs
  - after: https://click-ui-git-textfield-active-area-clickhouse.vercel.app/?path=/docs/forms-input-textfield--docs

### Remaining issues
- Because of how Inputs are built, there is still non-interactive areas in some cases. In particular, because we use `gap` to create space between elements inside InputWrapper, these gaps don't have proper cursor, and aren't interactive. To be fixed in next iterations.