### PR TITLE
Checkbox: support indeterminate state

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,10 +1,10 @@
 import type { StorybookConfig } from "@storybook/react-vite";
 const config: StorybookConfig = {
   core: {
-    disableTelemetry: true
+    disableTelemetry: true,
   },
   stories: [
-    "../src/Introduction.mdx", 
+    "../src/Introduction.mdx",
     "../src/components/icons/Icons.mdx",
     "../src/**/*.stories.@(js|jsx|ts|tsx)",
   ],
@@ -12,7 +12,7 @@ const config: StorybookConfig = {
     "@storybook/addon-links",
     "@storybook/addon-essentials",
     {
-      name: '@storybook/addon-storysource',
+      name: "@storybook/addon-storysource",
       options: {
         loaderOptions: {
           prettierConfig: { printWidth: 80, singleQuote: false },
@@ -31,5 +31,18 @@ const config: StorybookConfig = {
     autodocs: "tag",
   },
   staticDirs: ["../public"],
+  typescript: {
+    reactDocgen: "react-docgen-typescript",
+    reactDocgenTypescriptOptions: {
+      compilerOptions: {
+        allowSyntheticDefaultImports: false,
+        esModuleInterop: false,
+      },
+      shouldRemoveUndefinedFromOptional: true,
+      shouldExtractLiteralValuesFromEnum: true,
+      propFilter: prop =>
+        prop.parent ? !/node_modules\/(?!@radix-ui)/.test(prop.parent.fileName) : true,
+    },
+  },
 };
 export default config;

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,41 +1,37 @@
-import { Checkbox } from "./Checkbox";
+import { Meta, StoryObj } from "@storybook/react";
 
-const CheckboxComponent = ({
-  checked,
-  ...props
-}: {
-  checked: "default" | "checked" | "unchecked";
-  disabled: boolean;
-  label?: string;
-}) => {
-  return (
-    <Checkbox
-      checked={checked === "default" ? undefined : checked === "checked"}
-      {...props}
-    />
-  );
-};
-export default {
-  component: CheckboxComponent,
+import { Checkbox } from "./Checkbox";
+import { useEffect, useState } from "react";
+
+const meta: Meta<typeof Checkbox> = {
+  component: Checkbox,
   title: "Forms/Checkbox",
   tags: ["checkbox", "autodocs"],
   argTypes: {
-    checked: { control: "radio", options: ["default", "checked", "unchecked"] },
-    disabled: { control: "boolean" },
-    label: { control: "text" },
-    orientation: { control: "inline-radio", options: ["horizontal", "vertical"] },
-    dir: { control: "inline-radio", options: ["start", "end"] },
-    variant: {
-      control: "radio",
-      options: ["default", "var1", "var2", "var3", "var4", "var5", "var6"],
-    },
+    checked: { control: "radio", options: [true, false, "indeterminate"] },
+    defaultChecked: { control: "radio", options: [true, false, "indeterminate"] },
+  },
+  render: ({ checked, ...props }) => {
+    const [checkedState, setCheckedState] = useState(checked);
+
+    useEffect(() => {
+      setCheckedState(checked);
+    }, [checked]);
+
+    return (
+      <Checkbox
+        {...props}
+        checked={checkedState}
+        onCheckedChange={setCheckedState}
+      />
+    );
   },
 };
 
-export const Playground = {
+export default meta;
+
+export const Playground: StoryObj<typeof Checkbox> = {
   args: {
     label: "Accept terms and conditions",
-    disabled: false,
-    checked: "default",
   },
 };

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,7 +1,8 @@
+import { useEffect, useState } from "react";
+
 import { Meta, StoryObj } from "@storybook/react";
 
 import { Checkbox } from "./Checkbox";
-import { useEffect, useState } from "react";
 
 const meta: Meta<typeof Checkbox> = {
   component: Checkbox,

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -28,23 +28,23 @@ const Wrapper = styled(FormRoot)`
 export const Checkbox = ({
   id,
   label,
-  variant,
+  variant = "default",
   disabled,
-  orientation,
-  dir,
+  orientation = "horizontal",
+  dir = "end",
   checked,
   ...delegated
 }: CheckboxProps) => {
   const defaultId = useId();
   return (
     <Wrapper
-      $orientation={orientation ?? "horizontal"}
-      $dir={dir ?? "end"}
+      $orientation={orientation}
+      $dir={dir}
     >
       <CheckInput
         id={id ?? defaultId}
         data-testid="checkbox"
-        variant={variant ?? "default"}
+        variant={variant}
         disabled={disabled}
         aria-label={`${label}`}
         checked={checked}
@@ -77,7 +77,7 @@ const CheckInput = styled(RadixCheckbox.Root)<{
   justify-content: center;
   flex-shrink: 0;
 
-  ${({ theme, variant = "default" }) => `
+  ${({ theme, variant }) => `
     border-radius: ${theme.click.checkbox.radii.all};
     width: ${theme.click.checkbox.size.all};
     height: ${theme.click.checkbox.size.all};

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -32,6 +32,7 @@ export const Checkbox = ({
   disabled,
   orientation,
   dir,
+  checked,
   ...delegated
 }: CheckboxProps) => {
   const defaultId = useId();
@@ -46,11 +47,12 @@ export const Checkbox = ({
         variant={variant ?? "default"}
         disabled={disabled}
         aria-label={`${label}`}
+        checked={checked}
         {...delegated}
       >
         <CheckIconWrapper>
           <Icon
-            name="check"
+            name={checked === "indeterminate" ? "minus" : "check"}
             size="sm"
           />
         </CheckIconWrapper>
@@ -86,7 +88,8 @@ const CheckInput = styled(RadixCheckbox.Root)<{
     &:hover {
       background: ${theme.click.checkbox.color.variations[variant].background.hover};
     }
-    &[data-state="checked"] {
+    &[data-state="checked"],
+    &[data-state="indeterminate"] {
       border-color: ${theme.click.checkbox.color.variations[variant].stroke.active};
       background: ${theme.click.checkbox.color.variations[variant].background.active};
     }
@@ -94,7 +97,8 @@ const CheckInput = styled(RadixCheckbox.Root)<{
       background: ${theme.click.checkbox.color.background.disabled};
       border-color: ${theme.click.checkbox.color.stroke.disabled};
       cursor: not-allowed;
-      &[data-state="checked"] {
+      &[data-state="checked"],
+      &[data-state="indeterminate"] {
         background: ${theme.click.checkbox.color.background.disabled};
         border-color: ${theme.click.checkbox.color.stroke.disabled};
       }


### PR DESCRIPTION
## Why

Checkbox indeterminate state:
<img width="247" height="47" alt="image" src="https://github.com/user-attachments/assets/b4716808-aea4-477a-afca-3d5c5b3beeaf" />

Usually used to indicate that a subset of nested checkboxes is checked:
<img width="252" height="141" alt="image" src="https://github.com/user-attachments/assets/60c12cbc-4a01-4e2c-bbb5-6ffb122edcc4" />

It's a part of the standard: https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/indeterminate
And also is a part of radix-ui checkbox: https://www.radix-ui.com/primitives/docs/components/checkbox#root

So currently component can be set to the indeterminate state, but we don't have a visual indication for this.

## What

- support indeterminate state using the "minus" icon
- improve storybook generation: auto-generated specs for a component will now use inherited props from radix-ui