### PR TITLE
chore: 🤖  skip llm review when bot triggers pull request event

### DIFF
--- a/.github/workflows/llm-code-review.yml
+++ b/.github/workflows/llm-code-review.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   code-review:
     name: Claude Code Review
+    if: github.event.sender.type != 'Bot'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Why?

The workflow will now skip when triggered by a bot by checking github's event sender type. This prevents the workflow from running when bots like "Create Release" trigger pull request events.
  
## How?

- Checks github.event.sender.type != 'Bot'

## Preview?

N/A