### PR TITLE
style: 💄 number field end-content in a single line

### DIFF
--- a/src/components/InputWrapper/InputWrapper.tsx
+++ b/src/components/InputWrapper/InputWrapper.tsx
@@ -279,6 +279,8 @@ export const InputStartContent = styled.div`
 `;
 
 export const InputEndContent = styled.div`
+  white-space: nowrap;
+  flex-shrink: 0;
   ${({ theme }) => `
     padding-right: ${theme.click.field.space.x};
     gap: ${theme.click.field.space.gap};


### PR DESCRIPTION
## Why?

Number field end-content in a single line.

## How?

- Tweak CSS

## Preview?


https://github.com/user-attachments/assets/2ae80fb7-520f-479a-a556-8bf52547ecf2

