### PR TITLE
style: add curly eslint rule; fix failing places

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -36,6 +36,7 @@ export default tseslint.config(
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
+      curly: ['error', 'all'],
       "react-refresh/only-export-components": "warn",
       "no-multiple-empty-lines": "error",
       quotes: ["error", "double"],

--- a/src/components/CodeBlock/CodeBlock.tsx
+++ b/src/components/CodeBlock/CodeBlock.tsx
@@ -119,7 +119,9 @@ export const CodeBlock = ({
       setTimeout(() => setCopied(false), 2000);
     } catch (error) {
       let message = "Unable to copy code";
-      if (error instanceof Error) message = error.message;
+      if (error instanceof Error) {
+        message = error.message;
+      }
       setErrorCopy(true);
       if (typeof onCopyError === "function") {
         onCopyError(message);

--- a/src/components/FileUpload/FileMultiUpload.tsx
+++ b/src/components/FileUpload/FileMultiUpload.tsx
@@ -178,7 +178,9 @@ const formatFileSize = (sizeInBytes: number): string => {
 };
 
 const isFiletypeSupported = (filename: string, supportedTypes: string[]): boolean => {
-  if (!supportedTypes.length) return true;
+  if (!supportedTypes.length) {
+    return true;
+  }
 
   const extension = filename.toLowerCase().slice(filename.lastIndexOf("."));
   return supportedTypes.some(type => type.toLowerCase() === extension.toLowerCase());

--- a/src/components/FileUpload/FileUpload.tsx
+++ b/src/components/FileUpload/FileUpload.tsx
@@ -194,7 +194,9 @@ const formatFileSize = (sizeInBytes: number): string => {
 };
 
 const isFiletypeSupported = (filename: string, supportedTypes: string[]): boolean => {
-  if (!supportedTypes.length) return true;
+  if (!supportedTypes.length) {
+    return true;
+  }
 
   const extension = filename.toLowerCase().slice(filename.lastIndexOf("."));
   return supportedTypes.some(type => type.toLowerCase() === extension.toLowerCase());

--- a/src/components/SplitButton/SplitButton.tsx
+++ b/src/components/SplitButton/SplitButton.tsx
@@ -67,7 +67,9 @@ export const SplitButton = ({
 
   useEffect(() => {
     const targetDiv = ref.current;
-    if (!targetDiv) return;
+    if (!targetDiv) {
+      return;
+    }
 
     const resizeObserver = new ResizeObserver(entries => {
       for (const entry of entries) {


### PR DESCRIPTION
Enables the [eslint curly](https://eslint.org/docs/latest/rules/curly) rule (force curly braces around control structures), fixes the places that failed the check.

This is more consistent and in-line with the rest of our TypeScript codebases