### PR TITLE
fix: restore the `never` fields in SelectOptionItem

### DIFF
--- a/src/components/Select/common/types.ts
+++ b/src/components/Select/common/types.ts
@@ -40,6 +40,7 @@ export interface SelectGroupProps
 }
 export interface SelectOptionItem
   extends Omit<SelectItemProps, "children" | "label" | "description"> {
+  heading?: never;
   label: ReactNode;
   description?: ReactNode;
   [key: `data-${string}`]: string;
@@ -48,6 +49,7 @@ export interface SelectOptionItem
 interface SelectGroupOptionItem
   extends Omit<SelectGroupProps, "children" | "label" | "description"> {
   options: Array<SelectOptionItem>;
+  label?: never;
   [key: `data-${string}`]: string;
 }
 


### PR DESCRIPTION
In https://github.com/ClickHouse/click-ui/pull/610/ I removed fields that I thought were unnecessary. This changed component API though, the exported type became a union, one member of which didn't have the `label` field anymore. This reverts this change, restoring the API.