### PR TITLE
Add mobile styling for Dialog content

### DIFF
--- a/src/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/src/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -23,6 +23,9 @@ const ActionsWrapper = styled.div`
   display: flex;
   justify-content: flex-end;
   gap: ${props => props.theme.click.dialog.space.gap};
+  @media (max-width: ${({ theme }) => theme.breakpoint.sizes.sm}) {
+    flex-direction: column;
+  }
 `;
 
 const DialogContent = styled.div`

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -58,8 +58,8 @@ const DialogOverlay = styled(RadixDialog.Overlay)`
 const ContentArea = styled(RadixDialog.Content)`
   background: ${({ theme }) => theme.click.dialog.color.background.default};
   border-radius: ${({ theme }) => theme.click.dialog.radii.all};
-  padding: ${({ theme }) => theme.click.dialog.space.y}
-    ${({ theme }) => theme.click.dialog.space.x};
+  padding: ${({ theme }) =>
+    `${theme.click.dialog.space.y} ${theme.click.dialog.space.x}`};
   box-shadow: ${({ theme }) => theme.click.dialog.shadow.default};
   border: 1px solid ${({ theme }) => theme.click.global.color.stroke.default};
   width: 75%;
@@ -72,6 +72,11 @@ const ContentArea = styled(RadixDialog.Content)`
   transform: translate(-50%, -50%);
   animation: ${contentShow} 150ms cubic-bezier(0.16, 1, 0.3, 1);
   outline: none;
+
+  @media (max-width: ${({ theme }) => theme.breakpoint.sizes.sm}) {
+    max-height: 100%;
+    border-radius: 0;
+  }
 `;
 
 const TitleArea = styled.div`

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -76,6 +76,7 @@ const ContentArea = styled(RadixDialog.Content)`
   @media (max-width: ${({ theme }) => theme.breakpoint.sizes.sm}) {
     max-height: 100%;
     border-radius: 0;
+    width: 100%;
   }
 `;
 


### PR DESCRIPTION
After discussing with @crisalbu We wanted more data to be shown in the dialog content and also fix the issue with confirmation dialog buttons when the text is too long. So we have updated the styling to fix this for mobile devices

<img width="607" alt="Screenshot 2025-06-17 at 15 19 49" src="https://github.com/user-attachments/assets/adbff6d6-160d-4167-bc27-9c0695e69e33" />
<img width="496" alt="Screenshot 2025-06-17 at 15 17 25" src="https://github.com/user-attachments/assets/cb7e969a-3f91-4492-bf21-545b76c2a00c" />
