### PR TITLE
feat(Table): make `table-layout: auto` the default

### DIFF
--- a/.changeset/heavy-donuts-agree.md
+++ b/.changeset/heavy-donuts-agree.md
@@ -1,0 +1,7 @@
+---
+"@clickhouse/click-ui": patch
+---
+
+`Table` accepts a new `tableLayout` prop controlling its layout. Possible values: `'auto'`, `'fixed'`. Changes the default from
+`table-layout: fixed` to `table-layout: auto`, making tables adjust to their contents better. When overflown, tables gain horizontal scroll
+instead of squishing their contents.

--- a/src/components/Table/Table.module.css
+++ b/src/components/Table/Table.module.css
@@ -18,6 +18,13 @@
   width: 100%;
   overflow: visible;
   border-collapse: collapse;
+}
+
+.table__table_layout_auto {
+  table-layout: auto;
+}
+
+.table__table_layout_fixed {
   table-layout: fixed;
 }
 

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -291,6 +291,18 @@ const Thead = ({
   );
 };
 
+const tableVariants = cva(styles.table__table, {
+  variants: {
+    layout: {
+      auto: styles.table__table_layout_auto,
+      fixed: styles.table__table_layout_fixed,
+    },
+  },
+  defaultVariants: {
+    layout: 'auto',
+  },
+});
+
 const rowVariants = cva(styles.table__row, {
   variants: {
     isSelectable: {
@@ -380,6 +392,7 @@ interface CommonTableProps extends Omit<
   rowHeight?: string;
   resizableColumns?: boolean;
   mobileLayout?: MobileLayoutProp;
+  tableLayout?: 'auto' | 'fixed';
 }
 
 type SelectReturnValue = {
@@ -586,6 +599,7 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
       resizableColumns,
       mobileLayout = 'list',
       className,
+      tableLayout = 'auto',
       ...props
     },
     ref
@@ -848,7 +862,7 @@ const Table = forwardRef<HTMLTableElement, TableProps>(
           <table
             ref={ref}
             {...props}
-            className={cn(styles['table__table'], className)}
+            className={tableVariants({ layout: tableLayout, className })}
           >
             {showHeader && (
               <Thead


### PR DESCRIPTION
# Why

`table-layout: fixed` makes tables layout very controllable, but at expense of content accessibility.

Tabular data is hard to display adaptively. Default behavior is designed to display it in the best way possible, so let's use it. In cases where tables do not fit the viewport, they will receive a horizontal scroll that will keep both external table dimensions, and proper internal structure with all the content being accessible.

# What
- introduce a new prop `tableLayout?: 'auto' | 'fixed'` to `Table` that applies `table-layout: <tableLayout>` when specified, to support existing cases where it's required. Default is `auto`.