### PR TITLE
Update prettier and Refactor interface formatting for consistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "eslint-plugin-react-refresh": "0.4.7",
     "eslint-plugin-storybook": "^10.0.7",
     "jsdom": "^24.0.0",
-    "prettier": "3.6.2",
+    "prettier": "3.7.4",
     "prop-types": "^15.8.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -9,7 +9,8 @@ type Gap = "sm" | "md" | "lg";
 type Color = "default" | "link";
 
 export interface AccordionProps
-  extends SizeProp,
+  extends
+    SizeProp,
     Omit<RadixAccordion.AccordionSingleProps, "type" | "collapsible" | "title"> {
   /** The title text or element displayed in the accordion header */
   title: ReactNode;

--- a/src/components/AutoComplete/AutoComplete.stories.tsx
+++ b/src/components/AutoComplete/AutoComplete.stories.tsx
@@ -3,8 +3,10 @@ import { Meta, StoryObj } from "@storybook/react-vite";
 import { AutoComplete, AutoCompleteProps } from "./AutoComplete";
 import { selectOptions } from "../Select/selectOptions";
 
-interface AutoCompleteExampleProps
-  extends Omit<AutoCompleteProps, "options" | "children"> {
+interface AutoCompleteExampleProps extends Omit<
+  AutoCompleteProps,
+  "options" | "children"
+> {
   childrenType: "children" | "options";
 }
 

--- a/src/components/AutoComplete/AutoComplete.tsx
+++ b/src/components/AutoComplete/AutoComplete.tsx
@@ -32,8 +32,10 @@ import { getTextFromNodes } from "@/lib/getTextFromNodes";
 import AutoCompleteOptionList from "./AutoCompleteOptionList";
 
 type DivProps = HTMLAttributes<HTMLDivElement>;
-interface SelectItemComponentProps
-  extends Omit<DivProps, "disabled" | "onSelect" | "value" | "children"> {
+interface SelectItemComponentProps extends Omit<
+  DivProps,
+  "disabled" | "onSelect" | "value" | "children"
+> {
   separator?: boolean;
   disabled?: boolean;
   onSelect?: (value: string) => void;
@@ -51,8 +53,10 @@ type SelectItemLabel = {
   children?: never;
   label: ReactNode;
 };
-export interface SelectGroupProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, "heading"> {
+export interface SelectGroupProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  "heading"
+> {
   heading: ReactNode;
   value?: never;
   onSelect?: never;
@@ -86,8 +90,7 @@ type SelectChildrenType = {
 type SelectOptionProp = SelectOptionType | SelectChildrenType;
 
 interface Props
-  extends PopoverProps,
-    Omit<DivProps, "onChange" | "dir" | "onSelect" | "children"> {
+  extends PopoverProps, Omit<DivProps, "onChange" | "dir" | "onSelect" | "children"> {
   onSelect?: (value: string) => void;
   value?: string;
   placeholder?: string;

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -3,16 +3,20 @@ import { DefaultTheme, styled } from "styled-components";
 
 type ButtonGroupType = "default" | "borderless";
 
-export interface ButtonGroupElementProps
-  extends Omit<HTMLAttributes<HTMLButtonElement>, "children"> {
+export interface ButtonGroupElementProps extends Omit<
+  HTMLAttributes<HTMLButtonElement>,
+  "children"
+> {
   /** The unique value for this button */
   value: string;
   /** The label text to display */
   label?: ReactNode;
 }
 
-export interface ButtonGroupProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, "onClick"> {
+export interface ButtonGroupProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  "onClick"
+> {
   /** Array of button options to display */
   options: Array<ButtonGroupElementProps>;
   /** The currently selected button value */

--- a/src/components/CardHorizontal/CardHorizontal.tsx
+++ b/src/components/CardHorizontal/CardHorizontal.tsx
@@ -13,8 +13,10 @@ import {
 type CardColor = "default" | "muted";
 export type CardSize = "sm" | "md";
 
-export interface CardHorizontalProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, "title"> {
+export interface CardHorizontalProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  "title"
+> {
   /** The title text displayed in the card */
   title?: ReactNode;
   /** Icon to display in the card */

--- a/src/components/CardPrimary/CardPrimary.tsx
+++ b/src/components/CardPrimary/CardPrimary.tsx
@@ -8,8 +8,7 @@ import { WithTopBadgeProps, withTopBadge } from "@/components/CardPrimary/withTo
 export type CardPrimarySize = "sm" | "md";
 type ContentAlignment = "start" | "center" | "end";
 export interface CardPrimaryProps
-  extends HTMLAttributes<HTMLDivElement>,
-    WithTopBadgeProps {
+  extends HTMLAttributes<HTMLDivElement>, WithTopBadgeProps {
   /** The title text displayed in the card */
   title?: string;
   /** Icon name to display in the card header */

--- a/src/components/FileTabs/FileTabs.tsx
+++ b/src/components/FileTabs/FileTabs.tsx
@@ -80,8 +80,10 @@ export interface FileTabProps extends Omit<HTMLAttributes<HTMLDivElement>, "chil
   /** Whether the tab is in preview mode (italic text) */
   preview?: boolean;
 }
-export interface FileTabsProps
-  extends Omit<ReactSortableProps<ItemInterface>, "onSelect" | "list" | "setList"> {
+export interface FileTabsProps extends Omit<
+  ReactSortableProps<ItemInterface>,
+  "onSelect" | "list" | "setList"
+> {
   /** Index of the currently selected tab */
   selectedIndex?: number;
   /** The tab elements to render */

--- a/src/components/Flyout/Flyout.tsx
+++ b/src/components/Flyout/Flyout.tsx
@@ -199,8 +199,10 @@ const FlyoutElement = styled(Container)<{
   `}
 `;
 
-interface ElementProps
-  extends Omit<ContainerProps, "component" | "padding" | "gap" | "orientation"> {
+interface ElementProps extends Omit<
+  ContainerProps,
+  "component" | "padding" | "gap" | "orientation"
+> {
   type?: FlyoutType;
 }
 
@@ -217,18 +219,17 @@ const Element = ({ type, ...props }: ElementProps) => (
 Element.displayName = "Flyout.Element";
 Flyout.Element = Element;
 
-interface TitleHeaderProps
-  extends Omit<
-    ContainerProps,
-    | "orientaion"
-    | "justifyContent"
-    | "alignItems"
-    | "component"
-    | "padding"
-    | "gap"
-    | "children"
-    | "fillWidth"
-  > {
+interface TitleHeaderProps extends Omit<
+  ContainerProps,
+  | "orientaion"
+  | "justifyContent"
+  | "alignItems"
+  | "component"
+  | "padding"
+  | "gap"
+  | "children"
+  | "fillWidth"
+> {
   title: string;
   description?: string;
   type?: FlyoutType;
@@ -237,17 +238,16 @@ interface TitleHeaderProps
   showSeparator?: boolean;
 }
 
-interface ChildrenHeaderProps
-  extends Omit<
-    ContainerProps,
-    | "orientaion"
-    | "justifyContent"
-    | "alignItems"
-    | "component"
-    | "padding"
-    | "gap"
-    | "fillWidth"
-  > {
+interface ChildrenHeaderProps extends Omit<
+  ContainerProps,
+  | "orientaion"
+  | "justifyContent"
+  | "alignItems"
+  | "component"
+  | "padding"
+  | "gap"
+  | "fillWidth"
+> {
   title?: never;
   type?: FlyoutType;
   description?: never;
@@ -408,11 +408,10 @@ const Body = ({ align, ...props }: BodyProps) => (
 Body.displayName = "Flyout.Body";
 Flyout.Body = Body;
 
-export interface FlyoutFooterProps
-  extends Omit<
-    ContainerProps<"div">,
-    "orientaion" | "justifyContent" | "component" | "padding" | "gap"
-  > {
+export interface FlyoutFooterProps extends Omit<
+  ContainerProps<"div">,
+  "orientaion" | "justifyContent" | "component" | "padding" | "gap"
+> {
   type?: FlyoutType;
 }
 

--- a/src/components/Grid/Grid.test.tsx
+++ b/src/components/Grid/Grid.test.tsx
@@ -30,17 +30,16 @@ const Cell: CellProps = ({ type, rowIndex, columnIndex, isScrolling, ...props })
     </div>
   );
 };
-interface Props
-  extends Omit<
-    GridProps,
-    | "cell"
-    | "rowCount"
-    | "columnCount"
-    | "columnWidth"
-    | "focus"
-    | "onFocusChange"
-    | "onColumnResize"
-  > {
+interface Props extends Omit<
+  GridProps,
+  | "cell"
+  | "rowCount"
+  | "columnCount"
+  | "columnWidth"
+  | "focus"
+  | "onFocusChange"
+  | "onColumnResize"
+> {
   rowCount?: number;
   columnCount?: number;
   columnWidth?: (index: number) => number;

--- a/src/components/Grid/Header.tsx
+++ b/src/components/Grid/Header.tsx
@@ -48,19 +48,18 @@ const ScrollableHeaderContainer = styled.div<{
   left: ${({ $left }) => $left}px;
 `;
 
-interface ColumnProps
-  extends Pick<
-    HeaderProps,
-    | "cell"
-    | "getSelectionType"
-    | "onColumnResize"
-    | "getColumnWidth"
-    | "height"
-    | "getResizerPosition"
-    | "showBorder"
-    | "getColumnHorizontalPosition"
-    | "resizingState"
-  > {
+interface ColumnProps extends Pick<
+  HeaderProps,
+  | "cell"
+  | "getSelectionType"
+  | "onColumnResize"
+  | "getColumnWidth"
+  | "height"
+  | "getResizerPosition"
+  | "showBorder"
+  | "getColumnHorizontalPosition"
+  | "resizingState"
+> {
   columnIndex: number;
   isFirstColumn: boolean;
   isLastColumn: boolean;

--- a/src/components/Grid/RowNumberColumn.tsx
+++ b/src/components/Grid/RowNumberColumn.tsx
@@ -51,11 +51,10 @@ interface RowNumberColumnProps {
   showBorder: boolean;
   rowAutoHeight?: boolean;
 }
-interface RowNumberProps
-  extends Pick<
-    RowNumberColumnProps,
-    "rowHeight" | "getSelectionType" | "showBorder" | "rowStart"
-  > {
+interface RowNumberProps extends Pick<
+  RowNumberColumnProps,
+  "rowHeight" | "getSelectionType" | "showBorder" | "rowStart"
+> {
   rowIndex: number;
   isLastRow: boolean;
   isFirstRow: boolean;

--- a/src/components/Grid/types.ts
+++ b/src/components/Grid/types.ts
@@ -166,19 +166,18 @@ export interface GridContextMenuItemProps extends Omit<ContextMenuItemProps, "ch
   label: ReactNode;
 }
 
-export interface GridProps
-  extends Omit<
-    VariableSizeGridProps,
-    | "height"
-    | "width"
-    | "rowHeight"
-    | "children"
-    | "innerElementType"
-    | "innerRef"
-    | "outerElementType"
-    | "outerRef"
-    | "columnWidth"
-  > {
+export interface GridProps extends Omit<
+  VariableSizeGridProps,
+  | "height"
+  | "width"
+  | "rowHeight"
+  | "children"
+  | "innerElementType"
+  | "innerRef"
+  | "outerElementType"
+  | "outerRef"
+  | "columnWidth"
+> {
   autoFocus?: boolean;
   autoHeight?: boolean;
   rowStart?: number;

--- a/src/components/Input/NumberField.tsx
+++ b/src/components/Input/NumberField.tsx
@@ -2,7 +2,8 @@ import { ChangeEvent, InputHTMLAttributes, forwardRef, useId } from "react";
 import { Icon } from "@/components";
 import { InputWrapper, NumberInputElement, WrapperProps } from "./InputWrapper";
 export interface NumberFieldProps
-  extends Omit<WrapperProps, "id" | "children">,
+  extends
+    Omit<WrapperProps, "id" | "children">,
     Omit<InputHTMLAttributes<HTMLInputElement>, "type" | "onChange" | "dir"> {
   /** The input type - always number for NumberField */
   type?: "number";

--- a/src/components/Input/PasswordField.tsx
+++ b/src/components/Input/PasswordField.tsx
@@ -8,7 +8,8 @@ import {
   WrapperProps,
 } from "./InputWrapper";
 export interface PasswordFieldProps
-  extends Omit<WrapperProps, "id" | "children">,
+  extends
+    Omit<WrapperProps, "id" | "children">,
     Omit<
       InputHTMLAttributes<HTMLInputElement>,
       "children" | "type" | "string" | "onChange" | "dir"

--- a/src/components/Input/SearchField.tsx
+++ b/src/components/Input/SearchField.tsx
@@ -4,8 +4,10 @@ import { Icon, TextField } from "@/components";
 
 import { TextFieldProps } from "./TextField";
 
-export interface SearchFieldProps
-  extends Omit<TextFieldProps, "type" | "startContent" | "endContent"> {
+export interface SearchFieldProps extends Omit<
+  TextFieldProps,
+  "type" | "startContent" | "endContent"
+> {
   isFilter?: boolean;
 }
 

--- a/src/components/Input/TextArea.tsx
+++ b/src/components/Input/TextArea.tsx
@@ -3,7 +3,8 @@ import { TextAreaElement, InputWrapper, WrapperProps } from "./InputWrapper";
 import { mergeRefs } from "@/utils/mergeRefs";
 
 export interface TextAreaFieldProps
-  extends Omit<WrapperProps, "id" | "children">,
+  extends
+    Omit<WrapperProps, "id" | "children">,
     Omit<
       TextareaHTMLAttributes<HTMLTextAreaElement>,
       "children" | "type" | "value" | "onChange" | "dir"

--- a/src/components/Input/TextField.tsx
+++ b/src/components/Input/TextField.tsx
@@ -18,7 +18,8 @@ import {
 import { mergeRefs } from "@/utils/mergeRefs";
 
 export interface TextFieldProps
-  extends Omit<WrapperProps, "id" | "children">,
+  extends
+    Omit<WrapperProps, "id" | "children">,
     Omit<
       InputHTMLAttributes<HTMLInputElement>,
       "children" | "type" | "value" | "onChange" | "dir"

--- a/src/components/MultiAccordion/MultiAccordion.tsx
+++ b/src/components/MultiAccordion/MultiAccordion.tsx
@@ -85,8 +85,10 @@ export const MultiAccordion = ({
     </AccordionRoot>
   );
 };
-interface MultiAccordionItemProps
-  extends Omit<RadixAccordion.AccordionItemProps, "title"> {
+interface MultiAccordionItemProps extends Omit<
+  RadixAccordion.AccordionItemProps,
+  "title"
+> {
   /** The title text or element displayed in the accordion item header */
   title: ReactNode;
   /** The color variant of the item */

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -15,8 +15,10 @@ import {
 } from "@/components";
 import { styled } from "styled-components";
 
-export interface PaginationProps
-  extends Omit<ContainerProps<"div">, "children" | "onChange"> {
+export interface PaginationProps extends Omit<
+  ContainerProps<"div">,
+  "children" | "onChange"
+> {
   /** Total number of pages available */
   totalPages?: number;
   /** The currently selected page number */

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -2,8 +2,10 @@ import { HTMLAttributes, ReactNode } from "react";
 import { styled } from "styled-components";
 import { IconButton } from "@/components";
 
-interface CommonProgressBarProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, "children"> {
+interface CommonProgressBarProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  "children"
+> {
   /** The current progress value (0-100) */
   progress: number;
   /** Optional label to display */

--- a/src/components/Select/MultiSelect.tsx
+++ b/src/components/Select/MultiSelect.tsx
@@ -10,11 +10,10 @@ import {
   SelectItemDescription,
 } from "./common/InternalSelect";
 
-export interface MultiSelectProps
-  extends Omit<
-    SelectContainerProps,
-    "onChange" | "value" | "open" | "onOpenChange" | "onSelect"
-  > {
+export interface MultiSelectProps extends Omit<
+  SelectContainerProps,
+  "onChange" | "value" | "open" | "onOpenChange" | "onSelect"
+> {
   defaultValue?: Array<string>;
   onSelect?: (
     value: Array<string>,

--- a/src/components/Select/SingleSelect.tsx
+++ b/src/components/Select/SingleSelect.tsx
@@ -10,11 +10,10 @@ import {
   SelectItemDescription,
 } from "./common/InternalSelect";
 
-export interface SelectProps
-  extends Omit<
-    SelectContainerProps,
-    "onChange" | "value" | "sortable" | "open" | "onOpenChange" | "onSelect"
-  > {
+export interface SelectProps extends Omit<
+  SelectContainerProps,
+  "onChange" | "value" | "sortable" | "open" | "onOpenChange" | "onSelect"
+> {
   defaultValue?: string;
   onSelect?: (
     value: string,

--- a/src/components/Select/common/types.ts
+++ b/src/components/Select/common/types.ts
@@ -5,8 +5,10 @@ import { NoAvailableOptionsFactoryProps } from "@/components/Select/common/Inter
 
 declare type DivProps = HTMLAttributes<HTMLDivElement>;
 
-interface SelectItemComponentProps
-  extends Omit<DivProps, "disabled" | "onSelect" | "value" | "children"> {
+interface SelectItemComponentProps extends Omit<
+  DivProps,
+  "disabled" | "onSelect" | "value" | "children"
+> {
   separator?: boolean;
   disabled?: boolean;
   onSelect?: (
@@ -33,22 +35,28 @@ type SelectItemLabel = {
 
 export type SelectItemProps = SelectItemComponentProps &
   (SelectItemChildren | SelectItemLabel);
-export interface SelectGroupProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, "heading"> {
+export interface SelectGroupProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  "heading"
+> {
   heading: ReactNode;
   value?: never;
   onSelect?: never;
 }
-export interface SelectOptionItem
-  extends Omit<SelectItemProps, "children" | "label" | "description"> {
+export interface SelectOptionItem extends Omit<
+  SelectItemProps,
+  "children" | "label" | "description"
+> {
   heading?: never;
   label: ReactNode;
   description?: ReactNode;
   [key: `data-${string}`]: string;
 }
 
-export interface SelectGroupOptionItem
-  extends Omit<SelectGroupProps, "children" | "label" | "description"> {
+export interface SelectGroupOptionItem extends Omit<
+  SelectGroupProps,
+  "children" | "label" | "description"
+> {
   options: Array<SelectOptionItem>;
   label?: never;
   [key: `data-${string}`]: string;
@@ -69,7 +77,8 @@ type SelectChildrenType = {
 export type SelectionType = "custom" | "default";
 
 interface InternalSelectProps
-  extends PopoverProps,
+  extends
+    PopoverProps,
     Omit<HTMLAttributes<HTMLDivElement>, "onChange" | "dir" | "onSelect" | "children"> {
   onChange: (selectedValues: Array<string>) => void;
   onOpenChange: (open: boolean) => void;

--- a/src/components/SidebarCollapsibleTitle/SidebarCollapsibleTitle.tsx
+++ b/src/components/SidebarCollapsibleTitle/SidebarCollapsibleTitle.tsx
@@ -3,8 +3,7 @@ import { Icon, HorizontalDirection, IconName } from "@/components";
 import { Collapsible } from "../Collapsible/Collapsible";
 import { SidebarTitleWrapper } from "../SidebarNavigationTitle/SidebarNavigationTitle";
 
-export interface SidebarCollapsibleTitleProps
-  extends React.HTMLAttributes<HTMLButtonElement> {
+export interface SidebarCollapsibleTitleProps extends React.HTMLAttributes<HTMLButtonElement> {
   /** The label content to display */
   label: ReactNode;
   /** The content to display when expanded */

--- a/src/components/SplitButton/SplitButton.tsx
+++ b/src/components/SplitButton/SplitButton.tsx
@@ -29,8 +29,7 @@ type SubMenu = Omit<MenuItem, "type" | "items"> & {
 
 export type Menu = SubMenu | MenuGroup | MenuItem;
 export interface SplitButtonProps
-  extends DropdownMenuProps,
-    Omit<HTMLAttributes<HTMLButtonElement>, "dir"> {
+  extends DropdownMenuProps, Omit<HTMLAttributes<HTMLButtonElement>, "dir"> {
   /** The visual style variant of the button */
   type?: ButtonType;
   /** Whether the button is disabled */

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -381,8 +381,10 @@ const TableRowCloseButton = styled.button<TableRowCloseButtonProps>`
 interface TableCellType extends HTMLAttributes<HTMLTableCellElement> {
   label: ReactNode;
 }
-export interface TableRowType
-  extends Omit<HTMLAttributes<HTMLTableRowElement>, "onSelect" | "id"> {
+export interface TableRowType extends Omit<
+  HTMLAttributes<HTMLTableRowElement>,
+  "onSelect" | "id"
+> {
   id: string | number;
   items: Array<TableCellType>;
   isDisabled?: boolean;
@@ -392,8 +394,10 @@ export interface TableRowType
   isIndeterminate?: boolean;
 }
 
-interface CommonTableProps
-  extends Omit<HTMLAttributes<HTMLTableElement>, "children" | "onSelect"> {
+interface CommonTableProps extends Omit<
+  HTMLAttributes<HTMLTableElement>,
+  "children" | "onSelect"
+> {
   headers: Array<TableHeaderType>;
   rows: Array<TableRowType>;
   onDelete?: (item: TableRowType, index: number) => void;

--- a/yarn.lock
+++ b/yarn.lock
@@ -308,7 +308,7 @@ __metadata:
     eslint-plugin-storybook: "npm:^10.0.7"
     jsdom: "npm:^24.0.0"
     lodash: "npm:^4.17.21"
-    prettier: "npm:3.6.2"
+    prettier: "npm:3.7.4"
     prop-types: "npm:^15.8.1"
     react: "npm:18.3.1"
     react-dom: "npm:18.3.1"
@@ -6399,12 +6399,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:3.6.2":
-  version: 3.6.2
-  resolution: "prettier@npm:3.6.2"
+"prettier@npm:3.7.4":
+  version: 3.7.4
+  resolution: "prettier@npm:3.7.4"
   bin:
     prettier: bin/prettier.cjs
-  checksum: 10c0/488cb2f2b99ec13da1e50074912870217c11edaddedeadc649b1244c749d15ba94e846423d062e2c4c9ae683e2d65f754de28889ba06e697ac4f988d44f45812
+  checksum: 10c0/9675d2cd08eacb1faf1d1a2dbfe24bfab6a912b059fc9defdb380a408893d88213e794a40a2700bd29b140eb3172e0b07c852853f6e22f16f3374659a1a13389
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reformats TypeScript interface declarations across multiple components for improved readability and consistency, primarily by moving 'extends' and generic type parameters to a single line or consistent multi-line style. Also updates Prettier to version 3.7.4 in package.json and yarn.lock.