### PR TITLE
chore: 🤖 trigger build health check on pull request events

### DIFF
--- a/.github/workflows/build-health-checkup.yml
+++ b/.github/workflows/build-health-checkup.yml
@@ -3,6 +3,9 @@ name: 🏗️ Build Health Checkup
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
+  pull_request:
 
 env:
   HUSKY: 0


### PR DESCRIPTION
## Why?

Adds pull_request as a workflow trigger so the Build Health Checkup job appears in GitHub's branch protection settings and can be set as a required status check.

## How?

- Modify github action "on:" settings

## Preview?

N/A