### PR TITLE
Add Enter key support to trigger `onConfirm` in `ConfirmationDialog`

### DIFF
--- a/src/components/ConfirmationDialog/ConfirmationDialog.test.tsx
+++ b/src/components/ConfirmationDialog/ConfirmationDialog.test.tsx
@@ -18,6 +18,8 @@ describe("Dialog Component", () => {
       primaryActionLabel = "Confirm",
       secondaryActionLabel = "Cancel",
       children,
+      disabled,
+      loading,
     }: Partial<ConfirmationDialogProps> = {} as ConfirmationDialogProps
   ) =>
     renderCUI(
@@ -30,6 +32,8 @@ describe("Dialog Component", () => {
         onCancel={onCancel}
         open={open}
         children={children}
+        disabled={disabled}
+        loading={loading}
       />
     );
 
@@ -129,5 +133,57 @@ describe("Dialog Component", () => {
     expect(() => renderDialog({ children, message, open: true })).toThrowError(
       "You can't pass children and message props at the same time"
     );
+  });
+
+  describe("Enter key functionality", () => {
+    it("triggers onConfirm when Enter key is pressed", () => {
+      const onConfirm = vi.fn();
+      const { getByRole } = renderDialog({ onConfirm, open: true });
+
+      fireEvent.keyDown(getByRole("dialog"), { key: "Enter" });
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+    });
+
+    it("triggers onConfirm multiple times when Enter is pressed multiple times", () => {
+      const onConfirm = vi.fn();
+      const { getByRole } = renderDialog({ onConfirm, open: true });
+
+      fireEvent.keyDown(getByRole("dialog"), { key: "Enter" });
+      fireEvent.keyDown(getByRole("dialog"), { key: "Enter" });
+      fireEvent.keyDown(getByRole("dialog"), { key: "Enter" });
+      expect(onConfirm).toHaveBeenCalledTimes(3);
+    });
+
+    it("does not trigger onConfirm when Enter is pressed and dialog is disabled", () => {
+      const onConfirm = vi.fn();
+      const { getByRole } = renderDialog({
+        onConfirm,
+        disabled: true,
+        open: true,
+      });
+
+      fireEvent.keyDown(getByRole("dialog"), { key: "Enter" });
+      expect(onConfirm).not.toHaveBeenCalled();
+    });
+
+    it("does not trigger onConfirm when Enter is pressed and dialog is loading", () => {
+      const onConfirm = vi.fn();
+      const { getByRole } = renderDialog({
+        onConfirm,
+        loading: true,
+        open: true,
+      });
+
+      fireEvent.keyDown(getByRole("dialog"), { key: "Enter" });
+      expect(onConfirm).not.toHaveBeenCalled();
+    });
+
+    it("does not trigger onConfirm when Enter is pressed and onConfirm is not provided", () => {
+      const { getByRole } = renderDialog({ onConfirm: undefined, open: true });
+
+      expect(() =>
+        fireEvent.keyDown(getByRole("dialog"), { key: "Enter" })
+      ).not.toThrow();
+    });
   });
 });

