### PR TITLE
fix(Dialog): Suppress Missing Description Warning

### DIFF
--- a/.changeset/fix-dialog-description-warning.md
+++ b/.changeset/fix-dialog-description-warning.md
@@ -1,0 +1,5 @@
+---
+"@clickhouse/click-ui": patch
+---
+
+Suppress Radix `Missing Description` console warning when no `description` prop is provided to `Dialog.Content`. A hidden `RadixDialog.Description` is now rendered by default so Radix's accessibility check passes silently.

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -163,7 +163,11 @@ const DialogContent = ({
             <Spacer size="sm" />
           </>
         )}
-        {description && <Description>{description}</Description>}
+        {description ? (
+          <Description>{description}</Description>
+        ) : (
+          <RadixDialog.Description hidden />
+        )}
         {children}
       </ContentArea>
     </RadixDialog.Portal>


### PR DESCRIPTION
## Why?

When `Dialog.Content` is used without a `description` prop, Radix logs a console warning:

```
Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.
```

Passing `aria-describedby={undefined}` from the consumer side doesn't work because styled-components strips `undefined` props before they reach Radix's internal `DialogContent`.

## How?

Renders a hidden `<RadixDialog.Description hidden />` when no `description` prop is provided. This satisfies Radix's accessibility check without any visible UI change.

When `description` IS provided, the visible `<Description>` component renders as before.

## Tickets?

- [ClickHouse/librechat-admin-panel#13](https://github.com/ClickHouse/librechat-admin-panel/issues/13)

## Contribution checklist?

- [x] You've done enough research before writing
- [x] You have reviewed the PR