### PR TITLE
Updating named imports

### DIFF
--- a/src/components/FileUpload/FileUpload.tsx
+++ b/src/components/FileUpload/FileUpload.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
-import styled, { css } from "styled-components";
+import styled from "styled-components";
+import { css } from "styled-components";
 import { useState, useRef, useCallback } from "react";
 
 import { truncateFilename } from "@/utils/truncate.ts";

--- a/src/stories/chartColors.stories.tsx
+++ b/src/stories/chartColors.stories.tsx
@@ -1,5 +1,6 @@
 import { Container, Text } from "@/components";
-import styled, { useTheme } from "styled-components";
+import styled from "styled-components";
+import { useTheme } from "styled-components";
 
 const ColorBox = styled(Container)<{
   $color: string;


### PR DESCRIPTION
### Summary
CommonJS and doesn’t support mixed default + named imports the way ESM expects

So we can't use 

```
import styled, { css } from 'styled-components';
```

We must instead use

```
import styled from 'styled-components';
import { css } from 'styled-components';
```