### PR TITLE
Enhance publish workflow with branch input and npm tag logic

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,17 +71,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22.x'  # Node 22 includes npm >= 11.5.1 with OIDC support
-      - name: Verify npm version supports OIDC
+      - name: Upgrade npm for OIDC support
         run: |
+          npm install -g npm@latest
           echo "npm version: $(npm --version)"
-          NPM_VERSION=$(npm --version | cut -d. -f1)
-          if [ "$NPM_VERSION" -lt 11 ]; then
-            echo "⚠️  npm version is too old for OIDC. Upgrading npm..."
-            npm install -g npm@latest
-            echo "✓ npm upgraded to: $(npm --version)"
-          else
-            echo "✓ npm version supports OIDC tokenless publishing"
-          fi
       - name: Enable Corepack
         run: corepack enable
       - name: Install dependencies
@@ -101,21 +94,8 @@ jobs:
             # If it's a tag name input (e.g., scss-deprecation), use it as the npm tag
             echo "NPM_TAG=$GITHUB_TAG" >> "$GITHUB_ENV"
           fi
-      - name: Publish to npm with OIDC (tokenless)
-        run: |
-          echo "Publishing version: $(node -p "require('./package.json').version")"
-          echo "Publishing to tag: $NPM_TAG"
-          echo "Using OIDC tokenless publishing (npm >= 11.5.1)"
-          npm publish --access public --tag $NPM_TAG --provenance
-      - name: Show npm error log on failure
-        if: always()
-        run: |
-          if ls ~/.npm/_logs/*-debug-*.log 1> /dev/null 2>&1; then
-            echo "=== NPM Error Log ==="
-            cat ~/.npm/_logs/*-debug-*.log
-          else
-            echo "No npm error log (publish succeeded or no log generated)"
-          fi
+      - name: Publish to npm with OIDC
+        run: npm publish --access public --tag $NPM_TAG --provenance
       - name: update package version (for version inputs only)
         if: ${{ env.IS_VERSION_INPUT == 'true' }}
         run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickhouse/click-ui",
-  "version": "0.0.241-beta.6",
+  "version": "0.0.242",
   "description": "Official ClickHouse design system react library",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
Modernizes npm publishing with OIDC tokenless authentication and adds dual-mode release strategy for flexible experimental releases without git pollution.

## Changes

### 🔐 OIDC Tokenless Publishing
- Upgraded to Node 22 + npm 11.7.0 for OIDC support
- **Removes `NPM_CI_TOKEN` secret requirement** - zero secrets needed!
- Added `--provenance` flag for cryptographic package attestations
- Configured npm Trusted Publishers for supply chain security

### 🚀 Dual-Mode Release Strategy

**Mode 1: Version Input** (e.g., `0.0.243`, `0.0.243-beta.1`)
- Publishes with semantic version
- Creates git commit + tag
- Tracked in git history

**Mode 2: Tag Input** (e.g., `beta`, `scss-deprecation`, `experimental`)
- Generates prerelease version: `0.0.242-tagname.0`
- Publishes to custom npm tag
- **No git commit/tag** - clean git history!

### 📦 Other Improvements
- Upgraded Yarn 1.22 → Yarn 4.5.3
- Granular GitHub Actions permissions (removed `write-all`)
- Added branch selection for workflow dispatch
- Optimized workflow steps

## Benefits
- ✅ Zero npm token management
- ✅ Ephemeral OIDC tokens per workflow run
- ✅ Experimental releases don't clutter git
- ✅ Cryptographic provenance for packages
- ✅ Better supply chain security

## Usage Examples

**Official Release:**
```bash
# Input: 0.0.243
# Result: Published to @latest, git tag created
Beta Release:

# Input: 0.0.243-beta.1
# Result: Published to @beta, git tag created
Experimental Feature:

# Input: scss-deprecation
# Result: Published as 0.0.242-scss-deprecation.0 to @scss-deprecation
# No git changes!
Installation:

npm install @clickhouse/click-ui@latest
npm install @clickhouse/click-ui@beta
npm install @clickhouse/click-ui@scss-deprecation
```

## Testing

✅ Verified OIDC authentication with npm 11.7.0
✅ Tested both version and tag input modes
✅ Confirmed provenance signing works
✅ Validated git operations are conditional
✅ Successfully published test package

## Post-Merge Actions

Delete NPM_CI_TOKEN secret from repository settings (obsolete)
Verify npm Trusted Publisher remains configured