### PR TITLE
chore: 🤖 add normalisation pass in SVG convertor process/tool

### DIFF
--- a/.changeset/chore-add-optimization-pass-in-svg-convertor.md
+++ b/.changeset/chore-add-optimization-pass-in-svg-convertor.md
@@ -3,3 +3,13 @@
 ---
 
 Add an SVG normalization step to fix breaking issues before proceeding with conversion and optimization. The normalization is based in "conservative" optimisation steps, to reduce chances of visual changes.
+
+**Before:**
+```
+SVG File → SVGR (SVGO) → React Component
+```
+
+**After:**
+```
+SVG File → SVGO Normalize → Create temp file → SVGR (no SVGO) → React Component → Delete temp file
+```

--- a/.changeset/chore-add-optimization-pass-in-svg-convertor.md
+++ b/.changeset/chore-add-optimization-pass-in-svg-convertor.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': patch
+---
+
+Add an SVG normalization step to fix breaking issues before proceeding with conversion and optimization. The normalization is based in "conservative" optimisation steps, to reduce chances of visual changes.

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ storybook-static
 vite.config.ts.timestamp*
 .storybook/out
 tmp/*
+.scripts/js/.temp/
 
 .yarn/*
 !.yarn/releases

--- a/.scripts/js/convert-svg-to-react-component
+++ b/.scripts/js/convert-svg-to-react-component
@@ -170,7 +170,7 @@ const normalizeSvg = (svgPath, tempPath) => {
 const convertSvgToComponent = (svgPath, componentName, outputPath, defaultSize, skipSvgo = false) => {
   let svgrConfig;
   let tempConfigPath = null;
-  
+
   if (skipSvgo) {
     tempConfigPath = path.join(__dirname, '.temp', `svgr-config-${Date.now()}.mjs`);
     const configContent = `export default {
@@ -195,7 +195,7 @@ export default \${variables.componentName};
   } else {
     svgrConfig = path.join(__dirname, '../..', '.svgrrc.mjs');
   }
-  
+
   const cmd = `npx @svgr/cli --config-file "${svgrConfig}" --typescript "${svgPath}"`;
 
   let output;
@@ -233,7 +233,7 @@ export default \${variables.componentName};
   });
 
   fs.writeFileSync(outputPath, output);
-  
+
   if (tempConfigPath && fs.existsSync(tempConfigPath)) {
     try {
       fs.unlinkSync(tempConfigPath);
@@ -392,7 +392,7 @@ if (tempNormalizedPath && fs.existsSync(tempNormalizedPath)) {
   try {
     fs.unlinkSync(tempNormalizedPath);
   } catch (error) {
-    console.error(`⏭️  Skipping! Cleanup failure is ok`);
+    console.warn('⚠️ Failed to clean up temp SVGR config:', error.message);
   }
 }
 

--- a/.scripts/js/convert-svg-to-react-component
+++ b/.scripts/js/convert-svg-to-react-component
@@ -8,6 +8,7 @@ import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
+import { optimize } from 'svgo';
 import {
   filenameToKebabCase,
   filenameToComponentName,
@@ -136,6 +137,56 @@ const regenerateAssetRegistry = (config) => {
   );
 };
 
+const normalizeSvg = (svgPath, tempPath) => {
+  console.log('🔧 Normalizing SVG...');
+
+  try {
+    const svgContent = fs.readFileSync(svgPath, 'utf-8');
+
+    const result = optimize(svgContent, {
+      multipass: true,
+      plugins: [
+        {
+          name: 'preset-default',
+          params: {
+            overrides: {
+              removeViewBox: false,
+              convertPathData: {
+                floatPrecision: 2,
+                transformPrecision: 2,
+                makeArcs: {
+                  threshold: 2.5,
+                  tolerance: 0.5
+                }
+              },
+              removeUnknownsAndDefaults: {
+                keepRoleAttr: true
+              }
+            }
+          }
+        },
+        'cleanupIds',
+        'removeDimensions',
+        'removeXMLNS',
+        'removeXlink',
+        'removeEmptyAttrs',
+        'removeEmptyText',
+        'removeEmptyContainers',
+        'removeUnusedNS',
+        'sortAttrs',
+        'sortDefsChildren'
+      ]
+    });
+
+    fs.writeFileSync(tempPath, result.data);
+    console.log('✅ SVG normalized successfully');
+    return tempPath;
+  } catch (error) {
+    console.error('👹 Oops! SVG normalization failed:', error.message);
+    throw error;
+  }
+};
+
 const convertSvgToComponent = (svgPath, componentName, outputPath, defaultSize) => {
   const svgrConfig = path.join(__dirname, '../..', '.svgrrc.mjs');
   const cmd = `npx @svgr/cli --config-file "${svgrConfig}" --typescript "${svgPath}"`;
@@ -204,13 +255,17 @@ const cleanUp = (files) => {
 let args = process.argv.slice(2);
 
 const isRegenerate = args.includes('--regenerate');
+const skipNormalize = args.includes('--skip-normalize');
 
-// WARN: Do not change as this extracts and removes the --type flag from args if present, to allow args in package.json scripts
 const typeFlagIndex = args.findIndex(arg => arg.startsWith('--type='));
 let typeFlag = null;
 if (typeFlagIndex !== -1) {
   typeFlag = args[typeFlagIndex];
   args = args.filter((_, i) => i !== typeFlagIndex);
+}
+
+if (skipNormalize) {
+  args = args.filter(arg => arg !== '--skip-normalize');
 }
 
 if (isRegenerate) {
@@ -257,8 +312,9 @@ if (isRegenerate) {
 
 if (args.length < 1) {
   console.error('👹 Oops! The SVG file path is required');
-  console.error('💡 Usage: convert-svg-to-react-component <svg-path> [component-name] [--type=logos|icons|flags]');
+  console.error('💡 Usage: convert-svg-to-react-component <svg-path> [component-name] [--type=logos|icons|flags] [--skip-normalize]');
   console.error('💡 Or use: convert-svg-to-react-component --regenerate [--type=logos|icons|flags|payments]');
+  console.error('💡 Note: SVGs are automatically normalized before conversion. Use --skip-normalize to disable.');
   process.exit(1);
 }
 
@@ -296,7 +352,36 @@ const darkFile = path.join(systemDir, `${config.registryName.replace('Light', 'D
 
 console.log(`🍩 Baking ${componentName} for ${type}...`);
 
-convertSvgToComponent(svgPath, componentName, outputPath, config.defaultSize);
+let svgToConvert = svgPath;
+let tempNormalizedPath = null;
+
+if (!skipNormalize) {
+  const tempDir = path.join(__dirname, '.temp');
+  if (!fs.existsSync(tempDir)) {
+    fs.mkdirSync(tempDir, { recursive: true });
+  }
+  tempNormalizedPath = path.join(tempDir, `normalized-${Date.now()}.svg`);
+
+  try {
+    svgToConvert = normalizeSvg(svgPath, tempNormalizedPath);
+  } catch (error) {
+    console.error('💡 Try running with --skip-normalize if normalization causes issues');
+    process.exit(1);
+  }
+} else {
+  console.log('⏭️  Skipping SVG normalization (--skip-normalize flag set)');
+}
+
+convertSvgToComponent(svgToConvert, componentName, outputPath, config.defaultSize);
+
+if (tempNormalizedPath && fs.existsSync(tempNormalizedPath)) {
+  try {
+    fs.unlinkSync(tempNormalizedPath);
+  } catch (error) {
+    console.error(`⏭️  Skipping! Cleanup failure is ok`);
+  }
+}
+
 generateAssetTypes(config);
 regenerateAssetRegistry(config);
 

--- a/.scripts/js/convert-svg-to-react-component
+++ b/.scripts/js/convert-svg-to-react-component
@@ -167,11 +167,11 @@ const normalizeSvg = (svgPath, tempPath) => {
   }
 };
 
-const convertSvgToComponent = (svgPath, componentName, outputPath, defaultSize, skipSvgo = false) => {
+const convertSvgToComponent = (svgPath, componentName, outputPath, defaultSize, preNormalized = false) => {
   let svgrConfig;
   let tempConfigPath = null;
 
-  if (skipSvgo) {
+  if (preNormalized) {
     tempConfigPath = path.join(__dirname, '.temp', `svgr-config-${Date.now()}.mjs`);
     const configContent = `export default {
   typescript: true,
@@ -387,7 +387,8 @@ if (!skipNormalize) {
   console.log('⏭️  Skipping SVG normalization (--skip-normalize flag set)');
 }
 
-convertSvgToComponent(svgToConvert, componentName, outputPath, config.defaultSize, !skipNormalize);
+const didNormalize = !skipNormalize;
+convertSvgToComponent(svgToConvert, componentName, outputPath, config.defaultSize, didNormalize);
 
 if (tempNormalizedPath && fs.existsSync(tempNormalizedPath)) {
   try {

--- a/.scripts/js/convert-svg-to-react-component
+++ b/.scripts/js/convert-svg-to-react-component
@@ -271,6 +271,7 @@ let args = process.argv.slice(2);
 const isRegenerate = args.includes('--regenerate');
 const skipNormalize = args.includes('--skip-normalize');
 
+// WARN: Do not change as this extracts and removes the --type flag from args if present, to allow args in package.json scripts
 const typeFlagIndex = args.findIndex(arg => arg.startsWith('--type='));
 let typeFlag = null;
 if (typeFlagIndex !== -1) {

--- a/.scripts/js/convert-svg-to-react-component
+++ b/.scripts/js/convert-svg-to-react-component
@@ -151,30 +151,10 @@ const normalizeSvg = (svgPath, tempPath) => {
           params: {
             overrides: {
               removeViewBox: false,
-              convertPathData: {
-                floatPrecision: 2,
-                transformPrecision: 2,
-                makeArcs: {
-                  threshold: 2.5,
-                  tolerance: 0.5
-                }
-              },
-              removeUnknownsAndDefaults: {
-                keepRoleAttr: true
-              }
+              convertPathData: false
             }
           }
-        },
-        'cleanupIds',
-        'removeDimensions',
-        'removeXMLNS',
-        'removeXlink',
-        'removeEmptyAttrs',
-        'removeEmptyText',
-        'removeEmptyContainers',
-        'removeUnusedNS',
-        'sortAttrs',
-        'sortDefsChildren'
+        }
       ]
     });
 
@@ -187,8 +167,35 @@ const normalizeSvg = (svgPath, tempPath) => {
   }
 };
 
-const convertSvgToComponent = (svgPath, componentName, outputPath, defaultSize) => {
-  const svgrConfig = path.join(__dirname, '../..', '.svgrrc.mjs');
+const convertSvgToComponent = (svgPath, componentName, outputPath, defaultSize, skipSvgo = false) => {
+  let svgrConfig;
+  let tempConfigPath = null;
+  
+  if (skipSvgo) {
+    tempConfigPath = path.join(__dirname, '.temp', `svgr-config-${Date.now()}.mjs`);
+    const configContent = `export default {
+  typescript: true,
+  ref: false,
+  memo: false,
+  svgo: false,
+  template: (variables, { tpl }) => {
+    return tpl\`
+import { SVGAssetProps } from '../types';
+
+const \${variables.componentName} = (props: SVGAssetProps) => (
+  \${variables.jsx}
+);
+
+export default \${variables.componentName};
+\`;
+  },
+};`;
+    fs.writeFileSync(tempConfigPath, configContent);
+    svgrConfig = tempConfigPath;
+  } else {
+    svgrConfig = path.join(__dirname, '../..', '.svgrrc.mjs');
+  }
+  
   const cmd = `npx @svgr/cli --config-file "${svgrConfig}" --typescript "${svgPath}"`;
 
   let output;
@@ -226,6 +233,13 @@ const convertSvgToComponent = (svgPath, componentName, outputPath, defaultSize) 
   });
 
   fs.writeFileSync(outputPath, output);
+  
+  if (tempConfigPath && fs.existsSync(tempConfigPath)) {
+    try {
+      fs.unlinkSync(tempConfigPath);
+    } catch (error) {
+    }
+  }
 };
 
 const cleanUp = (files) => {
@@ -372,7 +386,7 @@ if (!skipNormalize) {
   console.log('⏭️  Skipping SVG normalization (--skip-normalize flag set)');
 }
 
-convertSvgToComponent(svgToConvert, componentName, outputPath, config.defaultSize);
+convertSvgToComponent(svgToConvert, componentName, outputPath, config.defaultSize, !skipNormalize);
 
 if (tempNormalizedPath && fs.existsSync(tempNormalizedPath)) {
   try {


### PR DESCRIPTION
## Why?

SVG inputs can break conversion due to malformed markup. This adds a normalisation step (based on conservative optimisation to reduce chances of visual diff) to fix structural issues upfront.

## How?

- Add a step/pass in the convertion script
- Before: SVG File → SVGR (SVGO) → React Component
- After: SVG File → SVGO Normalize → Create temp file → SVGR (no SVGO) → React Component → Delete temp file

## Preview?

<img width="820" height="156" alt="Screenshot 2026-04-10 at 10 17 19" src="https://github.com/user-attachments/assets/006cd0c6-660a-423a-a4b5-3b88b19403cf" />

<img width="816" height="188" alt="Screenshot 2026-04-10 at 10 17 08" src="https://github.com/user-attachments/assets/09db5542-0b09-4dc2-a7a6-faa1b1c088e2" />
