### PR TITLE
Codeblock: remove text styling alltogether

### DIFF
--- a/src/components/CodeBlock/CodeBlock.tsx
+++ b/src/components/CodeBlock/CodeBlock.tsx
@@ -45,7 +45,6 @@ const CodeBlockContainer = styled.div<{ $theme?: CodeThemeType }>`
   width: fill-available;
   width: stretch;
   position: relative;
-  cursor: text;
   ${({ theme, $theme }) => {
     const themeName = (theme.name !== "classic" ? theme.name : "light") as CodeThemeType;
 


### PR DESCRIPTION
After a chat with @ariser, it seems like the `cursor` styling isn't needed at all

#### with `cursor:text` (current styling)
https://github.com/user-attachments/assets/3e54d90c-77bb-49f8-bb1a-5a65507ad70c

#### with no `cursor` styling (what this PR enacts)
https://github.com/user-attachments/assets/e475ea74-3eb5-4a30-947c-5ef20d990c00

