### PR TITLE
fix(Dropdown): fix background styles for open state in GenericMenu

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -14,20 +14,6 @@ const DropdownMenuItem = styled(GenericMenuItem)<{ $type?: "default" | "danger" 
   position: relative;
   display: flex;
   min-height: 32px;
-  &[data-state="open"] {
-    ${({ theme, $type = "default" }) => {
-      const colorGroup =
-        theme?.click?.genericMenu?.item?.color?.[$type] ||
-        theme?.click?.genericMenu?.item?.color?.default;
-      if (!colorGroup || !theme?.click?.genericMenu?.item?.typography) return "";
-      return `
-      font: ${theme.click.genericMenu.item.typography.label.hover};
-      background: ${colorGroup.background.hover};
-      color: ${colorGroup.text.hover};
-      cursor: pointer;
-    `;
-    }}
-  }
 `;
 
 interface SubDropdownProps {

--- a/src/components/GenericMenu.tsx
+++ b/src/components/GenericMenu.tsx
@@ -101,7 +101,13 @@ export const GenericMenuItem = styled.div<{ $type?: "default" | "danger" }>`
       color:${theme.click.genericMenu.item.color[colorKey].text.hover};
       cursor: pointer;
     }
-    &[data-state="open"], &[data-state="checked"], &[data-selected="true"]  {
+    &[data-state="open"] {
+      background:${theme.click.genericMenu.item.color[colorKey].background.hover};
+      color:${theme.click.genericMenu.item.color[colorKey].text.hover};
+      font: ${theme.click.genericMenu.item.typography.label.hover};
+      cursor: pointer;
+    }
+    &[data-state="checked"], &[data-selected="true"]  {
       background:${theme.click.genericMenu.item.color[colorKey].background.active};
       color:${theme.click.genericMenu.item.color[colorKey].text.active};
       font: ${theme.click.genericMenu.item.typography.label.active};


### PR DESCRIPTION
This PR fixed the background styles for open state items in GenericMenu.

This was the issue reported by @crisalbu:
> Looking again at menus, the hover effect disappears when an item has a list of nested items.
![Hover effect disappeards](https://github.com/user-attachments/assets/2d9465e1-ef9b-4f43-9442-f1f72703756d)


### How to test?

- Go to the [ContextMenu](https://click-ui-git-fix-generimenu-bg-open-item-state-clickhouse.vercel.app/?path=/docs/display-contextmenu--docs) and test it
- Go to [DropDown](https://click-ui-git-fix-generimenu-bg-open-item-state-clickhouse.vercel.app/?path=/docs/display-dropdown--docs) and test it