### PR TITLE
ProgressBar: switch progress prop to CSS variable

### DIFF
--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -170,6 +170,7 @@ export const ProgressBar = ({
       $type={type}
       $orientation={orientation}
       $dir={dir}
+      // Using a CSS variable avoids generating a new styled-components class per progress value.
       style={
         {
           "--progress": `${progress}%`,


### PR DESCRIPTION
This updates `ProgressBar` to use a CSS variable for progress instead of generating a new styled-components class for every value. This reduces unnecessary class creation and improves performance without changing behavior.