### PR TITLE
chore: 🤖 triggers the release publisher process only on merge

### DIFF
--- a/.github/workflows/release-publisher.yml
+++ b/.github/workflows/release-publisher.yml
@@ -1,7 +1,8 @@
 name: 🚀 Release Publisher (NPM)
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
       - '**'
 
@@ -27,11 +28,11 @@ jobs:
         id: verify-merge
         run: |
           COMMIT_SHA="${{ github.sha }}"
-          
+
           echo "🔍 Checking if commit $COMMIT_SHA is from a release PR merge..."
-          
+
           COMMIT_MSG=$(git log -1 --format=%s "$COMMIT_SHA")
-          
+
           # WARNING: This is coupled with generate release commit
           # if you need to modify, apply the changes accordingly
           # Script outputs "VERSION RELEASE_TYPE" on success (e.g., "1.2.3 latest")
@@ -82,19 +83,19 @@ jobs:
         if: steps.verify-merge.outputs.is_release == 'true'
         run: |
           TAG="${{ steps.verify-merge.outputs.tag }}"
-          
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          
+
           # Check if tag already exists
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "⚠️ Tag $TAG already exists. Skipping tag creation."
             exit 0
           fi
-          
+
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"
-          
+
           echo "✅ Created and pushed tag $TAG"
 
       - name: Setup Node.js


### PR DESCRIPTION
## Why?

To trigger the release publisher process only on merge, while allowing support for workflow expected branch release formats, e.g. chore/v*, main, but also custom branches.

## How?

- Modify the release publisher on pull request

## Preview?

### Before

<img width="881" height="351" alt="Screenshot 2026-02-24 at 16 43 16" src="https://github.com/user-attachments/assets/ba3cedde-a3e1-4133-ab57-5df5ff2810e9" />

### After

<img width="882" height="440" alt="Screenshot 2026-02-24 at 16 43 47" src="https://github.com/user-attachments/assets/eae9b5f9-7727-4a56-b363-f16a3b10a62d" />
