### PR TITLE
fix: 🐛 handle uncaught error in confirmation dialog test run

### DIFF
--- a/src/components/ConfirmationDialog/ConfirmationDialog.test.tsx
+++ b/src/components/ConfirmationDialog/ConfirmationDialog.test.tsx
@@ -125,7 +125,7 @@ describe("Dialog Component", () => {
   it("fails to render in case you provide both children and message props", () => {
     const children = <div>test</div>;
     const message = "this is a test message";
-    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     expect(() => renderDialog({ children, message, open: true })).toThrowError(
       "You can't pass children and message props at the same time"


### PR DESCRIPTION
## Why?

There's an uncaught error in the confirmation dialog, which is present in the test runner. The exception is asserted/expected, but the output is noisy and causes confusion, e.g. "error: Uncaught [Error: You can't pass children and message props at the same time]  at reportException".

## How?

- Uses a spy
- Mocks the implementation
- Outputs blank

## Preview?

> Before

> Before

```js
 ❯ node_modules/@testing-library/dom/dist/query-helpers.js:52:17
 ❯ getByText node_modules/@testing-library/dom/dist/query-helpers.js:95:19
 ❯ src/components/DateDetails/DateDetails.test.tsx:125:7
    123|     fireEvent.click(trigger);
    124|     expect(
    125|       getByText(content => {
       |       ^
    126|         return content.includes("EDT");
    127|       })

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[4/4]⎯

 Test Files  1 failed | 53 passed (54)
      Tests  4 failed | 304 passed (308)
   Start at  11:39:04
   Duration  14.04s (transform 3.43s, setup 4.78s, collect 104.99s, tests


click-ui on 🌱 fix/missing-forward-refs [🗑📝🤷] is  v0.0.250 via  v23.9.
❯ git push origin fix/missing-forward-refs
Enumerating objects: 13, done.
Counting objects: 100% (13/13), done.
Delta compression using up to 12 threads
Compressing objects: 100% (7/7), done.
Writing objects: 100% (7/7), 606 bytes | 606.00 KiB/s, done.
Total 7 (delta 6), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (6/6), completed with 6 local objects.
remote:
remote: Create a pull request for 'fix/missing-forward-refs' on GitHub by
remote:      https://github.com/ClickHouse/click-ui/pull/new/fix/missing-f
remote:
remote: GitHub found 12 vulnerabilities on ClickHouse/click-ui's default b
remote:      https://github.com/ClickHouse/click-ui/security/dependabot
remote:
To github.com:ClickHouse/click-ui.git
 * [new branch]        fix/missing-forward-refs -> fix/missing-forward-ref

click-ui on 🌱 fix/missing-forward-refs [🗑📝🤷] is  v0.0.250 via  v23.9.
❯

click-ui on 🌱 fix/missing-forward-refs [🗑📝🤷] is  v0.0.250 via  v23.9.
❯ git checkout -b fix/missing-forward-refs

click-ui on 🌱 fix/missing-forward-refs [🗑📝🤷] is  v0.0.250 via  v23.9.
❯ yarn test src/components/ConfirmationDialog/ConfirmationDialog.test.tsx
 RUN  v2.1.9 /Users/punkbit/www/punkbit/clickhouse/click-ui

 ✓ src/components/ConfirmationDialog/ConfirmationDialog.test.tsx (11)
   ✓ Dialog Component (11)
     ✓ renders the dialog title
     ✓ doesn't render the dialog title when the open prop is false
     ✓ renders the dialog message
     ✓ renders the dialog primary action label
     ✓ closes the dialog on primary action click
     ✓ executes the primary action on primary action click
     ✓ renders the dialog secondary action label
     ✓ closes the dialog on secondary action click
     ✓ fails to render in case you provide both children and message props
     ✓ focuses the confirm button when dialog opens
     ✓ does not focus when dialog is closed

 Test Files  1 passed (1)
      Tests  11 passed (11)
   Start at  11:52:25
   Duration  3.38s (transform 1.52s, setup 178ms, collect 2.61s, tests 133


click-ui on 🌱 fix/missing-forward-refs [🗑📝🤷] is  v0.0.250 via  v23.9.
❯ yarn test src/components/ConfirmationDialog/ConfirmationDialog.test.tsx

 RUN  v2.1.9 /Users/punkbit/www/punkbit/clickhouse/click-ui

stderr | src/components/ConfirmationDialog/ConfirmationDialog.test.tsx > D
ialog Component > fails to render in case you provide both children and me
ssage props
Error: Uncaught [Error: You can't pass children and message props at the s
ame time]
    at reportException (/Users/punkbit/www/punkbit/clickhouse/click-ui/nod
e_modules/jsdom/lib/jsdom/living/helpers/runtime-script-errors.js:66:24)
    at innerInvokeEventListeners (/Users/punkbit/www/punkbit/clickhouse/cl
ick-ui/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:353:
9)
    at invokeEventListeners (/Users/punkbit/www/punkbit/clickhouse/click-u
i/node_modules/jsdom/lib/jsdom/living/events/EventTarget-impl.js:286:3)
    at HTMLUnknownElementImpl._dispatch (/Users/punkbit/www/punkbit/clickh
    at HTMLUnknownElementImpl.dispatchEvent (/Users/punkbit/www/punkbit/cl
    at HTMLUnknownElement.dispatchEvent (/Users/punkbit/www/punkbit/clickh
    at Object.invokeGuardedCallbackDev (/Users/punkbit/www/punkbit/clickho
    at invokeGuardedCallback (/Users/punkbit/www/punkbit/clickhouse/click-
    at beginWork$1 (/Users/punkbit/www/punkbit/clickhouse/click-ui/node_mo
    at performUnitOfWork (/Users/punkbit/www/punkbit/clickhouse/click-ui/n
    at ConfirmationDialog (/Users/punkbit/www/punkbit/clickhouse/click-ui/
    at renderWithHooks (/Users/punkbit/www/punkbit/clickhouse/click-ui/nod
    at mountIndeterminateComponent (/Users/punkbit/www/punkbit/clickhouse/
    at beginWork (/Users/punkbit/www/punkbit/clickhouse/click-ui/node_modu
    at HTMLUnknownElement.callCallback (/Users/punkbit/www/punkbit/clickho
    at HTMLUnknownElement.callTheUserObjectsOperation (/Users/punkbit/www/
    at innerInvokeEventListeners (/Users/punkbit/www/punkbit/clickhouse/cl
    at invokeEventListeners (/Users/punkbit/www/punkbit/clickhouse/click-u
    at HTMLUnknownElementImpl._dispatch (/Users/punkbit/www/punkbit/clickh
    at HTMLUnknownElementImpl.dispatchEvent (/Users/punkbit/www/punkbit/cl
Error: Uncaught [Error: You can't pass children and message props at the s
    at reportException (/Users/punkbit/www/punkbit/clickhouse/click-ui/nod
    at innerInvokeEventListeners (/Users/punkbit/www/punkbit/clickhouse/cl
    at invokeEventListeners (/Users/punkbit/www/punkbit/clickhouse/click-u
    at HTMLUnknownElementImpl._dispatch (/Users/punkbit/www/punkbit/clickh
    at HTMLUnknownElementImpl.dispatchEvent (/Users/punkbit/www/punkbit/cl
    at HTMLUnknownElement.dispatchEvent (/Users/punkbit/www/punkbit/clickh
    at Object.invokeGuardedCallbackDev (/Users/punkbit/www/punkbit/clickho
    at invokeGuardedCallback (/Users/punkbit/www/punkbit/clickhouse/click-
    at beginWork$1 (/Users/punkbit/www/punkbit/clickhouse/click-ui/node_mo
    at performUnitOfWork (/Users/punkbit/www/punkbit/clickhouse/click-ui/n
    at ConfirmationDialog (/Users/punkbit/www/punkbit/clickhouse/click-ui/
    at renderWithHooks (/Users/punkbit/www/punkbit/clickhouse/click-ui/nod
    at mountIndeterminateComponent (/Users/punkbit/www/punkbit/clickhouse/
    at beginWork (/Users/punkbit/www/punkbit/clickhouse/click-ui/node_modu
    at HTMLUnknownElement.callCallback (/Users/punkbit/www/punkbit/clickho
    at HTMLUnknownElement.callTheUserObjectsOperation (/Users/punkbit/www/
    at innerInvokeEventListeners (/Users/punkbit/www/punkbit/clickhouse/cl
    at invokeEventListeners (/Users/punkbit/www/punkbit/clickhouse/click-u
    at HTMLUnknownElementImpl._dispatch (/Users/punkbit/www/punkbit/clickh
    at HTMLUnknownElementImpl.dispatchEvent (/Users/punkbit/www/punkbit/cl
The above error occurred in the <ConfirmationDialog> component:

    at ConfirmationDialog (/Users/punkbit/www/punkbit/clickhouse/click-ui/
    at Provider (file:///Users/punkbit/www/punkbit/clickhouse/click-ui/nod
    at $a093c7e1ec25a057$export$f78649fb9ca566b8 (file:///Users/punkbit/ww
    at Provider (file:///Users/punkbit/www/punkbit/clickhouse/click-ui/nod
    at Provider (file:///Users/punkbit/www/punkbit/clickhouse/click-ui/nod
    at CollectionProvider (file:///Users/punkbit/www/punkbit/clickhouse/cl
    at $054eb8030ebde76e$export$f5d03d415824e0e (file:///Users/punkbit/www
    at ToastProvider (/Users/punkbit/www/punkbit/clickhouse/click-ui/src/c
    at exports.ThemeProvider (/Users/punkbit/www/punkbit/clickhouse/click-
    at ThemeProvider (/Users/punkbit/www/punkbit/clickhouse/click-ui/src/t
    at ClickUIProvider (/Users/punkbit/www/punkbit/clickhouse/click-ui/src
    at Wrapper (/Users/punkbit/www/punkbit/clickhouse/click-ui/src/utils/test-utils.tsx:8:3)

Consider adding an error boundary to your tree to customize error handling behavior.
Visit https://reactjs.org/link/error-boundaries to learn more about error boundaries.
```

