### PR TITLE
fix(Dialog): Use Radix Dialog Primitives for Accessibility

### DIFF
--- a/.changeset/fix-dialog-radix-primitives.md
+++ b/.changeset/fix-dialog-radix-primitives.md
@@ -1,0 +1,8 @@
+---
+"@clickhouse/click-ui": patch
+---
+
+Use Radix Dialog primitives for accessibility compliance.
+
+- Changed Dialog title from `styled.h2` to `styled(RadixDialog.Title)` so Radix recognizes it as a proper DialogTitle
+- Added optional `description` prop to Dialog.Content that renders as `RadixDialog.Description`

--- a/.changeset/fix-dialog-radix-primitives.md
+++ b/.changeset/fix-dialog-radix-primitives.md
@@ -6,3 +6,36 @@ Use Radix Dialog primitives for accessibility compliance.
 
 - Changed Dialog title from `styled.h2` to `styled(RadixDialog.Title)` so Radix recognizes it as a proper DialogTitle
 - Added optional `description` prop to Dialog.Content that renders as `RadixDialog.Description`
+
+### Before
+
+```tsx
+<Dialog.Content title="Confirm Action" showClose>
+  <Text color="muted">
+  Dialog body content goes here
+  </Text>
+  <Spacer />
+  <Separator size="lg" />
+  <ActionArea>
+    <Dialog.Close label="Close" />
+    <Button iconRight="arrow-right">Continue</Button>
+  </ActionArea>
+</Dialog.Content>
+```
+
+### After
+
+```tsx
+<Dialog.Content
+  title="Confirm Action"
+  description="Dialog body content goes here"
+  showClose
+>
+  <Spacer />
+  <Separator size="lg" />
+  <ActionArea>
+    <Dialog.Close label="Cancel" />
+    <Button type="primary">Confirm</Button>
+  </ActionArea>
+</Dialog.Content>
+```

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -102,6 +102,35 @@ export const ModalDialog: Story = {
   },
 };
 
+export const WithDescription: Story = {
+  render: () => (
+    <GridCenter>
+      <Dialog open>
+        <Dialog.Content
+          title="Confirm Action"
+          description="Are you sure you want to proceed? This action cannot be undone."
+          showClose
+        >
+          <Spacer />
+          <Separator size="lg" />
+          <ActionArea>
+            <Dialog.Close label="Cancel" />
+            <Button type="primary">Confirm</Button>
+          </ActionArea>
+        </Dialog.Content>
+      </Dialog>
+    </GridCenter>
+  ),
+  parameters: {
+    docs: {
+      story: {
+        inline: false,
+        iframeHeight: 500,
+      },
+    },
+  },
+};
+
 const TopNav = styled.div`
   position: absolute;
   top: 0;

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -108,6 +108,13 @@ const Title = styled(RadixDialog.Title)`
   margin: 0;
 `;
 
+const Description = styled(RadixDialog.Description)`
+  font: ${({ theme }) => theme.click.dialog.typography.description.default};
+  color: ${({ theme }) => theme.click.dialog.color.description.default};
+  padding: 0;
+  margin: 0;
+`;
+
 const CloseButton = ({ onClose }: { onClose?: () => void }) => (
   <RadixDialog.Close asChild>
     <CrossButton onClick={onClose}>
@@ -156,7 +163,7 @@ const DialogContent = ({
             <Spacer size="sm" />
           </>
         )}
-        {description && <RadixDialog.Description>{description}</RadixDialog.Description>}
+        {description && <Description>{description}</Description>}
         {children}
       </ContentArea>
     </RadixDialog.Portal>

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -121,6 +121,7 @@ const CloseButton = ({ onClose }: { onClose?: () => void }) => (
 
 const DialogContent = ({
   title,
+  description,
   children,
   showClose,
   onClose,
@@ -154,6 +155,9 @@ const DialogContent = ({
             </TitleArea>
             <Spacer size="sm" />
           </>
+        )}
+        {description && (
+          <RadixDialog.Description>{description}</RadixDialog.Description>
         )}
         {children}
       </ContentArea>

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -156,9 +156,7 @@ const DialogContent = ({
             <Spacer size="sm" />
           </>
         )}
-        {description && (
-          <RadixDialog.Description>{description}</RadixDialog.Description>
-        )}
+        {description && <RadixDialog.Description>{description}</RadixDialog.Description>}
         {children}
       </ContentArea>
     </RadixDialog.Portal>

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -102,7 +102,7 @@ const TitleArea = styled.div<{ $onlyClose?: boolean }>`
   min-height: ${({ theme }) => theme.sizes[9]}; // 32px
 `;
 
-const Title = styled.h2`
+const Title = styled(RadixDialog.Title)`
   font: ${({ theme }) => theme.click.dialog.typography.title.default};
   padding: 0;
   margin: 0;
@@ -155,7 +155,6 @@ const DialogContent = ({
             <Spacer size="sm" />
           </>
         )}
-
         {children}
       </ContentArea>
     </RadixDialog.Portal>

--- a/src/components/Dialog/Dialog.types.ts
+++ b/src/components/Dialog/Dialog.types.ts
@@ -16,6 +16,7 @@ export interface DialogTriggerProps extends React.ComponentPropsWithoutRef<'butt
 
 export interface DialogContentProps extends RadixDialog.DialogContentProps {
   children: ReactNode;
+  description?: string;
   showClose?: boolean;
   forceMount?: true;
   container?: HTMLElement | null;


### PR DESCRIPTION
## Why?

Dialog.Content has two accessibility issues:
1. Renders the `title` prop as a `styled.h2` instead of Radix's `DialogTitle` primitive, causing: `DialogContent requires a DialogTitle`
2. No way to provide a dialog description, causing: `Missing Description or aria-describedby`

## How?

- Changed `Title` from `styled.h2` to `styled(RadixDialog.Title)`
- Added optional `description` prop that renders as `RadixDialog.Description`
- Existing tests pass

## Tickets?

- [ClickHouse/librechat-admin-panel#13](https://github.com/ClickHouse/librechat-admin-panel/issues/13)

## Contribution checklist?

- [x] You've done enough research before writing
- [x] You have reviewed the PR