--- a/src/components/ConfirmationDialog/ConfirmationDialog.test.tsx
+++ b/src/components/ConfirmationDialog/ConfirmationDialog.test.tsx
@@ -18,8 +18,6 @@ describe("Dialog Component", () => {
       primaryActionLabel = "Confirm",
       secondaryActionLabel = "Cancel",
       children,
-      disabled,
-      loading,
     }: Partial<ConfirmationDialogProps> = {} as ConfirmationDialogProps
   ) =>
     renderCUI(
@@ -32,8 +30,6 @@ describe("Dialog Component", () => {
         onCancel={onCancel}
         open={open}
         children={children}
-        disabled={disabled}
-        loading={loading}
       />
     );
 
@@ -135,55 +131,15 @@ describe("Dialog Component", () => {
     );
   });
 
-  describe("Enter key functionality", () => {
-    it("triggers onConfirm when Enter key is pressed", () => {
-      const onConfirm = vi.fn();
-      const { getByRole } = renderDialog({ onConfirm, open: true });
+  it("focuses the confirm button when dialog opens", async () => {
+    const { getByTestId } = renderDialog({ open: true });
+    const confirmButton = getByTestId("confirm-action-button");
 
-      fireEvent.keyDown(getByRole("dialog"), { key: "Enter" });
-      expect(onConfirm).toHaveBeenCalledTimes(1);
-    });
+    expect(document.activeElement).toBe(confirmButton);
+  });
 
-    it("triggers onConfirm multiple times when Enter is pressed multiple times", () => {
-      const onConfirm = vi.fn();
-      const { getByRole } = renderDialog({ onConfirm, open: true });
-
-      fireEvent.keyDown(getByRole("dialog"), { key: "Enter" });
-      fireEvent.keyDown(getByRole("dialog"), { key: "Enter" });
-      fireEvent.keyDown(getByRole("dialog"), { key: "Enter" });
-      expect(onConfirm).toHaveBeenCalledTimes(3);
-    });
-
-    it("does not trigger onConfirm when Enter is pressed and dialog is disabled", () => {
-      const onConfirm = vi.fn();
-      const { getByRole } = renderDialog({
-        onConfirm,
-        disabled: true,
-        open: true,
-      });
-
-      fireEvent.keyDown(getByRole("dialog"), { key: "Enter" });
-      expect(onConfirm).not.toHaveBeenCalled();
-    });
-
-    it("does not trigger onConfirm when Enter is pressed and dialog is loading", () => {
-      const onConfirm = vi.fn();
-      const { getByRole } = renderDialog({
-        onConfirm,
-        loading: true,
-        open: true,
-      });
-
-      fireEvent.keyDown(getByRole("dialog"), { key: "Enter" });
-      expect(onConfirm).not.toHaveBeenCalled();
-    });
-
-    it("does not trigger onConfirm when Enter is pressed and onConfirm is not provided", () => {
-      const { getByRole } = renderDialog({ onConfirm: undefined, open: true });
-
-      expect(() =>
-        fireEvent.keyDown(getByRole("dialog"), { key: "Enter" })
-      ).not.toThrow();
-    });
+  it("does not focus when dialog is closed", () => {
+    const { queryByTestId } = renderDialog({ open: false });
+    expect(queryByTestId("confirm-action-button")).toBeNull();
   });
 });

--- a/src/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/src/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -53,19 +53,6 @@ export const ConfirmationDialog = ({
     throw new Error("You can't pass children and message props at the same time");
   }
 
-  /**
-   * Run the onConfirm callback when the Enter key is pressed.
-   * Prevents the default action of the Enter key if the dialog is not disabled or loading.
-   *
-   * @param event - The React keyboard event
-   */
-  const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === "Enter" && onConfirm && !disabled && !loading) {
-      event.preventDefault();
-      onConfirm();
-    }
-  };
-
   return (
     <Dialog
       open={open}
@@ -77,7 +64,6 @@ export const ConfirmationDialog = ({
         as={Dialog.Content}
         title={title}
         showClose={showClose}
-        onKeyDown={handleKeyDown}
         {...props}
       >
         <Container
@@ -98,6 +84,7 @@ export const ConfirmationDialog = ({
             disabled={!!disabled || !!loading}
             type={primaryActionType}
             label={primaryActionLabel}
+            autoFocus={open}
             onClick={() => {
               if (onConfirm) {
                 onConfirm();

--- a/src/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/src/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -53,6 +53,19 @@ export const ConfirmationDialog = ({
     throw new Error("You can't pass children and message props at the same time");
   }
 
+  /**
+   * Run the onConfirm callback when the Enter key is pressed.
+   * Prevents the default action of the Enter key if the dialog is not disabled or loading.
+   *
+   * @param event - The React keyboard event
+   */
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === "Enter" && onConfirm && !disabled && !loading) {
+      event.preventDefault();
+      onConfirm();
+    }
+  };
+
   return (
     <Dialog
       open={open}
@@ -64,6 +77,7 @@ export const ConfirmationDialog = ({
         as={Dialog.Content}
         title={title}
         showClose={showClose}
+        onKeyDown={handleKeyDown}
         {...props}
       >
         <Container


### PR DESCRIPTION
This PR adds keyboard event handler to ConfirmationDialog that triggers `onConfirm` when Enter key is pressed.