### PR TITLE
[icons] add text-slash icon and address hyphenated props for recent icons

### DIFF
--- a/src/components/Icon/IconCommon.tsx
+++ b/src/components/Icon/IconCommon.tsx
@@ -143,6 +143,7 @@ import Stop from "@/components/icons/Stop";
 import Support from "@/components/icons/Support";
 import Table from "@/components/icons/Table";
 import Taxi from "@/components/icons/Taxi";
+import TextSlash from "@/components/icons/TextSlash";
 import Trash from "@/components/icons/Trash";
 import TreeStructure from "@/components/icons/TreeStructure";
 import Underline from "@/components/icons/Underline";
@@ -300,6 +301,7 @@ export const ICONS_MAP = {
   support: Support,
   table: Table,
   taxi: Taxi,
+  "text-slash": TextSlash,
   trash: Trash,
   "tree-structure": TreeStructure,
   underline: Underline,

--- a/src/components/Icon/types.ts
+++ b/src/components/Icon/types.ts
@@ -153,6 +153,7 @@ export const ICON_NAMES = [
   "support",
   "table",
   "taxi",
+  "text-slash",
   "trash",
   "tree-structure",
   "upgrade",

--- a/src/components/icons/Bold.tsx
+++ b/src/components/icons/Bold.tsx
@@ -12,9 +12,9 @@ const Bold = (props: SVGAttributes<SVGElement>) => (
     <path
       d="M6.75 12H13.75C15.683 12 17.25 13.567 17.25 15.5V15.5C17.25 17.433 15.683 19 13.75 19H6.75V5H12.583C14.516 5 16.083 6.567 16.083 8.5V8.5C16.083 10.433 14.516 12 12.583 12"
       stroke="#161517"
-      stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     />
   </svg>
 );

--- a/src/components/icons/Italic.tsx
+++ b/src/components/icons/Italic.tsx
@@ -12,9 +12,9 @@ const Italic = (props: SVGAttributes<SVGElement>) => (
     <path
       d="M14.1821 18H5.45508H9.43508L14.5651 6H18.5451H9.81808"
       stroke="#161517"
-      stroke-width="1.5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     />
   </svg>
 );

--- a/src/components/icons/ListBulleted.tsx
+++ b/src/components/icons/ListBulleted.tsx
@@ -12,44 +12,44 @@ const ListBulleted = (props: SVGAttributes<SVGElement>) => (
     <path
       d="M8.99902 6.43673H20.0036"
       stroke="#161517"
-      stroke-width="1.5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     />
     <path
       d="M20.0036 12.0002H8.99902"
       stroke="#161517"
-      stroke-width="1.5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     />
     <path
       d="M8.99902 17.5632H20.0036"
       stroke="#161517"
-      stroke-width="1.5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     />
     <path
       d="M4.49728 5.93652C4.22102 5.93652 3.99707 6.16047 3.99707 6.43673C3.99707 6.71299 4.22102 6.93694 4.49728 6.93694C4.77354 6.93694 4.99749 6.71299 4.99749 6.43673C4.99749 6.16047 4.77354 5.93652 4.49728 5.93652"
       stroke="#161517"
-      stroke-width="1.5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     />
     <path
       d="M4.49728 11.5C4.22102 11.5 3.99707 11.724 3.99707 12.0002C3.99707 12.2765 4.22102 12.5004 4.49728 12.5004C4.77354 12.5004 4.99749 12.2765 4.99749 12.0002C4.99749 11.724 4.77354 11.5 4.49728 11.5"
       stroke="#161517"
-      stroke-width="1.5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     />
     <path
       d="M4.49728 17.063C4.22102 17.063 3.99707 17.2869 3.99707 17.5632C3.99707 17.8395 4.22102 18.0634 4.49728 18.0634C4.77354 18.0634 4.99749 17.8395 4.99749 17.5632C4.99749 17.2869 4.77354 17.063 4.49728 17.063"
       stroke="#161517"
-      stroke-width="1.5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     />
   </svg>
 );

--- a/src/components/icons/ListNumbered.tsx
+++ b/src/components/icons/ListNumbered.tsx
@@ -12,44 +12,44 @@ const ListNumbered = (props: SVGAttributes<SVGElement>) => (
     <path
       d="M11 4H20"
       stroke="#161517"
-      stroke-width="1.5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     />
     <path
       d="M11.1504 9H20.0004"
       stroke="#161517"
-      stroke-width="1.5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     />
     <path
       d="M6.5 9H4H5.25V4L4 5.25"
       stroke="#161517"
-      stroke-width="1.5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     />
     <path
       d="M11 15H20"
       stroke="#161517"
-      stroke-width="1.5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     />
     <path
       d="M11.1504 20H20.0004"
       stroke="#161517"
-      stroke-width="1.5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     />
     <path
       d="M4 15H6.5V17L4 18.5V20H6.75"
       stroke="#161517"
-      stroke-width="1.5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     />
   </svg>
 );

--- a/src/components/icons/TextSlash.tsx
+++ b/src/components/icons/TextSlash.tsx
@@ -13,44 +13,44 @@ const TextSlash = (props: SVGAttributes<SVGElement>) => (
       <path
         d="M4.5 3.75L19.5 20.25"
         stroke="#161517"
-        stroke-width="1.5"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
       <path
         d="M9 18.75H15"
         stroke="#161517"
-        stroke-width="1.5"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
       <path
         d="M12 12V18.75"
         stroke="#161517"
-        stroke-width="1.5"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
       <path
         d="M12 5.25V7.54031"
         stroke="#161517"
-        stroke-width="1.5"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
       <path
         d="M9.91797 5.25H18.7502V8.25"
         stroke="#161517"
-        stroke-width="1.5"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
       <path
         d="M5.25 8.25V5.25H5.86406"
         stroke="#161517"
-        stroke-width="1.5"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
       />
     </g>
     <defs>

--- a/src/components/icons/TextSlash.tsx
+++ b/src/components/icons/TextSlash.tsx
@@ -1,0 +1,68 @@
+import { SVGAttributes } from "react";
+
+const TextSlash = (props: SVGAttributes<SVGElement>) => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <g clip-path="url(#clip0_12066_12491)">
+      <path
+        d="M4.5 3.75L19.5 20.25"
+        stroke="#161517"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M9 18.75H15"
+        stroke="#161517"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M12 12V18.75"
+        stroke="#161517"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M12 5.25V7.54031"
+        stroke="#161517"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M9.91797 5.25H18.7502V8.25"
+        stroke="#161517"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M5.25 8.25V5.25H5.86406"
+        stroke="#161517"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </g>
+    <defs>
+      <clipPath id="clip0_12066_12491">
+        <rect
+          width="24"
+          height="24"
+          fill="white"
+        />
+      </clipPath>
+    </defs>
+  </svg>
+);
+
+export default TextSlash;

--- a/src/components/icons/Underline.tsx
+++ b/src/components/icons/Underline.tsx
@@ -12,16 +12,16 @@ const Underline = (props: SVGAttributes<SVGElement>) => (
     <path
       d="M6 20H18"
       stroke="#161517"
-      stroke-width="1.5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     />
     <path
       d="M17 4V11C17 13.761 14.761 16 12 16C9.239 16 7 13.761 7 11V4"
       stroke="#161517"
-      stroke-width="1.5"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
     />
   </svg>
 );


### PR DESCRIPTION
This PR adds a `text-slash` icon that can be used in text editor to clear current formatting.