### PR TITLE
feat(NumberField): add startContent and endContent props to NumberField

### DIFF
--- a/.changeset/bil-4944-contribute-spendthresholdinput-changes-up-into-click-ui.md
+++ b/.changeset/bil-4944-contribute-spendthresholdinput-changes-up-into-click-ui.md
@@ -2,4 +2,48 @@
 '@clickhouse/click-ui': minor
 ---
 
-Adds startContent and endContent props to NumberField, matching the existing TextField API
+Adds `startContent` and `endContent` props to `NumberField`, matching the existing `TextField` API. This enables rendering additional elements (e.g., unit labels, currency symbols) inside the input field without absolute-positioning hacks.
+
+## What has changed?
+
+- New `startContent` prop for rendering content to the left of the input
+- New `endContent` prop for rendering content to the right of the input
+- Clicking on `startContent` focuses the input field
+- `endContent` is displayed alongside the existing loading indicator when both are present
+- Added `WithEndContent` and `WithStartContent` stories
+
+## How to use?
+
+With a currency symbol prefix:
+
+```tsx
+import { NumberField, Text } from '@clickhouse/click-ui';
+
+<NumberField
+  label="Price"
+  placeholder="0.00"
+  hideControls
+  startContent={
+    <Text color="muted" size="sm">
+      $
+    </Text>
+  }
+/>
+```
+
+With a unit suffix:
+
+```tsx
+import { NumberField, Text } from '@clickhouse/click-ui';
+
+<NumberField
+  label="Spend limit"
+  placeholder="0"
+  hideControls
+  endContent={
+    <Text color="muted" size="sm">
+      dollars / credits
+    </Text>
+  }
+/>
+```

--- a/.changeset/bil-4944-contribute-spendthresholdinput-changes-up-into-click-ui.md
+++ b/.changeset/bil-4944-contribute-spendthresholdinput-changes-up-into-click-ui.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': minor
+---
+
+Adds startContent and endContent props to NumberField, matching the existing TextField API

--- a/src/components/InputWrapper/InputWrapper.tsx
+++ b/src/components/InputWrapper/InputWrapper.tsx
@@ -279,6 +279,8 @@ export const InputStartContent = styled.div`
 `;
 
 export const InputEndContent = styled.div`
+  white-space: nowrap;
+  flex-shrink: 0;
   ${({ theme }) => `
     padding-right: ${theme.click.field.space.x};
     gap: ${theme.click.field.space.gap};

