### PR TITLE
fix: adjust colors for disabled menu item

### DIFF
--- a/src/components/GenericMenu.tsx
+++ b/src/components/GenericMenu.tsx
@@ -105,6 +105,7 @@ export const GenericMenuItem = styled.div`
       font: ${theme.click.genericMenu.item.typography.label.active};
     }
     &[data-disabled] {
+      // TODO use theme.click.genericMenu.item.color.text.disabled after it's fixed https://github.com/ClickHouse/click-ui/issues/621
       color:${theme.global.color.text.disabled};
       font: ${theme.click.genericMenu.item.typography.label.disabled};
       pointer-events: none;


### PR DESCRIPTION
- remove background color for disabled items because it's not required for a menu item
- use global disabled color instead of component-specific, because the component-specific is bugged in dark theme
  - note: the global disabled color is slighly darker in light theme

we plan to revisit how colors are defined once Gareth is back from his vacation next month

this affects
- AutoComplete
- ContextMenu
- Dropdown
- SingleSelect
- MultiSelect
- CheckboxMultiSelect

| | before | after |
|--------|--------|--------|
|dark| ![image](https://github.com/user-attachments/assets/2e29d023-9dac-4df8-8de5-5c0d71ea52b6) | ![image](https://github.com/user-attachments/assets/5deefb6f-2670-4229-87fe-2a69839bad51) | 
|light| ![image](https://github.com/user-attachments/assets/87f643de-4461-4e87-8e38-bcbb1f4b9a3d) | ![image](https://github.com/user-attachments/assets/a1b7e934-a6b0-4159-b076-77a4863bc19b) |