### PR TITLE
chore: 🤖 split slack notifications (general vs pull requests)

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -293,5 +293,5 @@ jobs:
           # as notifications at the moment are inline
           # and hard to confirm output without CI/CD runtime
           payload: |
-            channel: "${{ secrets.SLACK_CHANNEL }}"
+            channel: "${{ secrets.SLACK_CHANNEL_FOR_PR }}"
             text: "===\n📦 *New Release PR Created*\n\n*Package:* ${{ steps.version-package.outputs.package_name }}\n*Version:* ${{ steps.version-package.outputs.version }}\n*Type:* ${{ inputs.release_type }}\n*Branch:* ${{ github.ref_name }}\n\n<${{ steps.create-pr.outputs.pull-request-url }}|View Pull Request>\n==="

--- a/.github/workflows/pull-request-slack-notification.yml
+++ b/.github/workflows/pull-request-slack-notification.yml
@@ -32,6 +32,6 @@ jobs:
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: >
             {
-              "channel": "${{ secrets.SLACK_CHANNEL }}",
+              "channel": "${{ secrets.SLACK_CHANNEL_FOR_PR }}",
               "text": "===\n🔔 ${{ secrets.SLACK_GROUP_TAG_NAME_FOR_CUI_NOTIFICATIONS }} *New Pull Request Opened*\n\n*Title:* ${{ steps.prepare.outputs.title }}\n*Author:* @${{ github.event.pull_request.user.login }}\n*Branch:* ${{ github.event.pull_request.head.ref }} → ${{ github.event.pull_request.base.ref }}\n\n*Description:*\n${{ steps.prepare.outputs.description }}\n\n<${{ github.event.pull_request.html_url }}|View Pull Request>\n==="
             }

--- a/.github/workflows/release-publisher.yml
+++ b/.github/workflows/release-publisher.yml
@@ -254,5 +254,5 @@ jobs:
           # as notifications at the moment are inline
           # and hard to confirm output without CI/CD runtime
           payload: |
-            channel: "${{ secrets.SLACK_CHANNEL }}"
+            channel: "${{ secrets.SLACK_CHANNEL_FOR_GENERAL }}"
             text: "===\n🚀 *Click UI ${{ steps.verify-merge.outputs.version }} has launched!* 🎉\n\n📦 <https://www.npmjs.com/package/@clickhouse/click-ui/v/${{ steps.verify-merge.outputs.version }}|View on npm>\n📋 <https://github.com/ClickHouse/click-ui/blob/${{ steps.verify-merge.outputs.tag }}/CHANGELOG.md|View Changelog>\n\n_Release type: ${{ steps.package-info.outputs.tag }}_\n==="


### PR DESCRIPTION
## Why?

Split Slack notification channels to route pull request-related notifications and general release announcements to separate channels. Now, pull requests, such as chores, features, and fixes, are routed to a dedicated pull request channel for Click UI. For packages published to npm, these are announced in Click UI's general chat room to incentivise adoption and feedback as early as possible.

## How?

- Replaced `SLACK_CHANNEL` with `SLACK_CHANNEL_FOR_PR` in `create-release.yml` for release PR notifications
- Replaced `SLACK_CHANNEL` with `SLACK_CHANNEL_FOR_PR` in `pull-request-slack-notification.yml` for new PR notifications
- Replaced `SLACK_CHANNEL` with `SLACK_CHANNEL_FOR_GENERAL` in `release-publisher.yml` for npm package published announcements

## Security checklist?

- [x] Sensitive data has been identified and is being protected properly
- [x] Build output contains no secrets or API keys

## Preview?

N/A