### PR TITLE
chore: 🤖 replace deprecated yarn flag frozen-lockfile

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -106,7 +106,7 @@ jobs:
           private-key: ${{ secrets.WORKFLOW_AUTH_PUBLIC_PRIVATE_KEY }}
 
       - name: Install Dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --immutable
 
       - name: Check pre-release status
         id: check-prerelease

--- a/.github/workflows/release-publisher.yml
+++ b/.github/workflows/release-publisher.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Install Dependencies
         if: steps.verify-merge.outputs.is_release == 'true'
-        run: yarn install --frozen-lockfile
+        run: yarn install --immutable
 
       - name: Build package
         if: steps.verify-merge.outputs.is_release == 'true'


### PR DESCRIPTION
## Why?

Replace deprecated yarn flag `frozen-lockfile` to favour `immutable`.

## How?

- Replace flags in create and publish workflows

## Tickets?

N/A

## Preview?

N/A