### PR TITLE
fix(Alert): remove branching from props interface

### DIFF
--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -14,17 +14,10 @@ export type AlertProps = {
   type?: AlertType;
   showIcon?: boolean;
   customIcon?: IconName;
-} & (
-  | {
-      dismissible: true;
-      /** Available for `dismissible == true` */
-      onDismiss?: () => void;
-    }
-  | {
-      dismissible?: false;
-      onDismiss?: never;
-    }
-);
+  dismissible?: boolean;
+  /** Available for `dismissible == true` */
+  onDismiss?: () => void;
+};
 
 const stateIconMap: Record<AlertState, IconName> = {
   neutral: "information",


### PR DESCRIPTION
While this excplicit type definition works better for preventing misuse of props, it works worse for types manupulation.

In perticular, this:
```ts
type ModifiedAlertProps = Omit<AlertProps, 'size'>;
```
would, in some cases, result in a type that won't accept `boolean` as a value type for the `dismissible` prop.

<img width="501" height="158" alt="image" src="https://github.com/user-attachments/assets/7b6aadd3-436a-47b7-8a16-df17647872db" />

```
  ...
  Types of property 'dismissible' are incompatible.
    Type 'boolean | undefined' is not assignable to type 'false | undefined'.
      Type 'true' is not assignable to type 'false'.ts(2322)
```

Making it simpler, but more versatile.