### PR TITLE
Add version bump option to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Release tag'
+        description: 'Release tag (version like 0.0.246 or prerelease name like beta/alpha/rc)'
         required: true
         type: string
       branch:
@@ -13,157 +13,97 @@ on:
         required: false
         default: 'main'
         type: string
-      version_bump:
-        description: 'Version bump type (none, patch, minor, major)'
-        required: false
-        default: 'none'
-        type: choice
-        options:
-          - none
-          - patch
-          - minor
-          - major
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: write      # For git push and tagging
-      id-token: write      # For OIDC trusted publishing to npm
+      contents: write
+      id-token: write
     steps:
-      - name: Set tag from input (manual trigger)
-        if: github.event_name == 'workflow_dispatch'
+      - name: Set tag and version type
         run: |
-          echo "GITHUB_TAG=${{ github.event.inputs.tag }}" >> "$GITHUB_ENV"
-          # Check if input is a semantic version (e.g., 0.0.242) or a tag name (e.g., beta, scss-deprecation)
-          if [[ "${{ github.event.inputs.tag }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
-            echo "IS_VERSION_INPUT=true" >> "$GITHUB_ENV"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ github.event.inputs.tag }}"
+            REF="${{ github.event.inputs.branch }}"
           else
-            echo "IS_VERSION_INPUT=false" >> "$GITHUB_ENV"
+            TAG="${GITHUB_REF#refs/tags/}"
+            REF="${{ github.event.release.target_commitish }}"
           fi
-      - name: Set tag from release (automatic trigger)
-        if: github.event_name == 'release'
+          echo "GITHUB_TAG=$TAG" >> "$GITHUB_ENV"
+          echo "CHECKOUT_REF=$REF" >> "$GITHUB_ENV"
+          [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]] && echo "IS_VERSION_INPUT=true" >> "$GITHUB_ENV" || echo "IS_VERSION_INPUT=false" >> "$GITHUB_ENV"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.CHECKOUT_REF }}
+          token: ${{ secrets.PAT_TOKEN }}
+          fetch-depth: 0
+
+      - name: Set package version
         run: |
-          echo "GITHUB_TAG=${GITHUB_REF#refs/tags/}" >> "$GITHUB_ENV"
-          echo "IS_VERSION_INPUT=true" >> "$GITHUB_ENV"
-      - name: Checkout repository (manual trigger)
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v4
+          if [[ "$IS_VERSION_INPUT" == "true" ]]; then
+            npm pkg set version=$GITHUB_TAG
+          else
+            LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+            IFS='.' read -r MAJOR MINOR PATCH <<< "${LAST_TAG#v}"
+            BASE_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
+
+            LATEST_VERSION=$(npm view @clickhouse/click-ui@${GITHUB_TAG} version 2>/dev/null || echo "")
+            if [ -z "$LATEST_VERSION" ]; then
+              PRERELEASE_NUM=0
+            else
+              # Extract base version from latest prerelease
+              LATEST_BASE=$(echo "$LATEST_VERSION" | grep -oE "^[0-9]+\.[0-9]+\.[0-9]+" || echo "")
+
+              # If base version changed, reset to 0, otherwise increment
+              if [[ "$LATEST_BASE" == "$BASE_VERSION" ]]; then
+                PRERELEASE_NUM=$(echo "$LATEST_VERSION" | grep -oE "\.[0-9]+$" | sed 's/\.//')
+                PRERELEASE_NUM=$((PRERELEASE_NUM + 1))
+              else
+                PRERELEASE_NUM=0
+              fi
+            fi
+
+            NEW_VERSION="${BASE_VERSION}-${GITHUB_TAG}.${PRERELEASE_NUM}"
+            echo "Version: $NEW_VERSION"
+            npm pkg set version=$NEW_VERSION --no-git-tag-version
+          fi
+
+      - uses: actions/setup-node@v4
         with:
