### PR TITLE
feat(CardHorizontal): improve disabled state accessibility

### DIFF
--- a/src/components/CardHorizontal/CardHorizontal.test.tsx
+++ b/src/components/CardHorizontal/CardHorizontal.test.tsx
@@ -3,95 +3,188 @@ import { CardHorizontal, CardHorizontalProps } from "./CardHorizontal";
 import { renderCUI } from "@/utils/test-utils";
 
 describe("CardHorizontal Component", () => {
-  describe("Horizontal card", () => {
-    const renderCard = (props: CardHorizontalProps) =>
-      renderCUI(<CardHorizontal {...props} />);
+  const renderCard = (props: CardHorizontalProps) =>
+    renderCUI(<CardHorizontal {...props} />);
 
-    it("should render the title", () => {
-      const title = "Test card component";
-      renderCard({
-        title,
-        icon: "warning",
-        description: "",
-        badgeText: "",
-      });
-
-      expect(screen.getByText(title)).toBeDefined();
-      expect(screen.queryByTestId("horizontal-card-badge")).toBeNull();
+  it("should render the title", () => {
+    const title = "Test card component";
+    renderCard({
+      title,
+      icon: "warning",
+      description: "",
+      badgeText: "",
     });
 
-    it("should render the description when provided", () => {
-      const description = "This is the card description";
-      renderCard({
-        icon: "warning",
-        title: "",
-        description,
-      });
+    expect(screen.getByText(title)).toBeDefined();
+    expect(screen.queryByTestId("horizontal-card-badge")).toBeNull();
+  });
 
-      expect(screen.getByText(description)).toBeDefined();
+  it("should render the description when provided", () => {
+    const description = "This is the card description";
+    renderCard({
+      icon: "warning",
+      title: "",
+      description,
     });
 
-    it("should render the badge when provided", () => {
-      const description = "This is the card description";
-      renderCard({
-        icon: "warning",
-        title: "title",
-        description,
-        badgeText: "Badge",
-      });
+    expect(screen.getByText(description)).toBeDefined();
+  });
 
-      expect(screen.getByText("title")).toBeDefined();
-      expect(screen.getByTestId("horizontal-card-badge")).toBeDefined();
-    });
-    it("should not render the badge when badgeText is provided and not title", () => {
-      const description = "This is the card description";
-      renderCard({
-        icon: "warning",
-        title: "",
-        description,
-        badgeText: "Badge",
-      });
-
-      expect(screen.queryByTestId("horizontal-card-badge")).toBeNull();
+  it("should render the badge when provided", () => {
+    const description = "This is the card description";
+    renderCard({
+      icon: "warning",
+      title: "title",
+      description,
+      badgeText: "Badge",
     });
 
-    it("should render the button when provided", () => {
-      renderCard({
-        title: "title",
-        infoText: "I'm a button",
-      });
+    expect(screen.getByText("title")).toBeDefined();
+    expect(screen.getByTestId("horizontal-card-badge")).toBeDefined();
+  });
 
-      expect(screen.getByText("title")).toBeDefined();
-      expect(screen.getByTestId("horizontal-card-button")).toBeDefined();
+  it("should not render the badge when badgeText is provided and not title", () => {
+    const description = "This is the card description";
+    renderCard({
+      icon: "warning",
+      title: "",
+      description,
+      badgeText: "Badge",
     });
 
-    it("should render with small size", () => {
-      const { container } = renderCard({
-        title: "Test card",
-        description: "Test description",
-        size: "sm",
-      });
+    expect(screen.getByText(description)).toBeDefined();
+  });
 
-      expect(container.firstChild).toBeDefined();
+  it("should render with small size", () => {
+    const { container } = renderCard({
+      title: "Test card",
+      description: "Test description",
+      size: "sm",
     });
 
-    it("should render with medium size", () => {
-      const { container } = renderCard({
-        title: "Test card",
-        description: "Test description",
-        size: "md",
-      });
+    expect(container.firstChild).toBeDefined();
+  });
 
-      expect(container.firstChild).toBeDefined();
+  it("should render with medium size", () => {
+    const { container } = renderCard({
+      title: "Test card",
+      description: "Test description",
+      size: "md",
     });
 
-    it("should default to medium size when size prop is not provided", () => {
-      const { container } = renderCard({
-        title: "Test card",
-        description: "Test description",
-      });
+    expect(container.firstChild).toBeDefined();
+  });
 
-      expect(container.firstChild).toBeDefined();
+  it("should default to medium size when size prop is not provided", () => {
+    const { container } = renderCard({
+      title: "Test card",
+      description: "Test description",
     });
+
+    expect(container.firstChild).toBeDefined();
+  });
+
+  it("should render the button when provided", () => {
+    renderCard({
+      title: "title",
+      infoText: "I'm a button",
+    });
+
+    expect(screen.getByText("title")).toBeDefined();
+    expect(screen.getByTestId("horizontal-card-button")).toBeDefined();
+  });
+
+  it("should have aria-disabled=true attribute when disabled", () => {
+    const { container } = renderCard({
+      title: "Test Card",
+      disabled: true,
+    });
+
+    const wrapper = container.firstChild;
+    expect(wrapper).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("should have aria-disabled=false when enabled", () => {
+    const { container } = renderCard({
+      title: "Test Card",
+      disabled: false,
+    });
+
+    const wrapper = container.firstChild;
+    expect(wrapper).toHaveAttribute("aria-disabled", "false");
+  });
+
+  it("should have tabIndex -1 when disabled", () => {
+    const { container } = renderCard({
+      title: "Test Card",
+      disabled: true,
+    });
+
+    const wrapper = container.firstChild;
+    expect(wrapper).toHaveAttribute("tabIndex", "-1");
+  });
+
+  it("should have tabIndex 0 when enabled", () => {
+    const { container } = renderCard({
+      title: "Test Card",
+      disabled: false,
+    });
+
+    const wrapper = container.firstChild;
+    expect(wrapper).toHaveAttribute("tabIndex", "0");
+  });
+
+  it("should not call onClick when disabled", () => {
+    const onClickMock = vitest.fn();
+    const { container } = renderCard({
+      title: "Test Card",
+      disabled: true,
+      onButtonClick: onClickMock,
+    });
+
+    const wrapper = container.firstChild as HTMLElement;
+    wrapper.click();
+
+    expect(onClickMock).not.toHaveBeenCalled();
+  });
+
+  it("should call onClick when enabled", () => {
+    const onClickMock = vitest.fn();
+    const { container } = renderCard({
+      title: "Test Card",
+      disabled: false,
+      onButtonClick: onClickMock,
+    });
+
+    const wrapper = container.firstChild as HTMLElement;
+    wrapper.click();
+
+    expect(onClickMock).toHaveBeenCalled();
+  });
+
+  it("should disable nested button when card is disabled", () => {
+    const { getByRole } = renderCard({
+      title: "Test Card",
+      infoText: "Click me",
+      disabled: true,
+    });
+
+    const button = getByRole("button");
+    expect(button).toBeDisabled();
+  });
+
+  it("should not open infoUrl when disabled", () => {
+    const windowOpenSpy = vitest.spyOn(window, "open").mockImplementation(() => null);
+    const { container } = renderCard({
+      title: "Test Card",
+      infoUrl: "https://example.com",
+      disabled: true,
+    });
+
+    const wrapper = container.firstChild as HTMLElement;
+    wrapper.click();
+
+    expect(windowOpenSpy).not.toHaveBeenCalled();
+    windowOpenSpy.mockRestore();
   });
 });

--- a/src/components/CardHorizontal/CardHorizontal.tsx
+++ b/src/components/CardHorizontal/CardHorizontal.tsx
@@ -240,6 +240,11 @@ export const CardHorizontal = ({
   ...props
 }: CardHorizontalProps) => {
   const handleClick = (e: React.MouseEvent<HTMLElement>) => {
+    if (disabled) {
+      e.preventDefault();
+      return;
+    }
+
     MouseEvent;
     if (typeof onButtonClick === "function") {
       onButtonClick(e);
@@ -255,7 +260,8 @@ export const CardHorizontal = ({
       $isSelectable={isSelectable}
       $color={color}
       $size={size}
-      tabIndex={0}
+      tabIndex={disabled ? -1 : 0}
+      aria-disabled={disabled}
       onClick={handleClick}
       {...props}
     >
@@ -320,6 +326,7 @@ export const CardHorizontal = ({
             <Button
               label={infoText}
               onClick={handleClick}
+              disabled={disabled}
               fillWidth
             />
           </Container>


### PR DESCRIPTION
Improves accessibility for the `CardHorizontal` component when disabled.

## Changes
- Add `aria-disabled` attribute to communicate disabled state to screen readers
- Set `tabIndex={disabled ? -1 : 0}` to remove disabled cards from keyboard tab order
- Add disabled guard in `handleClick` to prevent interaction when disabled
- Pass `disabled` prop to nested Button component for consistent state