### PR TITLE
chore: 🤖 make local circular dependency check as user opt-in

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -31,20 +31,25 @@ else
   exit 1
 fi
 
-if yarn circular-dependency:check; then
-  echo "✅ Circular dependency check is good!"
-else
-  echo "⚠️ WARNING: Circular dependency checkup found issues, fix them before committing, please!"
-  echo "💡 Use the following command to get further reports in your resolution yarn circular-dependency:check"
-  exit 1
-fi
-
 if yarn changeset:verify; then
   echo "✅ Changeset file's included!"
 else
   echo "⚠️ WARNING: You must include a changeset!"
   echo "💡 Use the command yarn changeset:add"
   exit 1
+fi
+
+if [[ -n "$RUN_DEPS_CHECK" ]]; then
+  if yarn circular-dependency:check; then
+    echo "✅ Circular dependency check is good!"
+  else
+    echo "⚠️ WARNING: Circular dependency checkup found issues, fix them before committing, please!"
+    echo "💡 Use the following command to get further reports in your resolution yarn circular-dependency:check"
+    exit 1
+  fi
+else
+  echo "🦖 Skipped circular dependency check! To enable
+  set RUN_DEPS_CHECK=1"
 fi
 
 echo "👍 Health check completed."

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -48,8 +48,7 @@ if [[ -n "$RUN_DEPS_CHECK" ]]; then
     exit 1
   fi
 else
-  echo "🦖 Skipped circular dependency check! To enable
-  set RUN_DEPS_CHECK=1"
+  echo "🦖 Skipped circular dependency check! To enable set RUN_DEPS_CHECK=1"
 fi
 
 echo "👍 Health check completed."

--- a/.scripts/bash/circular-dependency-check
+++ b/.scripts/bash/circular-dependency-check
@@ -11,6 +11,9 @@ TEMP_OUTPUT=$(mktemp)
 trap 'rm -f "$TEMP_OUTPUT"' EXIT
 
 if command -v yarn &> /dev/null; then
+  # NOTE: Redirect stdin to try prevent command hanging
+  # as a user has reported hanging in macOS (unable replicate
+  # but if issue persists for user remove redirection)
   yarn exec skott "$ENTRY_POINT" \
     --displayMode=file-tree \
     --showCircularDependencies \

--- a/.scripts/bash/circular-dependency-check
+++ b/.scripts/bash/circular-dependency-check
@@ -15,7 +15,7 @@ if command -v yarn &> /dev/null; then
     --displayMode=file-tree \
     --showCircularDependencies \
     --ignorePattern="$IGNORE_PATTERNS" \
-    --exitCodeOnCircularDependencies=1 > "$TEMP_OUTPUT" 2>&1 || true
+    --exitCodeOnCircularDependencies=1 < /dev/null > "$TEMP_OUTPUT" 2>&1 || true
 else
   echo "👹 Oops! The package skott is missing, have you installed the project dependencies?"
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ Check for circular dependencies that can cause build and runtime issues:
 yarn circular-dependency:check
 ```
 
+> [!TIP]
+> Set RUN_DEPS_CHECK=1 to run circular dependency checks automatically on commit.
+
 If circular dependencies are found it'll exit with a report showing the affeced files which require your attention.
 
 ### Generating design tokens


### PR DESCRIPTION
## Why?

Make the local circular dependency check opt-in. Originally reported by contributor @mneedham, who reported hanging on pre-committing in a macOS environment. Although, I was not able to reproduce on macOS (ventura 13.x)

## How?

- Wrap circular dependency check in Git commit hook with Flag
- Provide documentation explaining how to opt-in
- Redirect stdin (try to prevent the circular dep command from hanging if it tries to read user input)

## Preview?

N/A