-          ref: ${{ github.event.inputs.branch }}
-          token: ${{secrets.PAT_TOKEN}}
-          fetch-depth: 0
-      - name: Checkout repository (automatic release)
-        if: github.event_name == 'release'
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.release.target_commitish }}
-          token: ${{secrets.PAT_TOKEN}}
-          fetch-depth: 0
-      - name: Set up Git
+          node-version: '22.x'
+
+      - name: Setup dependencies
+        run: |
+          corepack enable
+          yarn install --immutable
+
+      - run: yarn test
+      - run: yarn build
+
+      - name: Publish to npm
+        run: |
+          [[ "$IS_VERSION_INPUT" == "false" || "$GITHUB_TAG" =~ (beta|alpha|rc) ]] && NPM_TAG="$GITHUB_TAG" || NPM_TAG="latest"
+          npm publish --access public --tag $NPM_TAG --provenance
+
+      - name: Commit and tag version
+        if: ${{ env.IS_VERSION_INPUT == 'true' }}
         run: |
           git config user.email "actions@clickhouse.com"
           git config user.name "GitHub Actions"
-      - name: Bump package version (for version inputs)
-        if: ${{ env.IS_VERSION_INPUT == 'true' }}
-        run: |
-          npm pkg set version=$GITHUB_TAG
-      - name: Generate prerelease version (for tag inputs)
-        if: ${{ env.IS_VERSION_INPUT == 'false' }}
-        run: |
-          # Get current version from package.json
-          CURRENT_VERSION=$(node -p "require('./package.json').version")
-          # Extract base version (remove any existing prerelease suffix)
-          BASE_VERSION=$(echo $CURRENT_VERSION | cut -d'-' -f1)
-
-          # Apply version bump if requested
-          BUMP_TYPE="${{ github.event.inputs.version_bump || 'none' }}"
-          if [ "$BUMP_TYPE" != "none" ]; then
-            echo "Applying $BUMP_TYPE version bump to $BASE_VERSION"
-
-            # Split version into major.minor.patch
-            IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
-
-            case "$BUMP_TYPE" in
-              patch)
-                PATCH=$((PATCH + 1))
-                ;;
-              minor)
-                MINOR=$((MINOR + 1))
-                PATCH=0
-                ;;
-              major)
-                MAJOR=$((MAJOR + 1))
-                MINOR=0
-                PATCH=0
-                ;;
-            esac
-
-            BASE_VERSION="${MAJOR}.${MINOR}.${PATCH}"
-            echo "New base version after bump: $BASE_VERSION"
-          fi
-
-          # Find the next available prerelease number
-          PRERELEASE_NUM=0
-          while true; do
-            TEST_VERSION="${BASE_VERSION}-${GITHUB_TAG}.${PRERELEASE_NUM}"
-
-            # Check if this version exists on npm
-            if npm view @clickhouse/click-ui@${TEST_VERSION} version 2>/dev/null; then
-              echo "Version ${TEST_VERSION} already exists, trying next number..."
-              PRERELEASE_NUM=$((PRERELEASE_NUM + 1))
-            else
-              # Version doesn't exist, we can use it
-              NEW_VERSION="${TEST_VERSION}"
-              break
-            fi
-
-            # Safety limit to prevent infinite loops
-            if [ $PRERELEASE_NUM -gt 100 ]; then
-              echo "Error: Too many prerelease versions (>100)"
-              exit 1
-            fi
-          done
-
-          echo "Generated prerelease version: $NEW_VERSION"
-          npm pkg set version=$NEW_VERSION --no-git-tag-version
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22.x'  # Node 22 includes npm >= 11.5.1 with OIDC support
-      - name: Upgrade npm for OIDC support
-        run: |
-          npm install -g npm@latest
-          echo "npm version: $(npm --version)"
-      - name: Enable Corepack
-        run: corepack enable
-      - name: Install dependencies
-        run: yarn install --immutable
-      - run: yarn test
-      - run: yarn build
-      - name: Determine npm tag
-        run: |
-          # If it's a version input (e.g., 0.0.242 or 0.0.242-beta.1), check for prerelease keywords
-          if [[ "$IS_VERSION_INPUT" == "true" ]]; then
-            if [[ "$GITHUB_TAG" == *"beta"* ]] || [[ "$GITHUB_TAG" == *"alpha"* ]] || [[ "$GITHUB_TAG" == *"rc"* ]]; then
-              echo "NPM_TAG=beta" >> "$GITHUB_ENV"
-            else
-              echo "NPM_TAG=latest" >> "$GITHUB_ENV"
-            fi
-          else
-            # If it's a tag name input (e.g., scss-deprecation), use it as the npm tag
-            echo "NPM_TAG=$GITHUB_TAG" >> "$GITHUB_ENV"
-          fi
-      - name: Publish to npm with OIDC
-        run: npm publish --access public --tag $NPM_TAG --provenance
-      - name: update package version (for version inputs only)
-        if: ${{ env.IS_VERSION_INPUT == 'true' }}
-        run: |
           git add package.json yarn.lock
