### PR TITLE
chore: 🤖 automated Slack notifications on new version release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -283,14 +283,6 @@ jobs:
 
             **Tag:** `v${{ steps.version-package.outputs.version }}` will be included in this PR
 
-      - name: Join Slack channel
-        if: ${{ steps.create-pr.outputs.pull-request-url }}
-        run: |
-          curl -s -X POST https://slack.com/api/conversations.join \
-            -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d '{"channel": "${{ secrets.SLACK_CHANNEL }}"}'
-
       - name: Notify Slack about release PR
         if: ${{ steps.create-pr.outputs.pull-request-url }}
         uses: slackapi/slack-github-action@v2.1.1

--- a/.github/workflows/release-publisher.yml
+++ b/.github/workflows/release-publisher.yml
@@ -244,14 +244,6 @@ jobs:
             echo "✅ Created maintenance branch '$MAINTENANCE_BRANCH'"
           fi
 
-      - name: Join Slack channel
-        if: steps.verify-merge.outputs.is_release == 'true'
-        run: |
-          curl -s -X POST https://slack.com/api/conversations.join \
-            -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d '{"channel": "${{ secrets.SLACK_CHANNEL }}"}'
-
       - name: Notify Slack about new release
         if: steps.verify-merge.outputs.is_release == 'true'
         uses: slackapi/slack-github-action@v2.1.1


### PR DESCRIPTION
## Why?

This adds Slack notifications to alert consumers whenever a new version is released. By surfacing changes, features, tweaks, bug fixes, and security patches to the right channel early, we can collect feedback as soon as possible! It'll also help promote and incentivise adoption of new versions.

⚠️ WARNING: Requires admin support

- Create new Slack Bot App https://api.slack.com/apps/
- In the left side menu go to "OAuth & Permissions"
- Copy "OAuth Tokens" and create a new gh secret, e.g. SLACK_BOT_TOKEN (corresponding to PR)
- Add sufficient permissions scope: OAuth Scope -> channels:join + chat:write

## How?

- Add notification to create and publish workflows

## Preview?

### On new release PR

<img width="1210" height="378" alt="Screenshot 2026-02-25 at 18 02 49" src="https://github.com/user-attachments/assets/62cc8c83-8c46-4c52-8375-8a99f9e23da0" />

### On new package version published

<img width="1193" height="160" alt="Screenshot 2026-02-25 at 18 02 25" src="https://github.com/user-attachments/assets/5121bd5a-6c93-45c2-8003-1ef0ff5fcb9b" />
