### PR TITLE
chore(dialog): 🤖 add story for new description prop

### DIFF
--- a/.changeset/fix-dialog-radix-primitives.md
+++ b/.changeset/fix-dialog-radix-primitives.md
@@ -6,3 +6,36 @@ Use Radix Dialog primitives for accessibility compliance.
 
 - Changed Dialog title from `styled.h2` to `styled(RadixDialog.Title)` so Radix recognizes it as a proper DialogTitle
 - Added optional `description` prop to Dialog.Content that renders as `RadixDialog.Description`
+
+### Before
+
+```tsx
+<Dialog.Content title="Confirm Action" showClose>
+  <Text color="muted">
+  Dialog body content goes here
+  </Text>
+  <Spacer />
+  <Separator size="lg" />
+  <ActionArea>
+    <Dialog.Close label="Close" />
+    <Button iconRight="arrow-right">Continue</Button>
+  </ActionArea>
+</Dialog.Content>
+```
+
+### After
+
+```tsx
+<Dialog.Content
+  title="Confirm Action"
+  description="Dialog body content goes here"
+  showClose
+>
+  <Spacer />
+  <Separator size="lg" />
+  <ActionArea>
+    <Dialog.Close label="Cancel" />
+    <Button type="primary">Confirm</Button>
+  </ActionArea>
+</Dialog.Content>
+```

--- a/src/components/Dialog/Dialog.stories.tsx
+++ b/src/components/Dialog/Dialog.stories.tsx
@@ -102,6 +102,35 @@ export const ModalDialog: Story = {
   },
 };
 
+export const WithDescription: Story = {
+  render: () => (
+    <GridCenter>
+      <Dialog open>
+        <Dialog.Content
+          title="Confirm Action"
+          description="Are you sure you want to proceed? This action cannot be undone."
+          showClose
+        >
+          <Spacer />
+          <Separator size="lg" />
+          <ActionArea>
+            <Dialog.Close label="Cancel" />
+            <Button type="primary">Confirm</Button>
+          </ActionArea>
+        </Dialog.Content>
+      </Dialog>
+    </GridCenter>
+  ),
+  parameters: {
+    docs: {
+      story: {
+        inline: false,
+        iframeHeight: 500,
+      },
+    },
+  },
+};
+
 const TopNav = styled.div`
   position: absolute;
   top: 0;


### PR DESCRIPTION
## Why?

Following up on #973 by @dustinhealy, I’ve added some before/after examples to the changeset and set up a new Storybook story. Using the newly introduced description prop for shorter text looks cleaner and handles the accessibility semantics better.

## How?

- Updates changeset
- Create a new story "with description"

## Preview?

<img width="1074" height="607" alt="Screenshot 2026-04-09 at 10 33 15" src="https://github.com/user-attachments/assets/123eabbd-29b9-4125-a167-ce9054f41411" />
