### PR TITLE
Add icon fields to BigStat component

### DIFF
--- a/src/components/BigStat/BigStat.test.tsx
+++ b/src/components/BigStat/BigStat.test.tsx
@@ -112,5 +112,53 @@ describe("BigStat Component", () => {
 
       expect(screen.getByText("Custom Height Title")).toBeDefined();
     });
+
+    it("should render with icon", () => {
+      const { getByTestId } = renderBigStat({
+        title: "Icon Title",
+        label: "Icon Label",
+        iconName: "user",
+      });
+
+      expect(screen.getByText("Icon Title")).toBeDefined();
+      expect(getByTestId("bigstat-icon-wrapper")).toBeDefined();
+    });
+
+    it("should not render icon when iconName is not provided", () => {
+      const { queryByTestId } = renderBigStat({
+        title: "No Icon Title",
+        label: "No Icon Label",
+      });
+
+      expect(queryByTestId("bigstat-icon-wrapper")).toBeNull();
+    });
+
+    it("should render with icon and custom icon size", () => {
+      const { getByTestId } = renderBigStat({
+        title: "Icon Size Title",
+        label: "Icon Size Label",
+        iconName: "database",
+        iconSize: "xl",
+      });
+
+      const iconWrapper = getByTestId("bigstat-icon-wrapper");
+      expect(iconWrapper).toBeDefined();
+      expect(iconWrapper.getAttribute("data-icon-size")).toBe("xl");
+
+      // Verify the Icon component is rendered within the wrapper
+      const iconElement = iconWrapper.querySelector("svg");
+      expect(iconElement).toBeDefined();
+    });
+
+    it("should use default icon size of lg when not specified", () => {
+      const { getByTestId } = renderBigStat({
+        title: "Default Icon Size",
+        label: "Default Size Label",
+        iconName: "user",
+      });
+
+      const iconWrapper = getByTestId("bigstat-icon-wrapper");
+      expect(iconWrapper.getAttribute("data-icon-size")).toBe("lg");
+    });
   });
 });

--- a/src/components/BigStat/BigStat.tsx
+++ b/src/components/BigStat/BigStat.tsx
@@ -63,7 +63,10 @@ export const BigStat = ({
   >
     <ContentWrapper>
       {iconName && (
-        <IconWrapper>
+        <IconWrapper
+          data-testid="bigstat-icon-wrapper"
+          data-icon-size={iconSize}
+        >
           <Icon
             name={iconName}
             size={iconSize}


### PR DESCRIPTION
This PR adds icon name and icon size fields to the BigStat component to better illustrate a stat. 
<br></br>
<img width="637" height="541" alt="Screenshot 2026-01-06 at 11 35 41 PM" src="https://github.com/user-attachments/assets/59aa40f8-76b2-4407-83f2-623086480ba0" />
