### PR TITLE
chore: 🤖 adjust pull request message position in Storybook preview refresh

### DIFF
--- a/.github/workflows/storybook-vercel.yml
+++ b/.github/workflows/storybook-vercel.yml
@@ -89,6 +89,7 @@ jobs:
             Built from commit: `${{ github.sha }}`
           message-id: storybook-preview
           repo-token: ${{ steps.gh-workflow-token.outputs.token }}
+          refresh-message-position: true
 
       - name: Deploy to Vercel (Production)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Why?

Adjust the positioning of the pull request message displayed during Storybook preview refresh to ensure it renders in the correct location.

## How?

- Update storybook vercel workflow

## Preview?

### Screenshot from external playground due to ops runtime need

<img width="884" height="800" alt="Screenshot 2026-03-04 at 10 18 22" src="https://github.com/user-attachments/assets/c7b1abcc-9f4e-4a9e-9c1c-b453cc2f76ff" />
