### PR TITLE
Alert: add onDismiss callback, fix link styles

### DIFF
--- a/src/components/Alert/Alert.stories.tsx
+++ b/src/components/Alert/Alert.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react-vite";
 
-import { Alert, Container } from "@/components";
+import { Alert, Container, Link } from "@/components";
 import { ICON_NAMES } from "@/components/Icon/types";
 
 const meta: Meta<typeof Alert> = {
@@ -36,17 +36,22 @@ export const TitleWithLink: StoryObj<typeof Alert> = {
     title: (
       <>
         Important: Please review our{" "}
-        <a
+        <Link
           href={"https://clickhouse.com/docs"}
           target="_blank"
           rel="noopener noreferrer"
         >
           documentation
-        </a>{" "}
+        </Link>{" "}
         before progressing
       </>
     ),
-    text: "Example demos how you can pass react elements like links to the title prop",
+    text: (
+      <>
+        Example demos how you can pass react elements like links to the title prop, with{" "}
+        <Link href="https://clickhouse.com/docs">a link</Link>
+      </>
+    ),
     state: "info",
     size: "medium",
     type: "default",

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -142,12 +142,16 @@ const TextWrapper = styled.div<{ $state: AlertState; $size: AlertSize }>`
   ${({ $size, theme }) => `
     gap: ${theme.click.alert[$size].space.gap};
     padding: ${theme.click.alert[$size].space.y} ${theme.click.alert[$size].space.x};
-    a {
-      font: inherit;
-      color: inherit;
-      text-decoration: underline;
-    }
-  `}
+    `}
+
+  a,
+  a:focus,
+  a:visited,
+  a:hover {
+    font: inherit;
+    color: inherit;
+    text-decoration: underline;
+  }
 `;
 
 const Title = styled.h6<{ $size: AlertSize }>`


### PR DESCRIPTION
## Why

1. Alerts are dismissable, but you can't react to them being closed. For example, you might want to update URL state after closing an alert, if it was shown based on a search param.
2. Link styles assume links inside Alerts aren't styled. But the common case is to use click-ui Link, which has styles that conflict with Alert styles.

## What

1. Add `onDismiss` callback that gets fired when an Alert is dismissed. Without the ability to prevent the event.
2. Force all link states to be the same when they are inside an Alert