### PR TITLE
chore(css-modules): 🤖 GitHub action for visual regression (development environment based [initial version])

### DIFF
--- a/.github/workflows/visual-regression-tests.yml
+++ b/.github/workflows/visual-regression-tests.yml
@@ -1,0 +1,42 @@
+name: 🎭 Visual regression tests
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+env:
+  HUSKY: 0
+
+jobs:
+  visual-regression:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 'latest'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      # NOTE: The tests path is located in playwright.config.ts
+      # e.g. ./tests
+      - name: Run visual regression tests
+        run: npx playwright test
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 30

--- a/.github/workflows/visual-regression-tests.yml
+++ b/.github/workflows/visual-regression-tests.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 'latest'
+          node-version: '24.x'
 
       - name: Enable Corepack
         run: corepack enable


### PR DESCRIPTION
## Why?

Introduces a GitHub Action for visual regression testing within the CI/CD pipeline. Unlike our existing Chromatic implementation, which relies on Storybook stories and cloud-managed snapshots, this action executes tests using screenshots managed directly within the development environment (curated by author). This ensures snapshots remain tightly coupled with the implementation code.

⚠️ Depends on #931 (should be merged first)

## How?

- Created a new GitHub workflow for `visual-regression-tests`

## Preview?

N/A