### PR TITLE
fix(Pagination): remove custom keydown handler

### DIFF
--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,6 +1,5 @@
 import {
   FocusEventHandler,
-  KeyboardEventHandler,
   MouseEventHandler,
   ReactElement,
   useCallback,
@@ -63,26 +62,6 @@ export const Pagination = ({
   const leftButtonDisabled = currentPage <= 1;
   const rightButtonDisabled =
     (!!totalPages && currentPage === totalPages) || disableNextButton;
-
-  const onKeyDown: KeyboardEventHandler<HTMLInputElement> = e => {
-    const isInputEnabled = !inputRef.current?.disabled;
-    if (
-      (e.key === "ArrowUp" || e.key === "ArrowRight") &&
-      isInputEnabled &&
-      !rightButtonDisabled
-    ) {
-      onChangeProp(currentPage + 1);
-    } else if (
-      (e.key === "ArrowDown" || e.key === "ArrowLeft") &&
-      isInputEnabled &&
-      !leftButtonDisabled
-    ) {
-      const newPage = currentPage - 1;
-      if (newPage > 0) {
-        onChangeProp(newPage);
-      }
-    }
-  };
 
   const onChange = (value: string) => {
     const sanitizedValue = parseInt(value, 10);
@@ -175,7 +154,6 @@ export const Pagination = ({
             onChange={onChange}
             value={currentPage}
             loading={false}
-            onKeyDown={onKeyDown}
             aria-label={currentPage.toString()}
             min={1}
             max={totalPages}


### PR DESCRIPTION
## What & Why

On this recording I press ArrowRight and ArrowLeft first, trying to move cursor inside the field.
Then I press ArrowUp and ArrowDown, trying to increase and decrease the value. It does this with a step of 2.

https://github.com/user-attachments/assets/5c007b16-6193-49b8-8ac8-108a8d49771d

This happens because we added a custom keydown handler, without disabling native `input type="number"` behavior. Makes no sense trying to recreate the logic, we should just use native behavior.