### PR TITLE
fix: 🐛 file upload in flyout size

### DIFF
--- a/src/components/FileUpload/FileUpload.tsx
+++ b/src/components/FileUpload/FileUpload.tsx
@@ -45,7 +45,7 @@ const UploadArea = styled.div<{
 }>`
   container-type: inline-size;
   container-name: uploadArea;
-  box-sizing:  border-box;
+  box-sizing: border-box;
   width: 100%;
   background-color: ${({ theme }) => theme.click.fileUpload.color.background.default};
   border: ${({ theme }) => `1px solid ${theme.click.fileUpload.color.stroke.default}`};


### PR DESCRIPTION
## Why?

After introducing latest changes, the file upload looks broken when nested in a flyout.

<img width="852" height="301" alt="Screenshot 2026-01-30 at 11 19 53" src="https://github.com/user-attachments/assets/7247aa51-42df-4d41-96dd-37ef88e1e90e" />


## How?

- Use border-box box-sizing for a 100% width

## Preview?


https://github.com/user-attachments/assets/c431115a-8052-4790-8657-f56f1e4ef251

