### PR TITLE
chore: 🤖 enable corepack in github workflow for changeset

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -22,14 +22,17 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: '23.x'
+
+      - name: Enable Corepack
+        run: corepack enable
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/release-publisher.yml
+++ b/.github/workflows/release-publisher.yml
@@ -79,7 +79,7 @@ jobs:
         if: steps.verify-merge.outputs.is_release == 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: 23
+          node-version: '23.x'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Upgrade npm for OIDC support


### PR DESCRIPTION
## Why?

Have to enable corepack due to yarn >= v4 requirements.

## How?

- Update github workflows for changeset

## Preview?

N/A