### PR TITLE
CheckboxMultiSelect: properly handle option clicks

### DIFF
--- a/src/components/IconWrapper/IconWrapper.tsx
+++ b/src/components/IconWrapper/IconWrapper.tsx
@@ -1,25 +1,10 @@
 import { ReactNode } from "react";
-import { HorizontalDirection, IconName } from "@/components";
-import { styled } from "styled-components";
-import { EllipsisContent } from "../EllipsisContent/EllipsisContent";
+
+import { Container, HorizontalDirection, IconName } from "@/components";
+import { GapOptions } from "@/components/Container/Container";
+import { EllipsisContent } from "@/components/EllipsisContent/EllipsisContent";
 import { Icon } from "@/components/Icon/Icon";
 import { IconSize } from "@/components/Icon/types";
-
-const LabelContainer = styled.div<{ $hasIcon: boolean; $iconDir: HorizontalDirection }>`
-  display: grid;
-  grid-template-columns: ${({ $hasIcon, $iconDir }) =>
-    `${$hasIcon && $iconDir === "start" ? "auto " : ""}1fr${
-      $hasIcon && $iconDir === "end" ? " auto" : ""
-    }`};
-  align-items: center;
-  justify-content: flex-start;
-
-  width: 100%;
-  width: -webkit-fill-available;
-  width: fill-available;
-  width: stretch;
-  gap: ${({ theme }) => theme.click.sidebar.navigation.item.default.space.gap};
-`;
 
 interface IconWrapperProps {
   icon?: IconName;
@@ -29,6 +14,7 @@ interface IconWrapperProps {
   height?: number | string;
   children: ReactNode;
   ellipsisContent?: boolean;
+  gap?: GapOptions;
 }
 
 const IconWrapper = ({
@@ -39,13 +25,14 @@ const IconWrapper = ({
   height,
   children,
   ellipsisContent = true,
+  gap = "sm",
   ...props
 }: IconWrapperProps) => {
   const TextWrapper = ellipsisContent ? EllipsisContent : "div";
   return (
-    <LabelContainer
-      $hasIcon={typeof icon === "string"}
-      $iconDir={iconDir}
+    <Container
+      orientation="horizontal"
+      gap={gap}
       {...props}
     >
       {icon && iconDir === "start" && (
@@ -69,7 +56,7 @@ const IconWrapper = ({
           height={height}
         />
       )}
-    </LabelContainer>
+    </Container>
   );
 };
 export default IconWrapper;

--- a/src/components/IconWrapper/IconWrapper.tsx
+++ b/src/components/IconWrapper/IconWrapper.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from "react";
 
-import { Container, HorizontalDirection, IconName } from "@/components";
-import { GapOptions } from "@/components/Container/Container";
+import { HorizontalDirection, IconName } from "@/components";
+import { Container, GapOptions } from "@/components/Container/Container";
 import { EllipsisContent } from "@/components/EllipsisContent/EllipsisContent";
 import { Icon } from "@/components/Icon/Icon";
 import { IconSize } from "@/components/Icon/types";

--- a/src/components/Select/SingleSelectValue.tsx
+++ b/src/components/Select/SingleSelectValue.tsx
@@ -31,6 +31,7 @@ const SingleSelectValue = ({
       <IconWrapper
         icon={icon}
         iconDir={iconDir}
+        gap="xxs"
       >
         {label ?? children ?? value}
       </IconWrapper>

--- a/src/components/Select/common/InternalSelect.tsx
+++ b/src/components/Select/common/InternalSelect.tsx
@@ -608,6 +608,11 @@ export type MultiSelectCheckboxItemProps = SelectItemProps & {
 
 SelectItem.displayName = "Select.Item";
 
+// FIXME IconWrapper should support gap prop
+const IconWrapperCustomGap = styled(IconWrapper)`
+  gap: ${({ theme }) => theme.spaces[1]};
+`;
+
 export const MultiSelectCheckboxItem = forwardRef<
   HTMLDivElement,
   MultiSelectCheckboxItemProps
@@ -679,12 +684,12 @@ export const MultiSelectCheckboxItem = forwardRef<
               disabled={disabled}
               variant={variant ?? "default"}
             />
-            <IconWrapper
+            <IconWrapperCustomGap
               icon={icon}
               iconDir={iconDir}
             >
               {label ?? children}
-            </IconWrapper>
+            </IconWrapperCustomGap>
           </Container>
         </GenericMenuItem>
         {separator && <Separator size="sm" />}

--- a/src/components/Select/common/InternalSelect.tsx
+++ b/src/components/Select/common/InternalSelect.tsx
@@ -25,6 +25,7 @@ import { Portal } from "@radix-ui/react-popover";
 import {
   Checkbox,
   CheckboxVariants,
+  Container,
   Icon,
   IconButton,
   Label,
@@ -630,7 +631,7 @@ export const MultiSelectCheckboxItem = forwardRef<
     const { highlighted, updateHighlighted, isHidden, selectedValues, onSelect } =
       useOption();
 
-    const handleSelect = (evt: MouseEvent<HTMLElement>) => {
+    const handleMenuItemClick = (evt: MouseEvent<HTMLElement>) => {
       if (!disabled) {
         onSelect(value, undefined, evt);
 
@@ -638,21 +639,6 @@ export const MultiSelectCheckboxItem = forwardRef<
           onSelectProp(value, undefined, evt);
         }
       }
-    };
-
-    const handleMenuItemClick = (evt: MouseEvent<HTMLElement>) => {
-      // Clicking checkbox label fires another click event on the checkbox input.
-      // They cancel each other out, so we handle checkbox clicks separately,
-      // and this covers the outside area.
-      if (evt.target !== evt.currentTarget) {
-        return;
-      }
-
-      handleSelect(evt);
-    };
-
-    const handleCheckboxClick = (evt: MouseEvent<HTMLButtonElement>): void => {
-      handleSelect(evt);
     };
 
     const handleMenuItemMouseOver = (e: MouseEvent<HTMLDivElement>) => {
@@ -683,59 +669,23 @@ export const MultiSelectCheckboxItem = forwardRef<
           data-testid={`multi-select-checkbox-${value}`}
           cui-select-item=""
         >
-          {icon && iconDir === "start" && (
+          <Container
+            orientation="horizontal"
+            gap="xs"
+          >
             <Checkbox
               checked={isChecked}
               data-testid="multi-select-checkbox"
               disabled={disabled}
-              label={
-                label ? (
-                  <div style={{ display: "flex", justifyContent: "center" }}>
-                    <Icon
-                      name={icon}
-                      size="sm"
-                    />
-                    {label}
-                  </div>
-                ) : (
-                  <div style={{ display: "flex", justifyContent: "center" }}>
-                    <Icon
-                      name={icon}
-                      size="sm"
-                    />
-                    {children}
-                  </div>
-                )
-              }
-              onClick={handleCheckboxClick}
               variant={variant ?? "default"}
             />
-          )}
-          {icon && iconDir === "end" && (
             <IconWrapper
               icon={icon}
-              iconDir="end"
+              iconDir={iconDir}
             >
-              <Checkbox
-                checked={isChecked}
-                data-testid="multi-select-checkbox"
-                disabled={disabled}
-                label={label ?? children}
-                onClick={handleCheckboxClick}
-                variant={variant ?? "default"}
-              />
+              {label ?? children}
             </IconWrapper>
-          )}
-          {!icon && (
-            <Checkbox
-              checked={isChecked}
-              data-testid="multi-select-checkbox"
-              disabled={disabled}
-              label={label ?? children}
-              onClick={handleCheckboxClick}
-              variant={variant ?? "default"}
-            />
-          )}
+          </Container>
         </GenericMenuItem>
         {separator && <Separator size="sm" />}
       </>

--- a/src/components/Select/common/InternalSelect.tsx
+++ b/src/components/Select/common/InternalSelect.tsx
@@ -586,6 +586,7 @@ export const SelectItem = forwardRef<HTMLDivElement, SelectItemProps>(
           <IconWrapper
             icon={icon}
             iconDir={iconDir}
+            gap="xxs"
           >
             {label ?? children}
           </IconWrapper>
@@ -607,11 +608,6 @@ export type MultiSelectCheckboxItemProps = SelectItemProps & {
 };
 
 SelectItem.displayName = "Select.Item";
-
-// FIXME IconWrapper should support gap prop
-const IconWrapperCustomGap = styled(IconWrapper)`
-  gap: ${({ theme }) => theme.spaces[1]};
-`;
 
 export const MultiSelectCheckboxItem = forwardRef<
   HTMLDivElement,
@@ -684,12 +680,13 @@ export const MultiSelectCheckboxItem = forwardRef<
               disabled={disabled}
               variant={variant ?? "default"}
             />
-            <IconWrapperCustomGap
+            <IconWrapper
               icon={icon}
               iconDir={iconDir}
+              gap="xxs"
             >
               {label ?? children}
-            </IconWrapperCustomGap>
+            </IconWrapper>
           </Container>
         </GenericMenuItem>
         {separator && <Separator size="sm" />}


### PR DESCRIPTION
## What & Why

Followup on https://github.com/ClickHouse/click-ui/pull/609

The previous fix made it better, but there are still cases when clicks aren't processed properly.

This fix removes all unnecessary handlers and variations, keeping the behavior simple and covering all cases.

## Changes

Don't use Checkbox label to render the option label, instead only use the checkbox itself, and render the label + optional icon next to it. This removes the possibility of double click on checkbox control, and hence on the MenuItem.

## Unintended changes

~~`IconWrapper` applies the standard spacings around icon used in other dropdowns.~~

`IconWrapper` still applies spacings between the icon and the label, but it's reduced for this specific case. This is not good, ideally IconWrapper should accept the `gap` prop to be able to customize it like this anywhere. But changing IconWrapper API is definitely outside the scope of this fix.

The difference:

| before | after (v2) |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/a18ffa9f-a45d-4014-b43e-fdd1b847aff3) | ![image](https://github.com/user-attachments/assets/a242db3f-cb88-45e6-b068-13357eeee4cc) | 

cc @crisalbu 