### PR TITLE
chore(ci): 🤖  improve changelog parsing

### DIFF
--- a/.github/workflows/release-publisher.yml
+++ b/.github/workflows/release-publisher.yml
@@ -158,19 +158,22 @@ jobs:
         id: changelog
         run: |
           VERSION="${{ steps.verify-merge.outputs.version }}"
+          CHANGELOG_PATH="CHANGELOG.md"
+          CHANGELOG_OUTPUT_TEMP_PATH="/tmp/changelog.txt"
+          FALLBACK_MSG="📝 See [CHANGELOG.md](./CHANGELOG.md) for details."
 
-          if [[ -f CHANGELOG.md ]]; then
-            CHANGELOG=$(awk "/## $VERSION/,/## [0-9]/" CHANGELOG.md | sed '1d;$d' | sed '/^$/d')
-
-            if [[ -z "$CHANGELOG" ]]; then
-              CHANGELOG="📝 See [CHANGELOG.md](./CHANGELOG.md) for details."
-            fi
-          else
-            CHANGELOG="No changelog available."
+          CHANGELOG=""
+          if [[ -f "$CHANGELOG_PATH" ]]; then
+            CHANGELOG=$(.scripts/bash/extract-changelog "$VERSION" "$CHANGELOG_PATH")
           fi
 
-          # Try persist multiple lines
-          echo "$CHANGELOG" > /tmp/changelog.txt
+          if [[ -n "$CHANGELOG" ]]; then
+            echo "$CHANGELOG" > "$CHANGELOG_OUTPUT_TEMP_PATH"
+          else
+            echo "No changelog available for version $VERSION." > "$CHANGELOG_OUTPUT_TEMP_PATH"
+            echo "" >> "$CHANGELOG_OUTPUT_TEMP_PATH"
+            echo "$FALLBACK_MSG" >> "$CHANGELOG_OUTPUT_TEMP_PATH"
+          fi
 
       - name: Create GitHub Release
         if: steps.verify-merge.outputs.is_release == 'true'

--- a/.scripts/bash/extract-changelog
+++ b/.scripts/bash/extract-changelog
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+if [[ $# -lt 1 ]]; then
+  echo "👹 Oops! Usage is extract-changelog <version> [changelog_file]"
+  exit 1
+fi
+
+VERSION="$1"
+CHANGELOG_FILE="${2:-CHANGELOG.md}"
+
+if [[ -z "$VERSION" ]]; then
+  echo "👹 Oops! Version is empty"
+  exit 1
+fi
+
+if [[ ! -f "$CHANGELOG_FILE" ]]; then
+  echo "👹 Oops! Changelog file not found: $CHANGELOG_FILE"
+  exit 1
+fi
+
+# NOTE: Extract content between "## <version>" and the next "## <version>" header
+FOUND=false
+CHANGELOG=""
+
+while IFS= read -r line; do
+  if [[ "$line" == "## $VERSION" ]]; then
+    FOUND=true
+    continue
+  fi
+
+  if $FOUND; then
+    if [[ "$line" =~ ^##\ [0-9] ]]; then
+      break
+    fi
+    CHANGELOG+="$line"$'\n'
+  fi
+done < "$CHANGELOG_FILE"
+
+CHANGELOG="${CHANGELOG%$'\n'}"
+
+# NOTE: Filter out any version headers that might have been captured
+CHANGELOG=$(echo "$CHANGELOG" | grep -v '^## [0-9]')
+
+if [[ -z "$CHANGELOG" ]]; then
+  echo "No changelog content found for version $VERSION"
+  exit 1
+fi
+
+# NOTE: Prevent GitHub mentioning user by replacing @username with `@username`
+echo "$CHANGELOG" | sed 's/@\([a-zA-Z0-9][a-zA-Z0-9-]*\)/`@\1`/g'

--- a/.scripts/bash/extract-changelog
+++ b/.scripts/bash/extract-changelog
@@ -38,9 +38,6 @@ done < "$CHANGELOG_FILE"
 
 CHANGELOG="${CHANGELOG%$'\n'}"
 
-# NOTE: Filter out any version headers that might have been captured
-CHANGELOG=$(echo "$CHANGELOG" | grep -v '^## [0-9]')
-
 if [[ -z "$CHANGELOG" ]]; then
   echo "No changelog content found for version $VERSION" >&2
   exit 1

--- a/.scripts/bash/extract-changelog
+++ b/.scripts/bash/extract-changelog
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ $# -lt 1 ]]; then
-  echo "👹 Oops! Usage is extract-changelog <version> [changelog_file]"
+  echo "👹 Oops! Usage is extract-changelog <version> [changelog_file]" >&2
   exit 1
 fi
 
@@ -9,12 +9,12 @@ VERSION="$1"
 CHANGELOG_FILE="${2:-CHANGELOG.md}"
 
 if [[ -z "$VERSION" ]]; then
-  echo "👹 Oops! Version is empty"
+  echo "👹 Oops! Version is empty" >&2
   exit 1
 fi
 
 if [[ ! -f "$CHANGELOG_FILE" ]]; then
-  echo "👹 Oops! Changelog file not found: $CHANGELOG_FILE"
+  echo "👹 Oops! Changelog file not found: $CHANGELOG_FILE" >&2
   exit 1
 fi
 
@@ -42,7 +42,7 @@ CHANGELOG="${CHANGELOG%$'\n'}"
 CHANGELOG=$(echo "$CHANGELOG" | grep -v '^## [0-9]')
 
 if [[ -z "$CHANGELOG" ]]; then
-  echo "No changelog content found for version $VERSION"
+  echo "No changelog content found for version $VERSION" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Why?

The changelog extraction logic was previously embedded directly in the release workflow. This made it difficult to test locally and debug issues without triggering the full CI pipeline, e.g. ops runtime requires going through the pull request review/feedback cycle that can be quite long making it hard to iterate/TIAS. Recently, noticed that changelog descriptionm wasn't properly included in the github release notes. Also, when changelog entries contained contributor mentions like `@username`, GitHub would tag the user, e.g. `@deprecated` which `@<term>` are now escaped.

## How?

- Extracts changelog parsing logic from the release workflow into a script
- Adds `@username` mention escaping to prevent unintended GitHub notifications
- Improves error handling with clear fallback messages when changelog content is unavailable
 
## Preview?

 ⚠️ Tested in a separate playground environment due to pull request feedback/review loop which is too long for this type of work. While the playground environment tries to be as close as Click UI's repository, there might be differences and further iterations may be required to be addressed separately.

### Expected flow

https://github.com/user-attachments/assets/d9e4f43f-33fc-4a1a-b767-29bd939f4a60

### Expected output A

<img width="1166" height="982" alt="Screenshot 2026-03-25 at 11 23 43" src="https://github.com/user-attachments/assets/11d5029c-7097-4cd4-b1f0-1de2774da857" />

### Expected output B

<img width="1161" height="996" alt="Screenshot 2026-03-25 at 11 27 06" src="https://github.com/user-attachments/assets/8dc37838-50f9-49d5-a5fd-a260e8779891" />
