### PR TITLE
Add `NoOptions` story and tests for `customText` handling in Select component

### DIFF
--- a/src/components/Select/SingleSelect.stories.tsx
+++ b/src/components/Select/SingleSelect.stories.tsx
@@ -123,7 +123,7 @@ export const UseFullWidth = {
 };
 
 export const NoOptions: StoryObj<typeof Select> = {
-  args: { label: "Label", customText: 'No results for "{search}"' },
+  args: { label: "Label", customText: "No results for \"{search}\"" },
   render: ({ customText, ...rest }) => (
     <Container fillWidth gap="sm">   
       <Panel width="400px">

--- a/src/components/Select/SingleSelect.stories.tsx
+++ b/src/components/Select/SingleSelect.stories.tsx
@@ -2,6 +2,7 @@ import { Meta, StoryObj } from "@storybook/react-vite";
 import { Select } from "@/components/Select/SingleSelect";
 import { selectOptions } from "@/components/Select/selectOptions";
 import { Container } from "@/components/Container/Container";
+import { GridContainer } from "@/components/GridContainer/GridContainer";
 import { Panel } from "@/components/Panel/Panel";
 import { Title } from "@/components/Typography/Title/Title";
 
@@ -119,4 +120,35 @@ export const UseFullWidth = {
     );
   },
   tags: ["form-field", "select", "autodocs"],
+};
+
+export const NoOptions: StoryObj<typeof Select> = {
+  args: { label: "Label", customText: 'No results for "{search}"' },
+  render: ({ customText, ...rest }) => (
+    <GridContainer
+      columnGap="sm"
+      gridTemplateColumns="repeat(2, auto)"
+    >
+      <Panel>
+        <Title type="h2">Empty options</Title>
+        <Select
+          options={[]}
+          customText="No results match your filters. Try adjusting them."
+          {...rest}
+        />
+      </Panel>
+      <Panel>
+        <Title type="h2">Simple options</Title>
+        <Select
+          options={[
+            { value: "apple", label: "Apple" },
+            { value: "banana", label: "Banana" },
+            { value: "cherry", label: "Cherry" },
+          ]}
+          customText={customText}
+          {...rest}
+        />
+      </Panel>
+    </GridContainer>
+  ),
 };

--- a/src/components/Select/SingleSelect.stories.tsx
+++ b/src/components/Select/SingleSelect.stories.tsx
@@ -2,7 +2,6 @@ import { Meta, StoryObj } from "@storybook/react-vite";
 import { Select } from "@/components/Select/SingleSelect";
 import { selectOptions } from "@/components/Select/selectOptions";
 import { Container } from "@/components/Container/Container";
-import { GridContainer } from "@/components/GridContainer/GridContainer";
 import { Panel } from "@/components/Panel/Panel";
 import { Title } from "@/components/Typography/Title/Title";
 
