### PR TITLE
Enable minification for production builds

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,7 +26,7 @@ if (!isBundledBuild) {
 const buildOptions: BuildOptions = {
   target: 'baseline-widely-available',
   emptyOutDir: false,
-  minify: false,
+  minify: true,
   lib: {
     entry: resolve(__dirname, "src/index.ts"),
     name: "click-ui",


### PR DESCRIPTION
Enabling minification reduces bundle size significantly while maintaining full debugging capability through source maps.

Size reductions (what consumers download over network):

📦 STANDARD BUILD
  ES Module:
    Raw:     2,299 KB → 1,714 KB  (25.4% reduction)
    Gzipped:   486 KB →   423 KB  (12.9% reduction)

  UMD Module:
    Raw:     2,425 KB → 1,361 KB  (43.8% reduction)
    Gzipped:   492 KB →   384 KB  (21.9% reduction)

📦 BUNDLED BUILD (with styled-components)
  ES Module:
    Raw:     2,361 KB → 1,767 KB  (25.1% reduction)
    Gzipped:   506 KB →   441 KB  (12.7% reduction)

  UMD Module:
    Raw:     2,487 KB → 1,400 KB  (43.7% reduction)
    Gzipped:   511 KB →   400 KB  (21.8% reduction)

Average: 34.5% reduction (raw), 17.3% reduction (gzipped)

Background:
- minify: false was added in March 2024 (PR #371) to aid debugging
- sourcemap: true was added in July 2024 (PR #644) to improve stack traces
- With source maps enabled, minification no longer affects debugging experience

Benefits:
- Smaller bundle size for faster downloads and better CDN caching
- Source maps still provide full TypeScript source-level debugging
- Follows industry standard (React, Material-UI, etc. all ship minified)
- Browsers load source maps on-demand only when devtools are open

Consumer Impact:
- Consumers download 60-111 KB less per bundle (gzipped)
- No loss of debugging capability - stack traces show original TypeScript
- DevTools display original source code, not minified code