### PR TITLE
chore(css-modules): 🤖 Prevent duplicate CSS imports in build watcher

### DIFF
--- a/.changeset/fix-tracked-imports-reset-watch-mode.md
+++ b/.changeset/fix-tracked-imports-reset-watch-mode.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': patch
+---
+
+Prevent duplicate CSS imports in `vite build --watch` mode by clearing `trackedImports` between rebuilds

--- a/plugins/css-colocate/index.ts
+++ b/plugins/css-colocate/index.ts
@@ -28,6 +28,11 @@ export const cssColocatePlugin = (): Plugin => {
     apply: 'build',
 
     async buildStart() {
+      // WARN: Reset between rebuilds
+      // to prevent future build:watch transform to keep
+      // appending, causing duplicate CSS imports
+      // on each rebuild
+      trackedImports.length = 0;
       await preprocessCssModules(config.root);
     },
 


### PR DESCRIPTION
## Why?

Prevent duplicate CSS imports in `vite build --watch` mode by clearing `trackedImports` between rebuilds.

## How?

- Reset on buildStart call

## Preview?

N/A