### PR TITLE
Export toast and make toast content vertical aligned

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,9 @@ import {
   GridContainer,
   TextField,
   Label,
+  createToast,
+  ToastProvider,
+  Toast,
 } from "@/components";
 import { Dialog } from "@/components/Dialog/Dialog";
 import { ConfirmationDialog } from "@/components/ConfirmationDialog/ConfirmationDialog";
@@ -108,6 +111,78 @@ const App = () => {
       theme={currentTheme}
       config={{ tooltip: { delayDuration: 0 } }}
     >
+      <Button
+        onClick={() => {
+          createToast({
+            title: "Toast Title",
+            description: "This is a toast description",
+            type: "success",
+            actions: [
+              {
+                label: "Action 1",
+                altText: "Action 1 Alt Text",
+                onClick: () => console.log("Action 1 clicked"),
+                type: "secondary",
+              },
+              {
+                label: "Action 2",
+                altText: "Action 2 Alt Text",
+                onClick: () => console.log("Action 2 clicked"),
+                type: "secondary",
+              },
+            ],
+          });
+        }}
+      >
+        Show Normal Toast
+      </Button>
+      <ToastProvider align="start">
+        <Button
+          onClick={() => {
+            createToast({
+              title: "Toast Title with Align Start",
+              description: "This is a toast description   with align start",
+              type: "success",
+              actions: [
+                {
+                  label: "Action 1",
+                  altText: "Action 1 Alt Text",
+                  onClick: () => console.log("Action 1 clicked"),
+                },
+                {
+                  label: "Action 2",
+                  altText: "Action 2 Alt Text",
+                  onClick: () => console.log("Action 2 clicked"),
+                },
+              ],
+              align: "start",
+            });
+          }}
+        >
+          Show Toast with Align Start
+        </Button>
+        <Toast
+          onClose={() => console.log("Toast closed")}
+          title="Toast Title with Align Start without Button"
+          duration={5000}
+          description="This is a toast description   with align start"
+          type="success"
+          actions={[
+            {
+              label: "Action 1",
+              altText: "Action 1 Alt Text",
+              onClick: () => console.log("Action 1 clicked"),
+              type: "primary",
+            },
+            {
+              label: "Action 2",
+              altText: "Action 2 Alt Text",
+              onClick: () => console.log("Action 2 clicked"),
+              type: "secondary",
+            },
+          ]}
+        />
+      </ToastProvider>
       <BackgroundWrapper>
         <ProgressBar
           progress={100}

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -274,9 +274,6 @@ export const ToastProvider = ({
       {...props}
     >
       <ToastContext.Provider value={value}>
-        {JSON.stringify(toasts[align].size)}
-        {align}
-        {JSON.stringify(Array.from(toasts[align]))}
         {children}
         {Array.from(toasts[align]).map(([id, toast]) => (
           <Toast

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -99,6 +99,7 @@ const ToastHeader = styled(RadixUIToast.Title)`
 
 const ToastDescriptionContainer = styled.div`
   display: flex;
+  flex-direction: column;
   justify-content: space-between;
   width: 100%;
   align-items: flex-end;
@@ -123,7 +124,7 @@ const Title = styled.div`
   flex: 1;
 `;
 
-const Toast = ({
+export const Toast = ({
   type,
   title,
   description,

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -204,7 +204,7 @@ const Viewport = styled(RadixUIToast.Viewport)<{ $align: "start" | "end" }>`
   outline: none;
 `;
 
-export interface ToastProviderProps extends RadixUIToast.ToastProps {
+export interface ToastProviderProps extends RadixUIToast.ToastProviderProps {
   align?: "start" | "end";
 }
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -71,4 +71,4 @@ export { createToast } from "./Toast/toastEmitter";
 export { UserIcon as ProfileIcon } from "./icons/UserIcon";
 export { default as VerticalStepper } from "./VerticalStepper/VerticalStepper";
 export { MultiAccordion } from "./MultiAccordion/MultiAccordion";
-export { ToastProvider } from "./Toast/Toast";
+export { ToastProvider, Toast } from "./Toast/Toast";


### PR DESCRIPTION
This is to fix the alignment in toasts and also exporting the toasts to components so that we can use it inside a ToastProvider incase we need to override the parent toast provider
The createToast would emit to both the content so it is necessary to export the component