### PR TITLE
Enhance BigStat component with error handling

### DIFF
--- a/src/components/BigStat/BigStat.stories.ts
+++ b/src/components/BigStat/BigStat.stories.ts
@@ -4,17 +4,26 @@ export default {
   component: BigStat,
   title: "Display/Big Stat",
   tags: ["big-stat", "autodocs"],
-  order: {
-    options: ["titleTop", "titleBottom"],
-    control: { type: "radio" },
-  },
-  size: {
-    options: ["lg", "sm"],
-    control: { type: "radio" },
-  },
-  spacing: {
-    options: ["lg", "sm"],
-    control: { type: "radio" },
+  argTypes: {
+    order: {
+      options: ["titleTop", "titleBottom"],
+      control: { type: "radio" },
+    },
+    size: {
+      options: ["lg", "sm"],
+      control: { type: "radio" },
+    },
+    spacing: {
+      options: ["lg", "sm"],
+      control: { type: "radio" },
+    },
+    state: {
+      options: ["default", "muted"],
+      control: { type: "radio" },
+    },
+    error: {
+      control: { type: "boolean" },
+    },
   },
 };
 
@@ -28,6 +37,7 @@ export const Playground = {
     order: "titleTop",
     height: "",
     fillWidth: false,
-    maxWidth: "none",
+    maxWidth: "300px",
+    error: false,
   },
 };

--- a/src/components/BigStat/BigStat.test.tsx
+++ b/src/components/BigStat/BigStat.test.tsx
@@ -17,5 +17,100 @@ describe("BigStat Component", () => {
       expect(screen.getByText(title)).toBeDefined();
       expect(screen.getByText(label)).toBeDefined();
     });
+
+    it("should render with default props", () => {
+      renderBigStat({
+        title: "Title",
+        label: "Label",
+      });
+
+      const wrapper = screen.getByText("Title").closest("div");
+      expect(wrapper).toBeDefined();
+    });
+
+    it("should render with error state", () => {
+      renderBigStat({
+        title: "Error Title",
+        label: "Error Label",
+        error: true,
+      });
+
+      expect(screen.getByText("Error Title")).toBeDefined();
+      expect(screen.getByText("Error Label")).toBeDefined();
+    });
+
+    it("should render with titleBottom order", () => {
+      renderBigStat({
+        title: "Bottom Title",
+        label: "Top Label",
+        order: "titleBottom",
+      });
+
+      expect(screen.getByText("Bottom Title")).toBeDefined();
+      expect(screen.getByText("Top Label")).toBeDefined();
+    });
+
+    it("should render with small size", () => {
+      renderBigStat({
+        title: "Small Title",
+        label: "Small Label",
+        size: "sm",
+      });
+
+      expect(screen.getByText("Small Title")).toBeDefined();
+      expect(screen.getByText("Small Label")).toBeDefined();
+    });
+
+    it("should render with muted state", () => {
+      renderBigStat({
+        title: "Muted Title",
+        label: "Muted Label",
+        state: "muted",
+      });
+
+      expect(screen.getByText("Muted Title")).toBeDefined();
+      expect(screen.getByText("Muted Label")).toBeDefined();
+    });
+
+    it("should render with fillWidth prop", () => {
+      renderBigStat({
+        title: "Full Width Title",
+        label: "Full Width Label",
+        fillWidth: true,
+      });
+
+      expect(screen.getByText("Full Width Title")).toBeDefined();
+    });
+
+    it("should render with maxWidth prop", () => {
+      renderBigStat({
+        title: "Max Width Title",
+        label: "Max Width Label",
+        maxWidth: "300px",
+      });
+
+      expect(screen.getByText("Max Width Title")).toBeDefined();
+    });
+
+    it("should render with large spacing", () => {
+      renderBigStat({
+        title: "Large Spacing Title",
+        label: "Large Spacing Label",
+        spacing: "lg",
+      });
+
+      expect(screen.getByText("Large Spacing Title")).toBeDefined();
+      expect(screen.getByText("Large Spacing Label")).toBeDefined();
+    });
+
+    it("should render with custom height", () => {
+      renderBigStat({
+        title: "Custom Height Title",
+        label: "Custom Height Label",
+        height: "8rem",
+      });
+
+      expect(screen.getByText("Custom Height Title")).toBeDefined();
+    });
   });
 });

--- a/src/components/BigStat/BigStat.tsx
+++ b/src/components/BigStat/BigStat.tsx
@@ -15,6 +15,7 @@ export interface BigStatProps extends Omit<HTMLAttributes<HTMLDivElement>, "titl
   spacing?: bigStatSpacing;
   state?: bigStatState;
   title: React.ReactNode;
+  error?: boolean;
 }
 
 //* Use this component to highlight important pieces of information. */
