### PR TITLE
chore: 🤖 add middle truncator storybook story

### DIFF
--- a/src/components/FileUpload/FileUpload.tsx
+++ b/src/components/FileUpload/FileUpload.tsx
@@ -2,10 +2,10 @@ import React, { useEffect } from 'react';
 import { styled, css } from 'styled-components';
 import { useState, useRef, useCallback } from 'react';
 
-import { Text } from "@/components/Typography/Text/Text";
-import { Title } from "@/components/Typography/Title/Title";
-import { Button, Icon, IconButton, ProgressBar, Container } from "@/components";
-import { MiddleTruncator } from "../MiddleTruncator";
+import { Text } from '@/components/Typography/Text/Text';
+import { Title } from '@/components/Typography/Title/Title';
+import { Button, Icon, IconButton, ProgressBar, Container } from '@/components';
+import { MiddleTruncator } from '../MiddleTruncator';
 
 interface FileInfo {
   name: string;

--- a/src/components/MiddleTruncator/MiddleTruncator.stories.tsx
+++ b/src/components/MiddleTruncator/MiddleTruncator.stories.tsx
@@ -1,5 +1,5 @@
-import { Meta, StoryObj } from "@storybook/react-vite";
-import { MiddleTruncator } from "./index";
+import { Meta, StoryObj } from '@storybook/react-vite';
+import { MiddleTruncator } from './index';
 
 type StoryArgs = React.ComponentProps<typeof MiddleTruncator> & {
   containerWidth: number;
@@ -7,17 +7,17 @@ type StoryArgs = React.ComponentProps<typeof MiddleTruncator> & {
 
 const meta: Meta<StoryArgs> = {
   component: MiddleTruncator,
-  title: "Display/MiddleTruncator",
-  tags: ["autodocs"],
+  title: 'Display/MiddleTruncator',
+  tags: ['autodocs'],
   argTypes: {
     text: {
-      control: { type: "text" },
+      control: { type: 'text' },
     },
     trailingChars: {
-      control: { type: "number" },
+      control: { type: 'number' },
     },
     containerWidth: {
-      control: { type: "range", min: 0, max: 100, step: 1 },
+      control: { type: 'range', min: 0, max: 100, step: 1 },
     },
   },
 };
@@ -28,7 +28,7 @@ type Story = StoryObj<StoryArgs>;
 
 export const Playground: Story = {
   args: {
-    text: "console.clickhouse.cloud_Archive.01-01-1975.lorem-ipsum-a-very-long-filename-01.csv",
+    text: 'console.clickhouse.cloud_Archive.01-01-1975.lorem-ipsum-a-very-long-filename-01.csv',
     trailingChars: 10,
     containerWidth: 20,
   },

--- a/src/components/MiddleTruncator/index.tsx
+++ b/src/components/MiddleTruncator/index.tsx
@@ -1,4 +1,4 @@
-import { styled } from "styled-components";
+import { styled } from 'styled-components';
 
 const TruncatorContainer = styled.div`
   display: flex;


### PR DESCRIPTION
## Why?

To include a story for the new component MiddleTruncator, as seen in FileUpload (PR #781)

## How?

- Created a new storybook story
- Add slide controller for responsive manual tests

## Preview?

https://github.com/user-attachments/assets/51f975f8-ffec-4f55-a8ee-983955d7250f