--- a/src/components/NumberField/NumberField.stories.tsx
+++ b/src/components/NumberField/NumberField.stories.tsx
@@ -52,7 +52,10 @@ export const WithEndContent: Story = {
     placeholder: '0',
     hideControls: true,
     endContent: (
-      <Text color="muted" size="sm">
+      <Text
+        color="muted"
+        size="sm"
+      >
         dollars / credits
       </Text>
     ),
@@ -65,7 +68,10 @@ export const WithStartContent: Story = {
     placeholder: '0.00',
     hideControls: true,
     startContent: (
-      <Text color="muted" size="sm">
+      <Text
+        color="muted"
+        size="sm"
+      >
         $
       </Text>
     ),

--- a/src/components/NumberField/NumberField.stories.tsx
+++ b/src/components/NumberField/NumberField.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { useEffect, useState } from 'react';
 import { NumberField, NumberFieldProps } from './NumberField';
 import { Container } from '@/components/Container';
-import { Text } from '@/components/Text/Text';
+import { Text } from '@/components/Text';
 
 const meta: Meta<typeof NumberField> = {
   component: NumberField,

--- a/src/components/NumberField/NumberField.stories.tsx
+++ b/src/components/NumberField/NumberField.stories.tsx
@@ -2,6 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { useEffect, useState } from 'react';
 import { NumberField, NumberFieldProps } from './NumberField';
 import { Container } from '@/components/Container';
+import { Text } from '@/components/Text/Text';
 
 const meta: Meta<typeof NumberField> = {
   component: NumberField,
@@ -42,5 +43,31 @@ export const Playground: Story = {
     disabled: false,
     placeholder: 'Placeholder',
     loading: false,
+  },
+};
+
+export const WithEndContent: Story = {
+  args: {
+    label: 'Spend limit',
+    placeholder: '0',
+    hideControls: true,
+    endContent: (
+      <Text color="muted" size="sm">
+        dollars / credits
+      </Text>
+    ),
+  },
+};
+
+export const WithStartContent: Story = {
+  args: {
+    label: 'Price',
+    placeholder: '0.00',
+    hideControls: true,
+    startContent: (
+      <Text color="muted" size="sm">
+        $
+      </Text>
+    ),
   },
 };

--- a/src/components/NumberField/NumberField.test.tsx
+++ b/src/components/NumberField/NumberField.test.tsx
@@ -11,7 +11,10 @@ describe('NumberField', () => {
 
   it('renders a number input', () => {
     const { getByRole } = renderCUI(
-      <NumberField label="Amount" onChange={onChange} />
+      <NumberField
+        label="Amount"
+        onChange={onChange}
+      />
     );
 
     expect(getByRole('spinbutton')).toBeInTheDocument();
@@ -57,7 +60,11 @@ describe('NumberField', () => {
 
   it('renders loading spinner', () => {
     const { getByRole } = renderCUI(
-      <NumberField label="Amount" onChange={onChange} loading />
+      <NumberField
+        label="Amount"
+        onChange={onChange}
+        loading
+      />
     );
 
     expect(getByRole('img', { name: 'loading-animated' })).toBeInTheDocument();

--- a/src/components/NumberField/NumberField.test.tsx
+++ b/src/components/NumberField/NumberField.test.tsx
@@ -1,0 +1,79 @@
+import { NumberField } from '@/components/NumberField';
+import { renderCUI } from '@/utils/test-utils';
+import { fireEvent } from '@testing-library/react';
+
+describe('NumberField', () => {
+  const onChange = vi.fn();
+
+  afterEach(() => {
+    onChange.mockClear();
+  });
+
+  it('renders a number input', () => {
+    const { getByRole } = renderCUI(
+      <NumberField label="Amount" onChange={onChange} />
+    );
+
+    expect(getByRole('spinbutton')).toBeInTheDocument();
+  });
+
+  it('renders endContent when provided', () => {
+    const { getByText } = renderCUI(
+      <NumberField
+        label="Spend limit"
+        onChange={onChange}
+        endContent={<span>dollars / credits</span>}
+      />
+    );
+
+    expect(getByText('dollars / credits')).toBeInTheDocument();
+  });
+
+  it('renders startContent when provided', () => {
+    const { getByText } = renderCUI(
+      <NumberField
+        label="Price"
+        onChange={onChange}
+        startContent={<span>$</span>}
+      />
+    );
+
+    expect(getByText('$')).toBeInTheDocument();
+  });
+
+  it('focuses the input when startContent is clicked', () => {
+    const { getByText, getByRole } = renderCUI(
+      <NumberField
+        label="Price"
+        onChange={onChange}
+        startContent={<span>$</span>}
+      />
+    );
+
+    fireEvent.click(getByText('$'));
+
+    expect(document.activeElement).toBe(getByRole('spinbutton'));
+  });
+
+  it('renders loading spinner', () => {
+    const { getByRole } = renderCUI(
+      <NumberField label="Amount" onChange={onChange} loading />
+    );
+
+    expect(getByRole('img', { name: 'loading-animated' })).toBeInTheDocument();
+  });
+
+  it('renders endContent and loading spinner together', () => {
+    const { getByText, getByRole } = renderCUI(
+      <NumberField
+        label="Amount"
+        onChange={onChange}
+        loading
+        endContent={<span>units</span>}
+      />
+    );
+
+    expect(getByText('units')).toBeInTheDocument();
+    expect(getByRole('img', { name: 'loading-animated' })).toBeInTheDocument();
+  });
+});

--- a/src/components/NumberField/NumberField.tsx
+++ b/src/components/NumberField/NumberField.tsx
@@ -1,4 +1,11 @@
-import { ChangeEvent, InputHTMLAttributes, ReactNode, forwardRef, useId, useRef } from 'react';
+import {
+  ChangeEvent,
+  InputHTMLAttributes,
+  ReactNode,
+  forwardRef,
+  useId,
+  useRef,
+} from 'react';
 import { Icon } from '@/components/Icon';
 import {
   InputEndContent,

--- a/src/components/NumberField/NumberField.tsx
+++ b/src/components/NumberField/NumberField.tsx
@@ -1,10 +1,13 @@
-import { ChangeEvent, InputHTMLAttributes, forwardRef, useId } from 'react';
+import { ChangeEvent, InputHTMLAttributes, ReactNode, forwardRef, useId, useRef } from 'react';
 import { Icon } from '@/components/Icon';
 import {
+  InputEndContent,
+  InputStartContent,
   InputWrapper,
   NumberInputElement,
   WrapperProps,
 } from '@/components/InputWrapper';
+import { mergeRefs } from '@/utils/mergeRefs';
 export interface NumberFieldProps
   extends
     Omit<WrapperProps, 'id' | 'children'>,
@@ -21,6 +24,10 @@ export interface NumberFieldProps
   dir?: 'start' | 'end';
   /** Whether to hide the increment/decrement controls */
   hideControls?: boolean;
+  /** Additional content to the left of the control */
+  startContent?: ReactNode;
+  /** Additional content to the right of the control */
+  endContent?: ReactNode;
 }
 
 export const NumberField = forwardRef<HTMLInputElement, NumberFieldProps>(
@@ -35,14 +42,24 @@ export const NumberField = forwardRef<HTMLInputElement, NumberFieldProps>(
       orientation,
       dir,
       hideControls,
+      startContent,
+      endContent,
       ...props
     },
     ref
   ) => {
+    const inputRef = useRef<HTMLInputElement>(null);
     const defaultId = useId();
     const onChange = (e: ChangeEvent<HTMLInputElement>) => {
       onChangeProp(e.target.value, e);
     };
+
+    const handleStartContentClick: React.MouseEventHandler<HTMLDivElement> = () => {
+      inputRef.current?.focus();
+    };
+
+    const hasStartContent = Boolean(startContent);
+    const hasEndContent = Boolean(loading || endContent);
 
     return (
       <InputWrapper
@@ -53,20 +70,32 @@ export const NumberField = forwardRef<HTMLInputElement, NumberFieldProps>(
         orientation={orientation}
         dir={dir}
       >
+        {startContent && (
+          <InputStartContent onClick={handleStartContentClick}>
+            {startContent}
+          </InputStartContent>
+        )}
         <NumberInputElement
-          ref={ref}
+          ref={mergeRefs([inputRef, ref])}
           type="number"
           id={id ?? defaultId}
           disabled={disabled}
           onChange={onChange}
           $hideControls={hideControls}
+          $hasStartContent={hasStartContent}
+          $hasEndContent={hasEndContent}
           {...props}
         />
-        {loading && (
-          <Icon
-            name="loading-animated"
-            size="sm"
-          />
+        {hasEndContent && (
+          <InputEndContent>
+            {endContent ? endContent : null}
+            {loading && (
+              <Icon
+                name="loading-animated"
+                size="sm"
+              />
+            )}
+          </InputEndContent>
         )}
       </InputWrapper>
     );


### PR DESCRIPTION
## Summary
- Adds `startContent` and `endContent` props to `NumberField`, matching the existing `TextField` API
- Enables rendering additional elements (e.g., unit labels) inside the input field without absolute-positioning hacks
- Adds `WithEndContent` and `WithStartContent` stories

Resolves [BIL-4944](https://linear.app/clickhouse/issue/BIL-4944)

## Test plan
- [x] Verify existing `Playground` story still works as before
- [x] Verify `WithEndContent` story renders "dollars / credits" label inside the field
- [x] Verify `WithStartContent` story renders "$" prefix inside the field
- [ ] Verify `loading` spinner still renders correctly (now inside `InputEndContent`)
- [ ] Verify clicking `startContent` focuses the input

🤖 Generated with [Claude Code](https://claude.com/claude-code)