### PR TITLE
Add SelectionPos to exported types

### DIFF
--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -54,6 +54,7 @@ export type {
   CellProps,
   SelectedRegion,
   SelectionFocus,
+  SelectionPos,
   SelectionAction,
   GridContextMenuItemProps,
   Rectangle,


### PR DESCRIPTION
SelectionPos has been added to the list of exported types in types.ts to make it available for use in other modules.