### PR TITLE
Reset Select and MultiSelect value when external value changes to undefined

### DIFF
--- a/src/components/Select/MultiSelect.test.tsx
+++ b/src/components/Select/MultiSelect.test.tsx
@@ -64,7 +64,7 @@ describe("MultiSelect", () => {
     expect(queryByText("Content0")).not.toBeNull();
   });
 
-  it("should always respect given value in select", () => {
+  it("should prioritize external value over internal state", () => {
     const onSelect = vi.fn();
     const { queryByText, getByTestId, getByText } = renderSelect({
       value: ["content0", "content1"],
@@ -85,6 +85,51 @@ describe("MultiSelect", () => {
     });
     expect(onSelect).toBeCalledTimes(1);
     expect(queryByTestingText(selectTrigger, "Content3")).toBeNull();
+  });
+
+  it("should react to external value change", () => {
+    const { getByTestId, rerender } = renderCUI(
+      <MultiSelect
+        value={["content0", "content1"]}
+        options={selectOptions}
+      />
+    );
+    const selectTrigger = getByTestId("select-trigger");
+    expect(selectTrigger).not.toBeNull();
+    expect(queryByTestingText(selectTrigger, "Content0")).not.toBeNull();
+    expect(
+      queryByTestingText(selectTrigger, "Content1 long text content")
+    ).not.toBeNull();
+    rerender(
+      <MultiSelect
+        value={["content0", "content3"]}
+        options={selectOptions}
+      />
+    );
+    expect(queryByTestingText(selectTrigger, "Content0")).not.toBeNull();
+    expect(queryByTestingText(selectTrigger, "Content1 long text content")).toBeNull();
+    expect(queryByTestingText(selectTrigger, "Content3")).not.toBeNull();
+  });
+
+  it("shuold fall back to placeholder if value changes to undefined", () => {
+    const { getByTestId, rerender } = renderCUI(
+      <MultiSelect
+        value={["content0", "content1"]}
+        placeholder="noop"
+        options={selectOptions}
+      />
+    );
+    const selectTrigger = getByTestId("select-trigger");
+    expect(selectTrigger).not.toBeNull();
+    expect(queryByTestingText(selectTrigger, "noop")).toBeNull();
+    rerender(
+      <MultiSelect
+        value={undefined}
+        placeholder="noop"
+        options={selectOptions}
+      />
+    );
+    expect(queryByTestingText(selectTrigger, "noop")).not.toBeNull();
   });
 
   it("should respect given defaultValue in select", () => {

--- a/src/components/Select/SingleSelect.test.tsx
+++ b/src/components/Select/SingleSelect.test.tsx
@@ -93,7 +93,7 @@ describe("Select", () => {
     expect(queryByText("Content0")).toBeNull();
   });
 
-  it("should always respect given value in select", () => {
+  it("should prioritize external value over internal state", () => {
     const onSelect = vi.fn();
     const { queryByText, getByTestId, getByText } = renderSelect({
       value: "content0",
@@ -113,6 +113,46 @@ describe("Select", () => {
     expect(queryByText("Content4")).toBeNull();
     expect(queryByTestingText(selectTrigger, "Content3")).toBeNull();
     expect(queryByTestingText(selectTrigger, "Content0")).not.toBeNull();
+  });
+
+  it("should react to external value change", () => {
+    const { getByTestId, rerender } = renderCUI(
+      <Select
+        value="content0"
+        options={selectOptions}
+      />
+    );
+    const selectTrigger = getByTestId("select-trigger");
+    expect(selectTrigger).not.toBeNull();
+    expect(queryByTestingText(selectTrigger, "Content0")).not.toBeNull();
+    rerender(
+      <Select
+        value="content3"
+        options={selectOptions}
+      />
+    );
+    expect(queryByTestingText(selectTrigger, "Content3")).not.toBeNull();
+  });
+
+  it("shuold fall back to placeholder if value changes to undefined", () => {
+    const { getByTestId, rerender } = renderCUI(
+      <Select
+        value="content0"
+        placeholder="noop"
+        options={selectOptions}
+      />
+    );
+    const selectTrigger = getByTestId("select-trigger");
+    expect(selectTrigger).not.toBeNull();
+    expect(queryByTestingText(selectTrigger, "noop")).toBeNull();
+    rerender(
+      <Select
+        value={undefined}
+        placeholder="noop"
+        options={selectOptions}
+      />
+    );
+    expect(queryByTestingText(selectTrigger, "noop")).not.toBeNull();
   });
 
   it("should respect given defaultValue in select", () => {

--- a/src/hooks/useUpdateEffect.test.ts
+++ b/src/hooks/useUpdateEffect.test.ts
@@ -1,0 +1,52 @@
+import { renderHook } from "@testing-library/react";
+import { useUpdateEffect } from "./useUpdateEffect";
+
+describe("useUpdateEffect", () => {
+  it("should not run the effect on the first render", () => {
+    const effect = vi.fn();
+
+    renderHook(() => useUpdateEffect(effect));
+
+    // The effect should not have been called yet
+    expect(effect).not.toHaveBeenCalled();
+  });
+
+  it("should run the effect on subsequent renders", () => {
+    const effect = vi.fn();
+
+    const { rerender } = renderHook(() => {
+      useUpdateEffect(effect);
+    });
+
+    rerender();
+
+    // The effect should have been called once
+    expect(effect).toHaveBeenCalledTimes(1);
+  });
+
+  it("should run the effect when dependencies change", () => {
+    const effect = vi.fn();
+
+    const { rerender } = renderHook((dependency: string = "initial_dependency") =>
+      useUpdateEffect(effect, [dependency])
+    );
+
+    rerender("updated_dependency");
+
+    // The effect should have been called once
+    expect(effect).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not run the effect if dependencies do not change", () => {
+    const effect = vi.fn();
+
+    const { rerender } = renderHook((dependency: string = "same_dependency") =>
+      useUpdateEffect(effect, [dependency])
+    );
+
+    rerender("same_dependency");
+
+    // The effect should not have been called again
+    expect(effect).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/hooks/useUpdateEffect.ts
+++ b/src/hooks/useUpdateEffect.ts
@@ -4,7 +4,7 @@ export const useUpdateEffect: typeof useEffect = (effect, deps) => {
   const isFirstMount = useRef(true);
 
   useEffect(() => {
-    if (isFirstMount) {
+    if (isFirstMount.current) {
       isFirstMount.current = false;
       return;
     }

--- a/src/utils/test-utils.tsx
+++ b/src/utils/test-utils.tsx
@@ -2,6 +2,7 @@ import { type ThemeName } from "@/theme";
 import { render as renderTL } from "@testing-library/react";
 import { ClickUIProvider } from "..";
 
+// eslint-disable-next-line react-refresh/only-export-components
 const Wrapper = ({
   theme,
   children,

--- a/src/utils/test-utils.tsx
+++ b/src/utils/test-utils.tsx
@@ -2,15 +2,29 @@ import { type ThemeName } from "@/theme";
 import { render as renderTL } from "@testing-library/react";
 import { ClickUIProvider } from "..";
 
+const Wrapper = ({
+  theme,
+  children,
+}: {
+  theme: ThemeName;
+  children: React.ReactNode;
+}) => (
+  <ClickUIProvider
+    theme={theme}
+    config={{ tooltip: { delayDuration: 0 } }}
+  >
+    {children}
+  </ClickUIProvider>
+);
+
 const renderCUI = (children: React.ReactNode, theme: ThemeName = "dark") => {
-  return renderTL(
-    <ClickUIProvider
-      theme={theme}
-      config={{ tooltip: { delayDuration: 0 } }}
-    >
-      {children}
-    </ClickUIProvider>
-  );
+  const rtlRenderResult = renderTL(<Wrapper theme={theme}>{children}</Wrapper>);
+
+  return {
+    ...rtlRenderResult,
+    rerender: (rerenderChildren: React.ReactNode) =>
+      rtlRenderResult.rerender(<Wrapper theme={theme}>{rerenderChildren}</Wrapper>),
+  };
 };
 
 export { renderCUI };


### PR DESCRIPTION
This PR introduced `useUpdateEffect`, but the implementation had a bug:
#522

`useUpdateEffect` was only used in `Select` and `MultiSelect`, and the only consequence was that switching external value to `undefined` didn't reset the control internal value.

This PR fixes it, and
- updates test utils to enable rerendering of click-ui components in tests
- covers cases with external value change for `Select` and `MultiSelect`