-          git commit -m 'bump version to ${{ env.GITHUB_TAG }}'
+          git commit -m "bump version to $GITHUB_TAG"
           git push
-      - name: Create and push git tag (for version inputs only)
-        if: ${{ github.event_name == 'workflow_dispatch' && env.IS_VERSION_INPUT == 'true' }}
+          [[ "${{ github.event_name }}" == "workflow_dispatch" ]] && git tag $GITHUB_TAG && git push origin $GITHUB_TAG || true
+
+      - name: Cleanup failed release
+        if: ${{ failure() && github.event_name == 'release' }}
         run: |
-          git tag $GITHUB_TAG
-          git push origin $GITHUB_TAG
+          echo "::warning::Build failed for release ${{ env.GITHUB_TAG }}"
+          echo "Cleaning up release and tag..."
+          gh release delete ${{ env.GITHUB_TAG }} --yes --cleanup-tag || true
+          echo "::notice::Release deleted. Fix the issue and create a new release."
+        env:
+          GH_TOKEN: ${{ github.token }}
 
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,16 @@ on:
         required: false
         default: 'main'
         type: string
+      version_bump:
+        description: 'Version bump type (none, patch, minor, major)'
+        required: false
+        default: 'none'
+        type: choice
+        options:
+          - none
+          - patch
+          - minor
+          - major
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -64,8 +74,56 @@ jobs:
           CURRENT_VERSION=$(node -p "require('./package.json').version")
           # Extract base version (remove any existing prerelease suffix)
           BASE_VERSION=$(echo $CURRENT_VERSION | cut -d'-' -f1)
-          # Generate prerelease version: base-tagname.0
-          NEW_VERSION="${BASE_VERSION}-${GITHUB_TAG}.0"
+
+          # Apply version bump if requested
+          BUMP_TYPE="${{ github.event.inputs.version_bump || 'none' }}"
+          if [ "$BUMP_TYPE" != "none" ]; then
+            echo "Applying $BUMP_TYPE version bump to $BASE_VERSION"
+
+            # Split version into major.minor.patch
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
+
+            case "$BUMP_TYPE" in
+              patch)
+                PATCH=$((PATCH + 1))
+                ;;
+              minor)
+                MINOR=$((MINOR + 1))
+                PATCH=0
+                ;;
+              major)
+                MAJOR=$((MAJOR + 1))
+                MINOR=0
+                PATCH=0
+                ;;
+            esac
+
+            BASE_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+            echo "New base version after bump: $BASE_VERSION"
+          fi
+
+          # Find the next available prerelease number
+          PRERELEASE_NUM=0
+          while true; do
+            TEST_VERSION="${BASE_VERSION}-${GITHUB_TAG}.${PRERELEASE_NUM}"
+
+            # Check if this version exists on npm
+            if npm view @clickhouse/click-ui@${TEST_VERSION} version 2>/dev/null; then
+              echo "Version ${TEST_VERSION} already exists, trying next number..."
+              PRERELEASE_NUM=$((PRERELEASE_NUM + 1))
+            else
+              # Version doesn't exist, we can use it
+              NEW_VERSION="${TEST_VERSION}"
+              break
+            fi
+
+            # Safety limit to prevent infinite loops
+            if [ $PRERELEASE_NUM -gt 100 ]; then
+              echo "Error: Too many prerelease versions (>100)"
+              exit 1
+            fi
+          done
+
           echo "Generated prerelease version: $NEW_VERSION"
           npm pkg set version=$NEW_VERSION --no-git-tag-version
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Introduces a 'version_bump' input to the publish GitHub Actions workflow, allowing selection of patch, minor, or major version increments before prerelease generation. The script now applies the specified version bump to the base version before determining the next available prerelease version.

There was also an issue with publishing the same beta version on the same version, so added a fix to move the count up so it won't break