### PR TITLE
Refactor components to use polymorphic utility types

### DIFF
--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -23,8 +23,9 @@ type JustifyContentOptions =
 export type PaddingOptions = "none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl";
 type WrapOptions = "nowrap" | "wrap" | "wrap-reverse";
 
-export interface ContainerProps<T extends ElementType = "div">
-  extends PolymorphicComponentProps<T> {
+export interface ContainerProps<
+  T extends ElementType = "div",
+> extends PolymorphicComponentProps<T> {
   /** Alignment of items along the cross axis */
   alignItems?: AlignItemsOptions;
   /** The content to display inside the container */

--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -1,12 +1,12 @@
 import { styled } from "styled-components";
-import {
-  ComponentProps,
-  ComponentPropsWithRef,
-  ElementType,
-  ReactNode,
-  forwardRef,
-} from "react";
+import { ElementType, forwardRef } from "react";
 import { Orientation } from "@/components";
+import {
+  PolymorphicComponent,
+  PolymorphicComponentProps,
+  PolymorphicProps,
+  PolymorphicRef,
+} from "@/utils/polymorphic";
 
 type AlignItemsOptions = "start" | "center" | "end" | "stretch";
 export type GapOptions = "none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl";
@@ -23,9 +23,8 @@ type JustifyContentOptions =
 export type PaddingOptions = "none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl";
 type WrapOptions = "nowrap" | "wrap" | "wrap-reverse";
 
-export interface ContainerProps<T extends ElementType = "div"> {
-  /** Custom component to render as */
-  component?: T;
+export interface ContainerProps<T extends ElementType = "div">
+  extends PolymorphicComponentProps<T> {
   /** Alignment of items along the cross axis */
   alignItems?: AlignItemsOptions;
   /** The content to display inside the container */
@@ -62,10 +61,6 @@ export interface ContainerProps<T extends ElementType = "div"> {
   overflow?: string;
 }
 
-type ContainerPolymorphicComponent = <T extends ElementType = "div">(
-  props: Omit<ComponentProps<T>, keyof T> & ContainerProps<T>
-) => ReactNode;
-
 const _Container = <T extends ElementType = "div">(
   {
     component,
@@ -87,8 +82,8 @@ const _Container = <T extends ElementType = "div">(
     minHeight,
     overflow,
     ...props
-  }: Omit<ComponentProps<T>, keyof T> & ContainerProps<T>,
-  ref: ComponentPropsWithRef<T>["ref"]
+  }: PolymorphicProps<T, ContainerProps<T>>,
+  ref: PolymorphicRef<T>
 ) => {
   return (
     <Wrapper
@@ -170,4 +165,4 @@ const Wrapper = styled.div<{
   }
 `;
 
-export const Container: ContainerPolymorphicComponent = forwardRef(_Container);
+export const Container: PolymorphicComponent<ContainerProps> = forwardRef(_Container);

--- a/src/components/EllipsisContent/EllipsisContent.tsx
+++ b/src/components/EllipsisContent/EllipsisContent.tsx
@@ -1,12 +1,12 @@
-import {
-  ComponentProps,
-  ComponentPropsWithRef,
-  ElementType,
-  ReactNode,
-  forwardRef,
-} from "react";
+import { ElementType, forwardRef } from "react";
 import { mergeRefs } from "@/utils/mergeRefs";
 import { styled } from "styled-components";
+import {
+  PolymorphicComponent,
+  PolymorphicComponentProps,
+  PolymorphicProps,
+  PolymorphicRef,
+} from "@/utils/polymorphic";
 
 const EllipsisContainer = styled.div`
   display: inline-block;
@@ -24,17 +24,12 @@ const EllipsisContainer = styled.div`
     text-overflow: ellipsis;
   }
 `;
-export interface EllipsisContentProps<T extends ElementType = "div"> {
-  component?: T;
-}
-
-type EllipsisPolymorphicComponent = <T extends ElementType = "div">(
-  props: Omit<ComponentProps<T>, keyof T> & EllipsisContentProps<T>
-) => ReactNode;
+export interface EllipsisContentProps<T extends ElementType = "div">
+  extends PolymorphicComponentProps<T> {}
 
 const _EllipsisContent = <T extends ElementType = "div">(
-  { component, ...props }: Omit<ComponentProps<T>, keyof T> & EllipsisContentProps<T>,
-  ref: ComponentPropsWithRef<T>["ref"]
+  { component, ...props }: PolymorphicProps<T, EllipsisContentProps<T>>,
+  ref: PolymorphicRef<T>
 ) => {
   return (
     <EllipsisContainer
@@ -52,4 +47,5 @@ const _EllipsisContent = <T extends ElementType = "div">(
   );
 };
 
-export const EllipsisContent: EllipsisPolymorphicComponent = forwardRef(_EllipsisContent);
+export const EllipsisContent: PolymorphicComponent<EllipsisContentProps> =
+  forwardRef(_EllipsisContent);

--- a/src/components/EllipsisContent/EllipsisContent.tsx
+++ b/src/components/EllipsisContent/EllipsisContent.tsx
@@ -24,8 +24,9 @@ const EllipsisContainer = styled.div`
     text-overflow: ellipsis;
   }
 `;
-export interface EllipsisContentProps<T extends ElementType = "div">
-  extends PolymorphicComponentProps<T> {}
+export interface EllipsisContentProps<
+  T extends ElementType = "div",
+> extends PolymorphicComponentProps<T> {}
 
 const _EllipsisContent = <T extends ElementType = "div">(
   { component, ...props }: PolymorphicProps<T, EllipsisContentProps<T>>,

--- a/src/components/GridContainer/GridContainer.tsx
+++ b/src/components/GridContainer/GridContainer.tsx
@@ -1,11 +1,11 @@
 import { styled } from "styled-components";
+import { ElementType, forwardRef } from "react";
 import {
-  ComponentProps,
-  ComponentPropsWithRef,
-  ElementType,
-  forwardRef,
-  ReactNode,
-} from "react";
+  PolymorphicComponent,
+  PolymorphicComponentProps,
+  PolymorphicProps,
+  PolymorphicRef,
+} from "@/utils/polymorphic";
 
 export type FlowOptions = "row" | "column" | "row-dense" | "column-dense";
 type GapOptions = "none" | "xxs" | "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "unset";
@@ -21,9 +21,8 @@ type ContentOptions =
   | "left"
   | "right";
 
-export interface GridContainerProps<T extends ElementType = "div"> {
-  /** Custom component to render as */
-  component?: T;
+export interface GridContainerProps<T extends ElementType = "div">
+  extends PolymorphicComponentProps<T> {
   /** Alignment of items along the block axis */
   alignItems?: ItemsOptions;
   /** Alignment of content along the block axis */
@@ -74,10 +73,6 @@ export interface GridContainerProps<T extends ElementType = "div"> {
   overflow?: string;
 }
 
-type GridContainerPolymorphicComponent = <T extends ElementType = "div">(
-  props: Omit<ComponentProps<T>, keyof T> & GridContainerProps<T>
-) => ReactNode;
-
 const _GridContainer = <T extends ElementType = "div">(
   {
     alignItems = "stretch",
@@ -106,8 +101,8 @@ const _GridContainer = <T extends ElementType = "div">(
     overflow,
     component,
     ...props
-  }: Omit<ComponentProps<T>, keyof T> & GridContainerProps<T>,
-  ref: ComponentPropsWithRef<T>["ref"]
+  }: PolymorphicProps<T, GridContainerProps<T>>,
+  ref: PolymorphicRef<T>
 ) => {
   return (
     <Wrapper
@@ -213,5 +208,5 @@ const Wrapper = styled.div<{
   }
 `;
 
-export const GridContainer: GridContainerPolymorphicComponent =
+export const GridContainer: PolymorphicComponent<GridContainerProps> =
   forwardRef(_GridContainer);

--- a/src/components/GridContainer/GridContainer.tsx
+++ b/src/components/GridContainer/GridContainer.tsx
@@ -21,8 +21,9 @@ type ContentOptions =
   | "left"
   | "right";
 
-export interface GridContainerProps<T extends ElementType = "div">
-  extends PolymorphicComponentProps<T> {
+export interface GridContainerProps<
+  T extends ElementType = "div",
+> extends PolymorphicComponentProps<T> {
   /** Alignment of items along the block axis */
   alignItems?: ItemsOptions;
   /** Alignment of content along the block axis */

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,17 +1,17 @@
-import {
-  ComponentProps,
-  ComponentPropsWithRef,
-  ElementType,
-  ReactEventHandler,
-  ReactNode,
-  forwardRef,
-} from "react";
+import { ElementType, ReactEventHandler, forwardRef } from "react";
 import { Icon, IconName } from "@/components";
 import { styled } from "styled-components";
 import { linkStyles } from "./common";
 import { TextSize, TextWeight } from "../commonTypes";
+import {
+  PolymorphicComponent,
+  PolymorphicComponentProps,
+  PolymorphicProps,
+  PolymorphicRef,
+} from "@/utils/polymorphic";
 
-export interface LinkProps<T extends ElementType = "a"> {
+export interface LinkProps<T extends ElementType = "a">
+  extends PolymorphicComponentProps<T> {
   /** The font size of the link text */
   size?: TextSize;
   /** The font weight of the link text */
@@ -22,8 +22,6 @@ export interface LinkProps<T extends ElementType = "a"> {
   children?: React.ReactNode;
   /** Optional icon to display after the link text */
   icon?: IconName;
-  /** Custom component to render as the link element */
-  component?: T;
 }
 
 const CuiLink = styled.a<{ $size: TextSize; $weight: TextWeight }>`
@@ -43,10 +41,6 @@ const IconWrapper = styled.span<{ $size: TextSize }>`
   }
 `;
 
-type LinkPolymorphicComponent = <T extends ElementType = "a">(
-  props: Omit<ComponentProps<T>, keyof T> & LinkProps<T>
-) => ReactNode;
-
 /** Component for linking to other pages or sections from with body text */
 const _Link = <T extends ElementType = "a">(
   {
@@ -57,8 +51,8 @@ const _Link = <T extends ElementType = "a">(
     children,
     component,
     ...props
-  }: Omit<ComponentProps<T>, keyof T> & LinkProps<T>,
-  ref: ComponentPropsWithRef<T>["ref"]
+  }: PolymorphicProps<T, LinkProps<T>>,
+  ref: PolymorphicRef<T>
 ) => (
   <CuiLink
     ref={ref}
@@ -80,4 +74,4 @@ const _Link = <T extends ElementType = "a">(
     )}
   </CuiLink>
 );
-export const Link: LinkPolymorphicComponent = forwardRef(_Link);
+export const Link: PolymorphicComponent<LinkProps, "a"> = forwardRef(_Link);

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -10,8 +10,9 @@ import {
   PolymorphicRef,
 } from "@/utils/polymorphic";
 
-export interface LinkProps<T extends ElementType = "a">
-  extends PolymorphicComponentProps<T> {
+export interface LinkProps<
+  T extends ElementType = "a",
+> extends PolymorphicComponentProps<T> {
   /** The font size of the link text */
   size?: TextSize;
   /** The font weight of the link text */

--- a/src/components/Typography/Text/Text.tsx
+++ b/src/components/Typography/Text/Text.tsx
@@ -11,8 +11,9 @@ import {
 export type TextAlignment = "left" | "center" | "right";
 export type TextColor = "default" | "muted" | "danger" | "disabled";
 
-export interface TextProps<T extends ElementType = "p">
-  extends PolymorphicComponentProps<T> {
+export interface TextProps<
+  T extends ElementType = "p",
+> extends PolymorphicComponentProps<T> {
   /** The text content to display */
   children: ReactNode;
   /** The text alignment */

--- a/src/components/Typography/Text/Text.tsx
+++ b/src/components/Typography/Text/Text.tsx
@@ -1,17 +1,18 @@
-import {
-  ComponentProps,
-  ComponentPropsWithRef,
-  ElementType,
-  ReactNode,
-  forwardRef,
-} from "react";
+import { ElementType, ReactNode, forwardRef } from "react";
 import { styled } from "styled-components";
 import { TextSize, TextWeight } from "@/components/commonTypes";
+import {
+  PolymorphicComponent,
+  PolymorphicComponentProps,
+  PolymorphicProps,
+  PolymorphicRef,
+} from "@/utils/polymorphic";
 
 export type TextAlignment = "left" | "center" | "right";
 export type TextColor = "default" | "muted" | "danger" | "disabled";
 
-export interface TextProps<T extends ElementType = "p"> {
+export interface TextProps<T extends ElementType = "p">
+  extends PolymorphicComponentProps<T> {
   /** The text content to display */
   children: ReactNode;
   /** The text alignment */
@@ -24,15 +25,9 @@ export interface TextProps<T extends ElementType = "p"> {
   weight?: TextWeight;
   /** Additional CSS class name */
   className?: string;
-  /** Custom component to render as */
-  component?: T;
   /** Whether the text should fill the full width of its container */
   fillWidth?: boolean;
 }
-
-type TextPolymorphicComponent = <T extends ElementType = "p">(
-  props: Omit<ComponentProps<T>, keyof T> & TextProps<T>
-) => ReactNode;
 
 const _Text = <T extends ElementType = "p">(
   {
@@ -45,8 +40,8 @@ const _Text = <T extends ElementType = "p">(
     component,
     fillWidth,
     ...props
-  }: Omit<ComponentProps<T>, keyof T> & TextProps<T>,
-  ref: ComponentPropsWithRef<T>["ref"]
+  }: PolymorphicProps<T, TextProps<T>>,
+  ref: PolymorphicRef<T>
 ) => (
   <CuiText
     as={component ?? "p"}
@@ -80,5 +75,5 @@ const CuiText = styled.p<{
 
 _Text.displayName = "Text";
 
-const Text: TextPolymorphicComponent = forwardRef(_Text);
+const Text: PolymorphicComponent<TextProps, "p"> = forwardRef(_Text);
 export { Text };

--- a/src/utils/polymorphic/README.md
+++ b/src/utils/polymorphic/README.md
@@ -1,0 +1,234 @@
+## What Are Polymorphic Components?
+
+Polymorphic components allow you to change the underlying HTML element or React component while preserving full type safety. This means you get autocomplete and type checking for both:
+1. The custom component's props (like `gap`, `orientation`, etc.)
+2. The native element's props (like `onClick`, `href`, `disabled`, etc.)
+
+## Key Features
+
+✅ **Full Type Safety** - TypeScript knows which props are valid based on the `component` prop
+✅ **DRY Implementation** - Reusable utility types in `@/utils/polymorphic`
+✅ **Ref Forwarding** - Properly typed refs for any element type
+✅ **Native & Custom Components** - Pass any HTML element or React component
+✅ **Works with Styled Components** - Compatible with styled-components and SCSS modules
+
+## Implementation
+
+### Utility Types
+
+All polymorphic logic is centralized in [`src/utils/polymorphic/index.ts`](index.ts):
+
+```typescript
+import {
+  PolymorphicComponent,
+  PolymorphicComponentProps,
+  PolymorphicProps,
+  PolymorphicRef,
+} from "@/utils/polymorphic";
+```
+
+### Creating a Polymorphic Component
+
+```typescript
+import { ElementType, forwardRef } from "react";
+import clsx from "clsx";
+import {
+  PolymorphicComponent,
+  PolymorphicComponentProps,
+  PolymorphicProps,
+  PolymorphicRef,
+} from "@/utils/polymorphic";
+import styles from "./MyComponent.module.scss";
+
+// 1. Define props interface extending PolymorphicComponentProps
+export interface MyComponentProps<T extends ElementType = "div">
+  extends PolymorphicComponentProps<T> {
+  customProp?: string;
+  gap?: "sm" | "md" | "lg";
+}
+
+// 2. Implement the component with PolymorphicProps and PolymorphicRef
+const _MyComponent = <T extends ElementType = "div">(
+  { component, customProp, gap, ...props }: PolymorphicProps<T, MyComponentProps<T>>,
+  ref: PolymorphicRef<T>
+) => {
+  const Component = component ?? "div";
+
+  return (
+    <Component
+      ref={ref}
+      className={clsx(styles.myComponent, {
+        [styles.gapSm]: gap === "sm",
+        [styles.gapMd]: gap === "md",
+        [styles.gapLg]: gap === "lg",
+      })}
+      {...props}
+    />
+  );
+};
+
+// 3. Export with PolymorphicComponent type
+export const MyComponent: PolymorphicComponent<MyComponentProps> = forwardRef(_MyComponent);
+```
+
+## Usage Examples
+
+### With Native HTML Elements
+
+```tsx
+// As a button - gets all button props
+<Container
+  component="button"
+  onClick={(e) => console.log(e)}
+  disabled
+  gap="md" // Custom Container prop
+/>
+
+// As an anchor - gets all anchor props
+<Container
+  component="a"
+  href="https://example.com"
+  target="_blank"
+  orientation="vertical" // Custom Container prop
+/>
+
+// As a list item
+<Link
+  component="li"
+  size="lg"
+  weight="bold"
+>
+  List item text
+</Link>
+```
+
+### With Custom React Components
+
+```tsx
+// Container rendered as Link
+<Container
+  component={Link}
+  size="xl" // Link prop
+  weight="bold" // Link prop
+  gap="lg" // Container prop
+>
+  This is a Container with Link styling
+</Container>
+
+// EllipsisContent rendered as Link
+<EllipsisContent
+  component={Link}
+  size="sm" // Link prop
+  weight="bold" // Link prop
+>
+  This text will be truncated with ellipsis
+</EllipsisContent>
+```
+
+### With Refs
+
+```tsx
+const buttonRef = useRef<HTMLButtonElement>(null);
+const divRef = useRef<HTMLDivElement>(null);
+
+<Container component="button" ref={buttonRef} gap="md">
+  Button Container
+</Container>
+
+<Container ref={divRef} gap="md">
+  Div Container (default)
+</Container>
+```
+
+## Available Polymorphic Components
+
+The following components support the `component` prop:
+
+- **`Container`** - Flexible layout container (default: `div`)
+- **`GridContainer`** - CSS Grid container (default: `div`)
+- **`EllipsisContent`** - Text truncation wrapper (default: `div`)
+- **`Link`** - Link component (default: `a`)
+- **`Text`** - Text/Typography component (default: `p`)
+
+## Type Safety Examples
+
+### ✅ Valid Usage
+
+```tsx
+// All these work perfectly with full autocomplete:
+
+<Container component="button" onClick={handler} disabled />
+<Container component="a" href="/path" target="_blank" />
+<Link component="span" onClick={handler} />
+<GridContainer component="section" role="region" />
+```
+
+### ❌ Type Errors (Caught at Compile Time)
+
+```tsx
+// ERROR: div doesn't have 'disabled'
+<Container component="div" disabled />
+
+// ERROR: span doesn't have 'href'
+<Link component="span" href="https://example.com" />
+
+// ERROR: Invalid prop value
+<Container gap="invalid-value" />
+```
+
+## Real-World Example
+
+```tsx
+<Container component="main" padding="lg" gap="xl" orientation="vertical">
+  <Container component="header" gap="md">
+    <Link component="h1" size="xl" weight="bold">
+      Page Title
+    </Link>
+  </Container>
+
+  <Container component="section" gap="md" orientation="vertical">
+    <Link component="h2" size="lg" weight="semibold">
+      Section Title
+    </Link>
+
+    <GridContainer
+      component="ul"
+      gridTemplateColumns="repeat(auto-fit, minmax(200px, 1fr))"
+      gap="md"
+    >
+      <Link component="li" size="md">Feature 1</Link>
+      <Link component="li" size="md">Feature 2</Link>
+      <Link component="li" size="md">Feature 3</Link>
+    </GridContainer>
+  </Container>
+
+  <Container component="footer" gap="sm">
+    <Link component="a" href="/docs" size="sm">
+      Documentation
+    </Link>
+  </Container>
+</Container>
+```
+
+## Technical Details
+
+### How It Works
+
+1. **`PolymorphicComponentProps<T>`** - Base interface with `component?: T`
+2. **`PolymorphicProps<T, TProps>`** - Merges component-specific props with native element props
+3. **`PolymorphicRef<T>`** - Extracts the correct ref type for element `T`
+4. **`PolymorphicComponent<TProps>`** - Final exported component type with proper inference
+
+### Type Inference Flow
+
+```typescript
+<Container component="button" onClick={...} />
+         ↓
+T = "button" (inferred from component prop)
+         ↓
+Props = ContainerProps & ComponentProps<"button">
+         ↓
+Result: You get autocomplete for both Container AND button props!
+```
+
+For more examples, see [`src/utils/polymorphic/index.test.tsx`](index.test.tsx).

--- a/src/utils/polymorphic/index.test.tsx
+++ b/src/utils/polymorphic/index.test.tsx
@@ -1,0 +1,251 @@
+/**
+ * Type safety tests for polymorphic components with SCSS
+ * These examples demonstrate that the polymorphic component pattern
+ * works correctly with SCSS modules and provides full type safety
+ */
+
+import { Container, Link, GridContainer, EllipsisContent } from "@/components";
+import { Text } from "@/components/Typography/Text/Text";
+
+// ============================================================================
+// Test 1: Native HTML Elements
+// ============================================================================
+
+export const NativeElementTest = () => (
+  <>
+    {/* Container as button - gets button props */}
+    <Container
+      component="button"
+      onClick={(e: React.MouseEvent<HTMLButtonElement>) =>
+        console.log(e.currentTarget.value)
+      } // ✅ button events work
+      disabled // ✅ button attributes work
+      gap="md" // ✅ Container props work
+    />
+
+    {/* Container as a link */}
+    <Container
+      component="a"
+      href="https://example.com" // ✅ anchor attributes work
+      target="_blank" // ✅ anchor attributes work
+      orientation="vertical" // ✅ Container props work
+    />
+
+    {/* Link as span */}
+    <Link
+      component="span"
+      size="lg" // ✅ Link props work
+      weight="bold" // ✅ Link props work
+      onClick={(e: React.MouseEvent<HTMLSpanElement>) => console.log(e)} // ✅ span events work
+    >
+      Link content
+    </Link>
+
+    {/* Text as h1 */}
+    <Text
+      component="h1"
+      size="lg" // ✅ Text props work
+      weight="bold" // ✅ Text props work
+      color="default" // ✅ Text props work
+    >
+      Heading text
+    </Text>
+  </>
+);
+
+// ============================================================================
+// Test 2: Custom React Components
+// ============================================================================
+
+export const CustomComponentTest = () => (
+  <>
+    {/* Container can render another custom component */}
+    <Container
+      component={Link}
+      size="lg" // ✅ Link props are available
+      weight="bold" // ✅ Link props are available
+      gap="lg" // ✅ Container props work
+    >
+      This is a Container rendered as Link
+    </Container>
+
+    {/* EllipsisContent rendered as Link */}
+    <EllipsisContent
+      component={Link}
+      size="sm" // ✅ Link props work
+      weight="bold" // ✅ Link props work
+    >
+      This text will be truncated
+    </EllipsisContent>
+
+    {/* Container rendered as Text */}
+    <Container
+      component={Text}
+      size="md" // ✅ Text props are available
+      color="muted" // ✅ Text props are available
+      gap="md" // ✅ Container props work
+    >
+      This is a Container rendered as Text
+    </Container>
+
+    {/* GridContainer as section */}
+    <GridContainer
+      component="section"
+      gridTemplateColumns="repeat(3, 1fr)" // ✅ Grid props work
+      gap="md" // ✅ Grid props work
+      role="region" // ✅ section attributes work
+      aria-label="Grid section" // ✅ section attributes work
+    />
+
+    {/* Link as button */}
+    <Link
+      component="button"
+      onClick={e => console.log(e)} // ✅ button events work
+      disabled // ✅ button attributes work
+      size="lg" // ✅ Link props work
+      weight="semibold" // ✅ Link props work
+    >
+      Button Link
+    </Link>
+  </>
+);
+
+// ============================================================================
+// Test 3: Type Errors (These should NOT compile if uncommented)
+// ============================================================================
+
+// Example type errors that would be caught:
+// 1. div doesn't have 'disabled'
+// 2. span doesn't have 'href'
+// 3. Invalid Container prop values
+// 4. Invalid Link color values
+
+// ============================================================================
+// Test 4: Ref Forwarding
+// ============================================================================
+
+import { useRef } from "react";
+
+export const RefTest = () => {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const divRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <>
+      {/* ✅ Ref type matches component type */}
+      <Container
+        component="button"
+        ref={buttonRef}
+        gap="md"
+      >
+        Button Container
+      </Container>
+
+      {/* ✅ Default ref type (div) */}
+      <Container
+        ref={divRef}
+        gap="md"
+      >
+        Div Container
+      </Container>
+    </>
+  );
+};
+
+// ============================================================================
+// Test 5: Real-World Usage Examples
+// ============================================================================
+
+export const RealWorldExample = () => (
+  <Container
+    component="main"
+    padding="lg"
+    gap="xl"
+    orientation="vertical"
+  >
+    <Container
+      component="header"
+      gap="md"
+    >
+      <Text
+        component="h1"
+        size="lg"
+        weight="bold"
+      >
+        Polymorphic Components with Styled Components
+      </Text>
+    </Container>
+
+    <Container
+      component="section"
+      gap="md"
+      orientation="vertical"
+    >
+      <Text
+        component="h2"
+        size="lg"
+        weight="semibold"
+      >
+        Features
+      </Text>
+
+      <GridContainer
+        component="ul"
+        gridTemplateColumns="repeat(auto-fit, minmax(200px, 1fr))"
+        gap="md"
+      >
+        <Text
+          component="li"
+          size="md"
+        >
+          ✅ Full type safety
+        </Text>
+        <Text
+          component="li"
+          size="md"
+        >
+          ✅ Works with styled-components
+        </Text>
+        <Text
+          component="li"
+          size="md"
+        >
+          ✅ Native HTML props
+        </Text>
+        <Text
+          component="li"
+          size="md"
+        >
+          ✅ Custom component props
+        </Text>
+      </GridContainer>
+    </Container>
+
+    <Container
+      component="footer"
+      gap="sm"
+    >
+      <Link
+        component="a"
+        href="https://example.com"
+        size="sm"
+      >
+        Learn more
+      </Link>
+    </Container>
+  </Container>
+);
+
+// ============================================================================
+// Vitest Suite
+// ============================================================================
+
+import { describe, it, expect } from "vitest";
+
+describe("Polymorphic Components Type Safety", () => {
+  it("should render polymorphic components without errors", () => {
+    // This test suite is primarily for TypeScript type checking
+    // The type-safe rendering is validated at compile time
+    expect(true).toBe(true);
+  });
+});

--- a/src/utils/polymorphic/index.ts
+++ b/src/utils/polymorphic/index.ts
@@ -1,0 +1,58 @@
+import { ComponentProps, ComponentPropsWithRef, ElementType, ReactNode } from "react";
+
+/**
+ * Utility types for creating type-safe polymorphic components with SCSS modules
+ *
+ * Usage example:
+ * ```tsx
+ * interface MyComponentProps<T extends ElementType = "div"> extends PolymorphicComponentProps<T> {
+ *   customProp?: string;
+ * }
+ *
+ * type MyComponentType = PolymorphicComponent<MyComponentProps>;
+ *
+ * const _MyComponent = <T extends ElementType = "div">(
+ *   props: PolymorphicProps<T, MyComponentProps<T>>,
+ *   ref: PolymorphicRef<T>
+ * ) => {
+ *   const Component = props.component ?? "div";
+ *   return <Component ref={ref} {...props} />;
+ * };
+ *
+ * export const MyComponent: MyComponentType = forwardRef(_MyComponent);
+ * ```
+ */
+
+/**
+ * Base props for polymorphic components
+ */
+export interface PolymorphicComponentProps<T extends ElementType> {
+  component?: T;
+}
+
+/**
+ * Merges the component's custom props with native HTML element props
+ * Excludes conflicting keys from ComponentProps to ensure custom props take precedence
+ */
+export type PolymorphicProps<
+  T extends ElementType,
+  TProps extends PolymorphicComponentProps<T>,
+> = Omit<ComponentProps<T>, keyof TProps> & TProps;
+
+/**
+ * Extracts the correct ref type for the polymorphic component
+ */
+export type PolymorphicRef<T extends ElementType> = ComponentPropsWithRef<T>["ref"];
+
+/**
+ * Type for the final exported polymorphic component
+ * This uses a mapped type to properly infer the element type
+ */
+export type PolymorphicComponent<
+  TProps extends PolymorphicComponentProps<ElementType>,
+  TDefaultElement extends ElementType = "div",
+> = <T extends ElementType = TDefaultElement>(
+  props: PolymorphicProps<T, Omit<TProps, "component"> & { component?: T }> & {
+    ref?: PolymorphicRef<T>;
+  }
+) => ReactNode;


### PR DESCRIPTION
Replaces custom polymorphic type logic in Container, GridContainer, EllipsisContent, Link, and Text components with shared utility types from src/utils/polymorphic. Adds src/utils/polymorphic with documentation and type tests to ensure type safety and ref forwarding for polymorphic components. This centralizes and standardizes the polymorphic pattern across the codebase.

We can reuse this in all the places where we need to extend the content with component prop in the future prs