### PR TITLE
ConfirmationDialog: make props extend HTMLDivElement

### DIFF
--- a/src/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/src/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -1,10 +1,10 @@
 import { Container, Dialog, Separator, Text } from "@/components";
-import { ReactElement, ReactNode } from "react";
+import { HTMLAttributes, ReactElement, ReactNode } from "react";
 import { styled } from "styled-components";
 
 type DialogPrimaryAction = "primary" | "danger";
 
-export interface ConfirmationDialogProps {
+export interface ConfirmationDialogProps extends HTMLAttributes<HTMLDivElement> {
   children?: ReactNode;
   disabled?: boolean;
   loading?: boolean;


### PR DESCRIPTION
A downstream element making use of `ConfirmationDialog` needs to pass a `onKeyPress` handler, but TypeScript is having a fit about it, even though the handler gets called and works properly.