### PR TITLE
Adding link to docs in intro text

### DIFF
--- a/src/Introduction.mdx
+++ b/src/Introduction.mdx
@@ -3,14 +3,10 @@
 
 <br /><br />
 
-# Click UI
-Welcome to the home of Click UI, the ClickHouse design system and component library. Our aim with Click UI is to provide an accessible, theme-able, modern, and attractive interface with which to experience the speed and power of ClickHouse.
-
-As we shift our tech stack to React, we’re looking to implement a consistent experience that runs across the entire ClickHouse ecosystem, whether that be the Cloud product, the docs, or the website.
-
-While this library is primarily meant for ClickHouse designers and developers, in keeping with the ethos of the company, this is an open-source project and we‘re excited to provide value to the greater community.
-
-The source code is available on [GitHub](https://github.com/ClickHouse/click-ui) and the latest version of the package can be on [npm.js](https://www.npmjs.com/package/@clickhouse/click-ui). Once ready, we’ll be publishing the design system to the Figma community.
+# Click UI component reference
+Click UI is the ClickHouse design system and component library. Our aim with Click UI is to provide an accessible, theme-able, modern, and attractive interface with which to experience the speed and power of ClickHouse.
+<br /><br />This site is a reference for inspecting components and their props. Official documentation lives at [clickhouse.design/click-ui](https://clickhouse.design/click-ui).
+<br /><br />The source code is available on [GitHub](https://github.com/ClickHouse/click-ui) and the latest version of the package can be on [npm.js](https://www.npmjs.com/package/@clickhouse/click-ui). Once ready, we’ll be publishing the design system to the Figma community.
 <br />
 ---
 <br />


### PR DESCRIPTION
Adding link to the official docs in the intro text of storybook for discoverability purposes.