### PR TITLE
fix(DatePicker): prevent scrunching of predefined lists

### DIFF
--- a/.changeset/chatty-terms-remain.md
+++ b/.changeset/chatty-terms-remain.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': patch
+---
+
+Explicitly sets box-sizing: content-box on predefined date picker lists. This prevents them for being pushed to too small a size when the app they're in uses a different box sizing model"

--- a/src/components/DatePicker/Common.tsx
+++ b/src/components/DatePicker/Common.tsx
@@ -26,6 +26,7 @@ import {
   weekdayFormatter,
 } from './utils';
 import { getMonthNames, DAYS, MONTHS, YEARS, DAYS_IN_WEEK } from '@/utils/date';
+import { Dropdown } from '@/components/Dropdown';
 
 const explicitWidth = '250px';
 const TXT_ON_MONTH_SELECT = 'Month';
@@ -497,6 +498,11 @@ export const DateTableCell = styled.td<{
           : theme.click.datePicker.dateOption.color.stroke.hover
       };`};
   }
+`;
+
+export const StyledDropdownItem = styled(Dropdown.Item)`
+  box-sizing: content-box;
+  min-height: 24px;
 `;
 
 export type Body = ReturnType<typeof useCalendar>['body'];

--- a/src/components/DatePicker/DateRangePicker.tsx
+++ b/src/components/DatePicker/DateRangePicker.tsx
@@ -12,7 +12,13 @@ import {
 import { isSameDate, UseCalendarOptions } from '@h6s/calendar';
 import { styled } from 'styled-components';
 import { Dropdown } from '@/components/Dropdown';
-import { Body, CalendarRenderer, DateRangePickerInput, DateTableCell } from './Common';
+import {
+  Body,
+  CalendarRenderer,
+  DateRangePickerInput,
+  DateTableCell,
+  StyledDropdownItem,
+} from './Common';
 import { Container } from '@/components/Container';
 import { Panel } from '@/components/Panel';
 import { Icon } from '@/components/Icon';
@@ -53,10 +59,6 @@ const CalendarRendererContainer = styled.div<{ $openDirection?: OpenDirection }>
 const StyledCalendarRenderer = styled(CalendarRenderer)`
   border-radius: ${({ theme }) => theme.click.datePicker.dateOption.radii.default};
   min-height: 221px;
-`;
-
-const StyledDropdownItem = styled(Dropdown.Item)`
-  min-height: 24px;
 `;
 
 // max-height of 210px allows the scrollable container to be a reasonble height that matches the calendar

--- a/src/components/DatePicker/DateTimeRangePicker.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.tsx
@@ -17,6 +17,7 @@ import {
   CalendarRenderer,
   DateTimeRangePickerInput,
   DateTableCell,
+  StyledDropdownItem,
 } from './Common';
 import { Container } from '../Container/Container';
 import { Panel } from '../Panel/Panel';
@@ -66,10 +67,6 @@ const StyledCalendarRenderer = styled(CalendarRenderer)`
 
 const StyledTriggerList = styled(Tabs.TriggersList)`
   justify-content: space-around;
-`;
-
-const StyledDropdownItem = styled(Dropdown.Item)`
-  min-height: 24px;
 `;
 
 // max-height of 210px allows the scrollable container to be a reasonble height that matches the calendar


### PR DESCRIPTION
## Why?

Control plane uses box-sizing: border-box. This causes the date picker predefined list of items, which use rely on the box-sizing model to be content-box, to be smaller than intended.

<img width="2019" height="1162" alt="Screenshot 2026-03-09 at 11 29 20 AM" src="https://github.com/user-attachments/assets/f884d812-e374-4193-a792-4cdf9d7f6bbb" />


## How?

- Explicitly set the box sizing on each predefined list item
- Since both DateRangePicker and DateTimeRangePicker use this construct, move it into common

<img width="2019" height="1162" alt="Screenshot 2026-03-09 at 11 29 34 AM" src="https://github.com/user-attachments/assets/12d43902-9c99-4909-9f02-04f016febc84" />
