### PR TITLE
fix: props and outer width in progress bar story

### DIFF
--- a/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -1,13 +1,29 @@
+import { StoryFn } from "@storybook/react-vite";
 import { ProgressBar } from "./ProgressBar";
 
 export default {
   component: ProgressBar,
   title: "Display/ProgressBar",
   tags: ["progressBar", "autodocs"],
+  decorators: [
+    (Story: StoryFn) => (
+      <div style={{ width: "400px", height: "200px" }}>
+        <Story />
+      </div>
+    ),
+  ],
   argTypes: {
     type: {
       options: ["default", "small"],
       control: { type: "select" },
+    },
+    orientation: {
+      options: ["horizontal", "vertical"],
+      control: { type: "radio" },
+    },
+    dir: {
+      options: ["start", "end"],
+      control: { type: "radio" },
     },
     dismissable: {
       control: { type: "boolean" },
@@ -25,8 +41,10 @@ export default {
 
 export const DefaultProgressBar = {
   args: {
-    progress: 100,
+    progress: 60,
     type: "default",
+    orientation: "horizontal",
+    dir: "start",
     dismissable: true,
     onCancel: () => console.log("onCancel clicked"),
     successMessage: "Progress completed",
@@ -35,8 +53,18 @@ export const DefaultProgressBar = {
 
 export const SmallProgressBar = {
   args: {
-    progress: 100,
+    progress: 60,
     type: "small",
-    successMessage: "Progress completed",
+    orientation: "horizontal",
+    dir: "start",
+  },
+};
+
+export const VerticalProgressBar = {
+  args: {
+    progress: 75,
+    type: "small",
+    orientation: "vertical",
+    dir: "start",
   },
 };


### PR DESCRIPTION
It was tough to see the progress bar in its story. Plus, the `orientation` and `dir` props weren't hooked up, so you couldn't see what they did.

Before:
<img width="1301" height="1115" alt="image" src="https://github.com/user-attachments/assets/3a234d1d-83bc-4a3c-8691-3801bbf14860" />

After:
<img width="1142" height="1100" alt="image" src="https://github.com/user-attachments/assets/1f9e3a95-3a81-4139-933d-6e8fc5d482dd" />

<img width="1143" height="1019" alt="image" src="https://github.com/user-attachments/assets/423ddcd3-fafb-4497-8238-06c42d5c1478" />
