### PR TITLE
fix(MultiAccordion): restrain item trigger content within item element

### DIFF
--- a/src/components/MultiAccordion/MultiAccordion.tsx
+++ b/src/components/MultiAccordion/MultiAccordion.tsx
@@ -144,11 +144,13 @@ const MultiAccordionItem = ({
           fillWidth
           justifyContent="space-between"
           component="span"
+          overflow="hidden"
         >
           <Text
             component="span"
             size={customSize}
             fillWidth={fillWidth}
+            style={{ overflow: "hidden" }}
           >
             {title}
           </Text>

--- a/src/components/MultiAccordion/MultiAccordion.tsx
+++ b/src/components/MultiAccordion/MultiAccordion.tsx
@@ -146,14 +146,13 @@ const MultiAccordionItem = ({
           component="span"
           overflow="hidden"
         >
-          <Text
+          <AccordionItemTitle
             component="span"
             size={customSize}
             fillWidth={fillWidth}
-            style={{ overflow: "hidden" }}
           >
             {title}
-          </Text>
+          </AccordionItemTitle>
           {showCheck && (
             <CustomIcon
               name={isCompleted ? "check-in-circle" : "circle"}
@@ -290,4 +289,8 @@ const CustomIcon = styled(Icon)<{ $isCompleted: boolean }>`
 const AccordionContent = styled(RadixAccordion.Content)<{ $padding: PaddingOptions }>`
   padding: ${({ theme, $padding }): string => theme.click.container.space[$padding]};
   padding-top: 0;
+`;
+
+const AccordionItemTitle = styled(Text)`
+  overflow: hidden;
 `;


### PR DESCRIPTION
## What and Why

Right now if item title can't wrap, it breaks item layout:
![image](https://github.com/user-attachments/assets/37794281-4d98-4fd8-9780-b89539b7ff9e)

With the change it would look like that:
![image](https://github.com/user-attachments/assets/043d4684-72e5-4e18-91fc-a99766b5fb60)

Which allows consumers to adjust overflow behavior on their side:
![image](https://github.com/user-attachments/assets/30e34388-013b-459e-bdfd-7d584856274a)

Without these changes, an attempt to apply overflow behavior on consumer's side results in broken layout as well:
![image](https://github.com/user-attachments/assets/76b7cef1-62c3-4761-994c-fee5d9662b39)
