### PR TITLE
chore: 🤖 on pull request changes for storybook vercel job

### DIFF
--- a/.github/workflows/storybook-vercel.yml
+++ b/.github/workflows/storybook-vercel.yml
@@ -67,7 +67,7 @@ jobs:
           EOF
 
       - name: Deploy to Vercel (Preview)
-        if: github.ref != 'refs/heads/main'
+        if: github.event_name == 'pull_request'
         id: deploy
         run: |
           DEPLOYMENT_URL=$(vercel deploy \
@@ -78,7 +78,7 @@ jobs:
           echo "Preview deployed to: $DEPLOYMENT_URL"
 
       - name: Comment PR with Preview URL
-        if: github.ref != 'refs/heads/main'
+        if: github.event_name == 'pull_request'
         uses: mshick/add-pr-comment@v2
         with:
           message: |
@@ -91,7 +91,7 @@ jobs:
           repo-token: ${{ steps.gh-workflow-token.outputs.token }}
 
       - name: Deploy to Vercel (Production)
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           COMMIT_MSG=$(git log -1 --format=%s)
 


### PR DESCRIPTION
## Why?

Notice that the storybook pull request preview URL comment step fails to update or produce a comment in the context of the pull request after the initial one. Believe this is due to the "on:" initially running on "push".

## How?

- Adds "on: pull_request"
- Determine execution of steps based on branch or pull_request event name

## Preview?

N/A