### PR TITLE
Set min-height for Select

### DIFF
--- a/src/components/Select/common/SelectStyled.tsx
+++ b/src/components/Select/common/SelectStyled.tsx
@@ -21,7 +21,7 @@ export const StyledSelectTrigger = styled(Trigger)<{ $error: boolean }>`
   justify-content: space-between;
   align-items: center;
   cursor: pointer;
-  min-height: ${({ theme }) => theme.sizes[9]};
+  min-height: ${({ theme }) => theme.genericMenu.panel.size.height};
 
   span:first-of-type {
     max-width: 100%;

--- a/src/components/Select/common/SelectStyled.tsx
+++ b/src/components/Select/common/SelectStyled.tsx
@@ -21,6 +21,7 @@ export const StyledSelectTrigger = styled(Trigger)<{ $error: boolean }>`
   justify-content: space-between;
   align-items: center;
   cursor: pointer;
+  min-height: ${({ theme }) => theme.sizes[9]};
 
   span:first-of-type {
     max-width: 100%;


### PR DESCRIPTION
Currently, the Select component's height varies depending on whether the Select has a value or not. 

<img width="698" alt="Screenshot 2025-07-06 at 10 21 39 PM" src="https://github.com/user-attachments/assets/b6b704c3-1b6d-4bc5-8e23-a619a8e5e2bd" />
<br></br>
Ideally, the height of the Select does not change depending on what value it has. 


This PR fixes the height of the Select to what it is when it has a truthy value