@@ -125,11 +124,8 @@ export const UseFullWidth = {
 export const NoOptions: StoryObj<typeof Select> = {
   args: { label: "Label", customText: 'No results for "{search}"' },
   render: ({ customText, ...rest }) => (
-    <GridContainer
-      columnGap="sm"
-      gridTemplateColumns="repeat(2, auto)"
-    >
-      <Panel>
+    <Container fillWidth gap="sm">   
+      <Panel width="400px">
         <Title type="h2">Empty options</Title>
         <Select
           options={[]}
@@ -137,7 +133,7 @@ export const NoOptions: StoryObj<typeof Select> = {
           {...rest}
         />
       </Panel>
-      <Panel>
+      <Panel width="400px">
         <Title type="h2">Simple options</Title>
         <Select
           options={[
@@ -149,6 +145,6 @@ export const NoOptions: StoryObj<typeof Select> = {
           {...rest}
         />
       </Panel>
-    </GridContainer>
+    </Container>
   ),
 };

--- a/src/components/Select/SingleSelect.stories.tsx
+++ b/src/components/Select/SingleSelect.stories.tsx
@@ -2,6 +2,7 @@ import { Meta, StoryObj } from "@storybook/react-vite";
 import { Select } from "@/components/Select/SingleSelect";
 import { selectOptions } from "@/components/Select/selectOptions";
 import { Container } from "@/components/Container/Container";
+import { Text } from "@/components/Typography/Text/Text";
 import { Panel } from "@/components/Panel/Panel";
 import { Title } from "@/components/Typography/Title/Title";
 
@@ -126,7 +127,8 @@ export const NoOptions: StoryObj<typeof Select> = {
   render: ({ customText, ...rest }) => (
     <Container fillWidth gap="sm">   
       <Panel width="400px">
-        <Title type="h2">Empty options</Title>
+        <Title type="h2">No options available</Title>
+        <Text>When no options are available, the component will display a custom text.</Text>
         <Select
           options={[]}
           customText="No results match your filters. Try adjusting them."
@@ -134,7 +136,8 @@ export const NoOptions: StoryObj<typeof Select> = {
         />
       </Panel>
       <Panel width="400px">
-        <Title type="h2">Simple options</Title>
+        <Title type="h2">Search returns no results</Title>
+        <Text>When the search returns no results, the component will display a custom text.</Text>
         <Select
           options={[
             { value: "apple", label: "Apple" },

--- a/src/components/Select/SingleSelect.stories.tsx
+++ b/src/components/Select/SingleSelect.stories.tsx
@@ -123,7 +123,7 @@ export const UseFullWidth = {
 };
 
 export const NoOptions: StoryObj<typeof Select> = {
-  args: { label: "Label", customText: 'No results for "{search}"' },
+  args: { label: "Label", customText: "No results for \"{search}\"" },
   render: ({ customText, ...rest }) => (
     <Container
       fillWidth

--- a/src/components/Select/SingleSelect.stories.tsx
+++ b/src/components/Select/SingleSelect.stories.tsx
@@ -123,6 +123,7 @@ export const UseFullWidth = {
 };
 
 export const NoOptions: StoryObj<typeof Select> = {
+  // prettier-ignore
   args: { label: "Label", customText: "No results for \"{search}\"" },
   render: ({ customText, ...rest }) => (
     <Container

--- a/src/components/Select/SingleSelect.stories.tsx
+++ b/src/components/Select/SingleSelect.stories.tsx
@@ -123,12 +123,17 @@ export const UseFullWidth = {
 };
 
 export const NoOptions: StoryObj<typeof Select> = {
-  args: { label: "Label", customText: "No results for \"{search}\"" },
+  args: { label: "Label", customText: 'No results for "{search}"' },
   render: ({ customText, ...rest }) => (
-    <Container fillWidth gap="sm">   
+    <Container
+      fillWidth
+      gap="sm"
+    >
       <Panel width="400px">
         <Title type="h2">No options available</Title>
-        <Text>When no options are available, the component will display a custom text.</Text>
+        <Text>
+          When no options are available, the component will display a custom text.
+        </Text>
         <Select
           options={[]}
           customText="No results match your filters. Try adjusting them."
@@ -137,7 +142,9 @@ export const NoOptions: StoryObj<typeof Select> = {
       </Panel>
       <Panel width="400px">
         <Title type="h2">Search returns no results</Title>
-        <Text>When the search returns no results, the component will display a custom text.</Text>
+        <Text>
+          When the search returns no results, the component will display a custom text.
+        </Text>
         <Select
           options={[
             { value: "apple", label: "Apple" },

--- a/src/components/Select/SingleSelect.test.tsx
+++ b/src/components/Select/SingleSelect.test.tsx
@@ -372,5 +372,33 @@ describe("Select", () => {
       expect(onClick).toBeCalledTimes(1);
       expect(btn).not.toBeVisible();
     });
+
+    it("replaces {search} token in customText", () => {
+      const { queryByText, getByTestId } = renderSelect({
+        showSearch: true,
+        customText: "No results for {search}",
+      });
+      const selectTrigger = queryByText("Select an option");
+      expect(selectTrigger).not.toBeNull();
+      selectTrigger && fireEvent.click(selectTrigger);
+
+      fireEvent.change(getByTestId("select-search-input"), {
+        target: { value: "xyz" },
+      });
+      const emptyState = queryByText("No results for xyz");
+      expect(emptyState).not.toBeNull();
+    });
+  });
+
+  it("shows customText when options list is empty", () => {
+    const { queryByText } = renderSelect({
+      options: [],
+      customText: "Nothing here",
+    });
+    const selectTrigger = queryByText("Select an option");
+    expect(selectTrigger).not.toBeNull();
+    selectTrigger && fireEvent.click(selectTrigger);
+
+    expect(queryByText("Nothing here")).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

This PR adds a `NoOptions` story to demonstrate how to use `customText` when no options are available.

Example 1 - When no options are available, the component will display a custom text.
Example 2 - When the search returns no results, the component will display a custom text.

Closes #653.

https://github.com/user-attachments/assets/39f3ebad-4505-4ce4-b91a-c5a8a2d12be2


## Preview

https://click-ui-git-select-no-options-text-clickhouse.vercel.app/?path=/story/forms-select--no-options