### PR TITLE
feat(Table): indeterminate state for selectable rows

### DIFF
--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -13,6 +13,7 @@ const rows: TableRowType[] = [
       { label: "Maria Anders" },
       { label: "Germany" },
     ],
+    isIndeterminate: true,
   },
   {
     id: "row-2",
@@ -63,28 +64,31 @@ export const Selectable: StoryObj<typeof Table> = {
     rows,
     isSelectable: true,
     selectedIds: [],
-    indeterminateIds: ["row-1"],
   },
-  render: ({ selectedIds, indeterminateIds, ...props }) => {
+  render: ({ selectedIds, rows: rowsProp, ...props }) => {
+    const [rows, setRows] = useState(rowsProp);
     const [selectedRows, setSelectedRows] = useState(selectedIds);
-    const [indeterminateRows, setIndeterminateRows] = useState(indeterminateIds);
 
     useEffect(() => {
       setSelectedRows(selectedIds);
     }, [selectedIds]);
 
     useEffect(() => {
-      setIndeterminateRows(indeterminateIds);
-    }, [indeterminateIds, selectedIds]);
+      setRows(prevState =>
+        prevState.map(row => ({
+          ...row,
+          isIndeterminate: selectedRows?.includes(row.id) ? false : row.isIndeterminate,
+        }))
+      );
+    }, [selectedRows]);
 
     return (
       <Table
         {...props}
+        rows={rows}
         selectedIds={selectedRows}
-        indeterminateIds={indeterminateRows}
-        onSelect={(selectedItems, indeterminateItems) => {
+        onSelect={selectedItems => {
           setSelectedRows(selectedItems.map(({ item: { id } }) => id));
-          setIndeterminateRows(indeterminateItems.map(({ item: { id } }) => id));
         }}
       />
     );

--- a/src/components/Table/Table.stories.tsx
+++ b/src/components/Table/Table.stories.tsx
@@ -63,21 +63,29 @@ export const Selectable: StoryObj<typeof Table> = {
     rows,
     isSelectable: true,
     selectedIds: [],
+    indeterminateIds: ["row-1"],
   },
-  render: ({ selectedIds, ...props }) => {
+  render: ({ selectedIds, indeterminateIds, ...props }) => {
     const [selectedRows, setSelectedRows] = useState(selectedIds);
+    const [indeterminateRows, setIndeterminateRows] = useState(indeterminateIds);
 
     useEffect(() => {
       setSelectedRows(selectedIds);
     }, [selectedIds]);
 
+    useEffect(() => {
+      setIndeterminateRows(indeterminateIds);
+    }, [indeterminateIds, selectedIds]);
+
     return (
       <Table
         {...props}
         selectedIds={selectedRows}
-        onSelect={selectedItems =>
-          setSelectedRows(selectedItems.map(({ item: { id } }) => id))
-        }
+        indeterminateIds={indeterminateRows}
+        onSelect={(selectedItems, indeterminateItems) => {
+          setSelectedRows(selectedItems.map(({ item: { id } }) => id));
+          setIndeterminateRows(indeterminateItems.map(({ item: { id } }) => id));
+        }}
       />
     );
   },


### PR DESCRIPTION
## Why

There are cases when we need to indicate that a row is “partially selected”.

For example, imagine a dialog for specifying “These N roles should be assigned to the following users”. Some of the users may already have some of the roles assigned to them. In this case we can't check the row (because not _all_ of the roles are assigned to this user), and we can't leave the row unchecked (because _some_ of the roles _are_ assigned). We need the indeterminate state to handle this situation.

## What

See https://github.com/ClickHouse/click-ui/pull/647#discussion_r2250871579

Initial version, no longer actual:
- add a separate prop `indeterminateIds` that has the same behavior and shape as `selectedIds`
- `onSelect` handler now reports two arrays: `selectedIds` and `indeterminateIds`
  - this preserves backward compatibility, handlers that expect a single argument will still work
- users can't modify `indeterminateIds`, it can only be set programmatically