### PR TITLE
refactor: 💡 set table cell wrapping to default to truncated (ellipsis)

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -787,7 +787,7 @@ const TextWrapped = styled.span`
 
 const Cell = ({
   label,
-  overflowMode,
+  overflowMode = 'truncated',
 }: {
   label: ReactNode;
   overflowMode?: OverflowMode;


### PR DESCRIPTION
## Why?

Set table cell wrapping to default to truncated (ellipsis)

## How?

- Modify Cell fallback to ellipsis

## Preview?

<img width="885" height="350" alt="Screenshot 2026-02-03 at 09 33 57" src="https://github.com/user-attachments/assets/d7f85688-b1c6-401f-9a55-648c38570559" />