### PR TITLE
[ClickPipes] `ProgressBar` 100% bug

### DIFF
--- a/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -23,12 +23,20 @@ export default {
   },
 };
 
-export const Playground = {
+export const DefaultProgressBar = {
   args: {
-    progress: 0,
+    progress: 100,
     type: "default",
     dismissable: true,
     onCancel: () => console.log("onCancel clicked"),
+    successMessage: "Progress completed",
+  },
+};
+
+export const SmallProgressBar = {
+  args: {
+    progress: 100,
+    type: "small",
     successMessage: "Progress completed",
   },
 };

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -55,7 +55,7 @@ const ProgressContainer = styled.div<{
   min-height: 2px;
   ${({ theme, $completed, $progress, $type }) => `
     background: ${
-      $completed
+      $completed && $type === "default"
         ? theme.click.field.color.background.default
         : `linear-gradient(to right, ${theme.global.color.accent.default} 0%, ${theme.global.color.accent.default} ${$progress}%, ${theme.click.field.color.background.default} ${$progress}%,  ${theme.click.field.color.background.default} 100%)`
     };


### PR DESCRIPTION
[Currently](https://click-ui.vercel.app/?path=/docs/display-progressbar--docs), when you set the `ProgressBar` to type `small` and set the progress to 100%, the bar is empty as if it were 0%. This PR puts that right. 

---

![ProgressBar](https://github.com/user-attachments/assets/7a625fb5-b75e-4435-9941-17216b132c95)
![FileUpload](https://github.com/user-attachments/assets/98fe4059-0114-48fe-bf37-a989564c0f86)
