### PR TITLE
fix: 🐛 component rfc template as issue not pull request

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/component_rfc.md
+++ b/.github/PULL_REQUEST_TEMPLATE/component_rfc.md
@@ -1,15 +1,7 @@
----
-name: 🎁 Component RFC
-about: Propose a new component or significant change to an existing one
-title: '[RFC] '
-labels: 'rfc'
-assignees: ''
----
-
 # Component RFC — [Component Name]
 
 > Use this template when proposing a **new component** or a **significant change** to an existing one.
-> Fill in every section and check each box as you go. The checklist acts as the acceptance criteria for the proposal.
+> Fill in every section and check each box as you go. The checklist acts as the acceptance criteria for the PR.
 
 ---
 

--- a/.github/PULL_REQUEST_TEMPLATE/default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/default.md
@@ -1,0 +1,35 @@
+## Why?
+
+Clear and short explanation here.
+
+## How?
+
+- Done A (replace with a breakdown of the steps)
+- Done B
+- Done C
+
+## Tickets?
+
+- [Ticket 1](the-ticket-url-here)
+- [Ticket 2](the-ticket-url-here)
+- [Ticket 3](the-ticket-url-here)
+
+## Contribution checklist?
+
+- [ ] You've done enough research before writing
+- [ ] You have reviewed the PR
+- [ ] The commit messages are detailed
+- [ ] The `build` command runs locally
+- [ ] Assets or static content are linked and stored in the project
+- [ ] For documentation, guides or references, you've tested the commands
+
+## Security checklist?
+
+- [ ] All user inputs are validated and sanitized
+- [ ] No usage of `dangerouslySetInnerHTML`
+- [ ] Sensitive data has been identified and is being protected properly
+- [ ] Build output contains no secrets or API keys
+
+## Preview?
+
+Optionally, provide a demo or a preview url here


### PR DESCRIPTION
## Why?

A quick fix for the Component RFC template workflow, which made the Pull request template disappear. I believe this was meant to be an issue template instead of a pull request template.

⚠️ Closed to favour https://github.com/ClickHouse/click-ui/pull/875

## Preview?

<img width="893" height="407" alt="Screenshot 2026-03-05 at 12 21 58" src="https://github.com/user-attachments/assets/25464c61-9b18-44ee-baf1-65ef6e1c63ec" />
