### PR TITLE
chore(qa): 🤖 relax constraints on "latest" tag usage

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -30,14 +30,6 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - name: Validate branch for latest release
-        if: inputs.release_type == 'latest' && github.ref_name != 'main'
-        run: |
-          echo "👹 Oops! Cannot release 'latest' from branch '${{ github.ref_name }}'!"
-          echo "💡 The 'latest' release type can only be created from the 'main' branch."
-          echo "💡 Maintenance branches should use 'stable' instead."
-          exit 1
-
       - name: Checkout Repo
         uses: actions/checkout@v6
         with:

--- a/docs/package-release.md
+++ b/docs/package-release.md
@@ -218,7 +218,10 @@ git push origin chore/v1.0.0
 
 ### Promoting to stable release
 
-Stable releases are created from `chore/v*` branches. Once a stable release is published, the pre-release mode is switched off and `main` must be updated to reflect the version bump and exit from pre-release mode.
+Stable releases (`stable` or `latest`) can be created from `chore/v*` branches. Once released, the pre-release mode is switched off and `main` must be updated to reflect the version bump and exit from pre-release mode.
+
+> [!WARN]
+> Use `latest` only when you want the release to become the default version on npm.
 
 Follow these steps:
 
@@ -226,7 +229,7 @@ Follow these steps:
 
 2. Run the [Create Release](https://github.com/ClickHouse/click-ui/actions/workflows/create-release.yml) workflow from the `chore/v*` branch:
    - Select the maintenance branch (e.g., `chore/v1.0.0`)
-   - Choose `stable` as the release type
+   - Choose `stable` or `latest` as the release type
    - Confirm the release type and branch name
 
 3. Review and merge the release PR into the maintenance branch

--- a/docs/package-release.md
+++ b/docs/package-release.md
@@ -221,7 +221,8 @@ git push origin chore/v1.0.0
 Stable releases (`stable` or `latest`) can be created from `chore/v*` branches. Once released, the pre-release mode is switched off and `main` must be updated to reflect the version bump and exit from pre-release mode.
 
 > [!WARNING]
-> Use `latest` only when you want the release to become the default version on npm.
+> Use `latest` only when you want this version to become the **default** installed by `npm install @clickhouse/click-ui`.
+> Publishing `latest` from an older maintenance branch (e.g., `chore/v1.x.x`) **will downgrade** the default for all users who haven't pinned a version, even if a newer `v2.x.x` was previously `latest`.
 
 Follow these steps:
 

--- a/docs/package-release.md
+++ b/docs/package-release.md
@@ -220,7 +220,7 @@ git push origin chore/v1.0.0
 
 Stable releases (`stable` or `latest`) can be created from `chore/v*` branches. Once released, the pre-release mode is switched off and `main` must be updated to reflect the version bump and exit from pre-release mode.
 
-> [!WARN]
+> [!WARNING]
 > Use `latest` only when you want the release to become the default version on npm.
 
 Follow these steps:


### PR DESCRIPTION
## Why?

The `latest` tag is a reserved tag that indicates the default version in npm. Safeguards were previously introduced to incentivise the release cycle to help maintain quality standards, e.g., pre-release (test or release candidate) -> stable -> latest. The recent introduction of the "skip pre-release" mode (#983) gives maintainers immediate control over defining a "stable" release. As a result, we are relaxing the previous safeguards around the latest tag to support this new flexibility

## How?

- Remove "create-release" guard "Validate branch for latest release"
- Update documentation

## Contribution checklist?

- [ ] You've done enough research before writing
- [x] You have reviewed the PR
- [x] The commit messages are detailed
- [ ] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [x] For documentation, guides or references, you've tested the commands

## Security checklist?

- [ ] All user inputs are validated and sanitized
- [ ] No usage of `dangerouslySetInnerHTML`
- [ ] Sensitive data has been identified and is being protected properly
- [ ] Build output contains no secrets or API keys

## Preview?

N/A