@@ -28,6 +29,7 @@ export const BigStat = ({
   spacing = "sm",
   state = "default",
   title = "Title",
+  error = false,
   ...props
 }: BigStatProps) => (
   <Wrapper
@@ -38,11 +40,13 @@ export const BigStat = ({
     $state={state}
     $fillWidth={fillWidth}
     $maxWidth={maxWidth}
+    $error={error}
     {...props}
   >
     <Label
       $state={state}
       $size={size}
+      $error={error}
     >
       {label}
     </Label>
@@ -63,6 +67,7 @@ const Wrapper = styled.div<{
   $size?: bigStatSize;
   $spacing?: bigStatSpacing;
   $state?: bigStatState;
+  $error?: boolean;
 }>`
   display: flex;
   justify-content: center;
@@ -75,6 +80,7 @@ const Wrapper = styled.div<{
     $height = "fixed",
     $order,
     $spacing = "sm",
+    $error = false,
     theme,
   }) => `
     background-color: ${theme.click.bigStat.color.background[$state]};
@@ -82,7 +88,9 @@ const Wrapper = styled.div<{
     font: ${theme.click.bigStat.typography[$size].label[$state]};
     border-radius: ${theme.click.bigStat.radii.all};
     border: ${theme.click.bigStat.stroke} solid ${
-      theme.click.bigStat.color.stroke[$state]
+      $error
+        ? theme.click.bigStat.color.stroke.danger
+        : theme.click.bigStat.color.stroke[$state]
     };
   gap: ${theme.click.bigStat.space[$spacing].gap};
   padding: ${theme.click.bigStat.space.all};
@@ -96,9 +104,10 @@ const Wrapper = styled.div<{
 const Label = styled.div<{
   $state?: bigStatState;
   $size?: bigStatSize;
+  $error?: boolean;
 }>`
-  ${({ $state = "default", $size = "lg", theme }) => `
-    color: ${theme.click.bigStat.color.label[$state]};
+  ${({ $state = "default", $size = "lg", $error = false, theme }) => `
+    color: ${$error ? theme.click.bigStat.color.label.danger : theme.click.bigStat.color.label[$state]};
     font: ${theme.click.bigStat.typography[$size].label[$state]};
   `}
 `;

--- a/src/styles/types.ts
+++ b/src/styles/types.ts
@@ -342,7 +342,8 @@
       "color": {
         "stroke": {
           "default": string,
-          "muted": string
+          "muted": string,
+          "danger": string
         },
         "background": {
           "default": string,
@@ -350,7 +351,8 @@
         },
         "label": {
           "default": string,
-          "muted": string
+          "muted": string,
+          "danger": string
         },
         "title": {
           "default": string,

--- a/src/styles/variables.dark.json
+++ b/src/styles/variables.dark.json
@@ -146,7 +146,8 @@
       "color": {
         "stroke": {
           "default": "#323232",
-          "muted": "#323232"
+          "muted": "#323232",
+          "danger": "#ffbaba"
         },
         "background": {
           "default": "#1F1F1C",
@@ -154,7 +155,8 @@
         },
         "label": {
           "default": "#b3b6bd",
-          "muted": "#b3b6bd"
+          "muted": "#b3b6bd",
+          "danger": "#ffbaba"
         },
         "title": {
           "default": "rgb(97.5% 97.5% 97.5%)",

--- a/src/styles/variables.json
+++ b/src/styles/variables.json
@@ -341,7 +341,8 @@
       "color": {
         "stroke": {
           "default": "#e6e7e9",
-          "muted": "#e6e7e9"
+          "muted": "#e6e7e9",
+          "danger": "#c10000"
         },
         "background": {
           "default": "#ffffff",
@@ -349,7 +350,8 @@
         },
         "label": {
           "default": "#696e79",
-          "muted": "#696e79"
+          "muted": "#696e79",
+          "danger": "#c10000"
         },
         "title": {
           "default": "lch(11.1 1.37 305)",

--- a/src/styles/variables.light.json
+++ b/src/styles/variables.light.json
@@ -146,7 +146,8 @@
       "color": {
         "stroke": {
           "default": "#e6e7e9",
-          "muted": "#e6e7e9"
+          "muted": "#e6e7e9",
+          "danger": "#c10000"
         },
         "background": {
           "default": "#ffffff",
@@ -154,7 +155,8 @@
         },
         "label": {
           "default": "#696e79",
-          "muted": "#696e79"
+          "muted": "#696e79",
+          "danger": "#c10000"
         },
         "title": {
           "default": "lch(11.1 1.37 305)",


### PR DESCRIPTION
This pull request adds support for an error state to the `BigStat` component, allowing it to visually indicate errors with distinct styling. The changes include updates to the component props, styling logic, Storybook stories, and tests to handle and demonstrate the error state. Additionally, theme tokens were `npm run generate-tokens` to support new error colors.

**BigStat component enhancements:**

* Added an `error` prop to `BigStat`, allowing the component to be rendered in an error state. The error state changes the border and label colors to use the new "danger" theme values. 

**Theme and styling updates:**

* Run the `generate-tokens`.

**Storybook improvements:**

* Updated `BigStat.stories.ts` to add controls for the new `error` and `state` props, and set a default `maxWidth` value in the playground story.

**Test coverage:**

* Added new tests in `BigStat.test.tsx` to verify rendering of the error state and other prop combinations, ensuring the component behaves correctly with the new and existing props.

#### Screenshots with default and muted states

<img width="1312" height="542" alt="image" src="https://github.com/user-attachments/assets/d29b69b6-436d-49e6-b617-26b9788bf849" />
