### PR TITLE
chore: 🤖 add select text+icon storybook story (cloud provider)

### DIFF
--- a/src/components/Select/SingleSelect.stories.tsx
+++ b/src/components/Select/SingleSelect.stories.tsx
@@ -22,13 +22,22 @@ export const CloudProvider: StoryObj<typeof Select> = {
   },
   render: props => (
     <Select {...props}>
-      <Select.Item value="aws" icon="aws">
+      <Select.Item
+        value="aws"
+        icon="aws"
+      >
         AWS
       </Select.Item>
-      <Select.Item value="gcp" icon="gcp">
+      <Select.Item
+        value="gcp"
+        icon="gcp"
+      >
         GCP
       </Select.Item>
-      <Select.Item value="azure" icon="azure">
+      <Select.Item
+        value="azure"
+        icon="azure"
+      >
         Azure
       </Select.Item>
     </Select>


### PR DESCRIPTION
## Why?

To provide a story/playground for a Select with text + icon. Here, it's provided as a Cloud provider Select component story. 

## How?

- Added new story for Select

## Tickets?

- [CUI-90](https://linear.app/clickhouse/issue/CUI-90/select-selectitem-with-an-icon-prefix-breaks-at-smaller-screen-sizes)

## Preview?

<img width="784" height="272" alt="Screenshot 2026-02-03 at 11 41 20" src="https://github.com/user-attachments/assets/58b85594-98b9-42f9-bb35-2761763a2618" />
