### PR TITLE
feat(DateRangePicker): allow opening custom date range on left

### DIFF
--- a/.changeset/warm-jokes-cross.md
+++ b/.changeset/warm-jokes-cross.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': minor
+---
+
+Allows setting an open direction on DateRangePicker

--- a/src/components/DatePicker/DateRangePicker.stories.tsx
+++ b/src/components/DatePicker/DateRangePicker.stories.tsx
@@ -42,6 +42,36 @@ export const Default: Story = {
   },
 };
 
+export const DateRangePickerLeftSide: Story = {
+  args: {
+    predefinedDatesList: [],
+  },
+  render: (args: Args) => {
+    const endDate = args.endDate ? new Date(args.endDate) : undefined;
+    const startDate = args.startDate ? new Date(args.startDate) : undefined;
+
+    const predefinedDatesList = getPredefinedMonthsForDateRangePicker(-6);
+
+    return (
+      <div style={{ alignItems: 'end', float: 'right' }}>
+        <DateRangePicker
+          key="default"
+          endDate={endDate}
+          disabled={args.disabled}
+          futureDatesDisabled={args.futureDatesDisabled}
+          futureStartDatesDisabled={args.futureStartDatesDisabled}
+          maxRangeLength={args.maxRangeLength}
+          onSelectDateRange={args.onSelectDateRange}
+          openDirection="left"
+          placeholder={args.placeholder}
+          predefinedDatesList={predefinedDatesList}
+          startDate={startDate}
+        />
+      </div>
+    );
+  },
+};
+
 export const DateRangeWithMaxRange: Story = {
   args: {
     maxRangeLength: 15,

--- a/src/components/DatePicker/DateRangePicker.tsx
+++ b/src/components/DatePicker/DateRangePicker.tsx
@@ -4,6 +4,8 @@ import {
   SetStateAction,
   useCallback,
   useEffect,
+  useLayoutEffect,
+  useRef,
   useState,
 } from 'react';
 import { isSameDate, UseCalendarOptions } from '@h6s/calendar';
@@ -20,24 +22,28 @@ import {
   selectedDateFormatter,
 } from './utils';
 
+type OpenDirection = 'left' | 'right';
+
+const calendarWidth = 275;
+
 const PredefinedCalendarContainer = styled(Panel)`
   align-items: start;
   background: ${({ theme }) => theme.click.panel.color.background.muted};
 `;
 
 const PredefinedDatesContainer = styled(Container)`
-  width: 275px;
+  width: ${calendarWidth}px;
 `;
 
 // left value of 276px is the width of the PredefinedDatesContainer + 1 pixel for border
-const CalendarRendererContainer = styled.div`
+const CalendarRendererContainer = styled.div<{ $openDirection?: OpenDirection }>`
   border: ${({ theme }) =>
     `${theme.click.datePicker.dateOption.stroke} solid ${theme.click.datePicker.dateOption.color.background.range}`};
   border-radius: ${({ theme }) => theme.click.datePicker.dateOption.radii.default};
   box-shadow:
     lch(6.77 0 0 / 0.15) 4px 4px 6px -1px,
     lch(6.77 0 0 / 0.15) 2px 2px 4px -1px;
-  left: 276px;
+  ${({ $openDirection }) => ($openDirection === 'left' ? 'right: 100%;' : 'left: 276px;')}
   position: absolute;
   top: 0;
 `;
@@ -281,6 +287,7 @@ export interface DateRangePickerProps {
   futureDatesDisabled?: boolean;
   futureStartDatesDisabled?: boolean;
   onSelectDateRange: (selectedStartDate: Date, selectedEndDate: Date) => void;
+  openDirection?: OpenDirection;
   placeholder?: string;
   predefinedDatesList?: Array<DateRange>;
   maxRangeLength?: number;
@@ -296,6 +303,7 @@ export const DateRangePicker = ({
   futureStartDatesDisabled = false,
   maxRangeLength = -1,
   onSelectDateRange,
+  openDirection = 'right',
   placeholder = 'start date – end date',
   predefinedDatesList,
   responsivePositioning = true,
@@ -304,6 +312,9 @@ export const DateRangePicker = ({
   const [selectedStartDate, setSelectedStartDate] = useState<Date>();
   const [selectedEndDate, setSelectedEndDate] = useState<Date>();
   const [shouldShowCustomRange, setShouldShowCustomRange] = useState<boolean>(false);
+  const [calendarOpenDirection, setCalendarOpenDirection] =
+    useState<OpenDirection>(openDirection);
+  const calendarContainerRef = useRef<HTMLDivElement>(null);
 
   const calendarOptions: UseCalendarOptions = {};
 
@@ -324,16 +335,28 @@ export const DateRangePicker = ({
     }
   }, [endDate]);
 
+  useLayoutEffect(() => {
+    if (shouldShowCustomRange && calendarContainerRef.current) {
+      if (
+        calendarContainerRef.current.getBoundingClientRect().right > window.innerWidth
+      ) {
+        setCalendarOpenDirection('left');
+      }
+    }
+  }, [shouldShowCustomRange]);
+
   const closeDatePicker = useCallback((): void => {
     setIsOpen(false);
     setShouldShowCustomRange(false);
-  }, []);
+    setCalendarOpenDirection(openDirection);
+  }, [openDirection]);
 
   const handleOpenChange = (isOpen: boolean): void => {
     setIsOpen(isOpen);
 
     if (!isOpen) {
       setShouldShowCustomRange(false);
+      setCalendarOpenDirection(openDirection);
     }
   };
 
@@ -419,7 +442,10 @@ export const DateRangePicker = ({
             />
 
             {shouldShowCustomRange && (
-              <CalendarRendererContainer>
+              <CalendarRendererContainer
+                $openDirection={calendarOpenDirection}
+                ref={calendarContainerRef}
+              >
                 <StyledCalendarRenderer
                   calendarOptions={calendarOptions}
                   allowYearMonthSelection={false}


### PR DESCRIPTION
- Creates concept of `openDirection` on `DateRangePicker`
- Allows setting an `openDirection` on `DateRangePicker`
- Automatically sets it to left if there isn't enough space to the right of the picker

<img width="695" height="358" alt="Screenshot 2026-02-25 at 5 04 21 PM" src="https://github.com/user-attachments/assets/3fd1665c-938f-4378-a40f-18768f32c485" />
