### PR TITLE
fix: 🐛 middle truncator success+upload text position

### DIFF
--- a/src/components/MiddleTruncator/index.tsx
+++ b/src/components/MiddleTruncator/index.tsx
@@ -2,7 +2,7 @@ import { styled } from 'styled-components';
 
 const TruncatorContainer = styled.div`
   display: flex;
-  width: 100%;
+  width: auto;
   min-width: 0;
   overflow: hidden;
   white-space: nowrap;


### PR DESCRIPTION
## Why?

The success icon is pushed to the right due to the middle truncator container getting 100% width.

## How?

- Style fix

## Preview?

<img width="841" height="117" alt="Screenshot 2026-01-29 at 19 28 37" src="https://github.com/user-attachments/assets/04201676-7018-4711-b70a-9a9fa8190472" />

<img width="841" height="105" alt="Screenshot 2026-01-29 at 19 28 07" src="https://github.com/user-attachments/assets/652494b0-38a0-4091-9bc1-19b4146ac74b" />
