### PR TITLE
fix(CodeBlock): Show Action Buttons on Hover

### DIFF
--- a/.changeset/fix-codeblock-button-overlap.md
+++ b/.changeset/fix-codeblock-button-overlap.md
@@ -1,0 +1,5 @@
+---
+"@clickhouse/click-ui": patch
+---
+
+CodeBlock action buttons (copy, wrap) are now hidden by default and revealed on hover or focus-within with a fade transition. Buttons display a semi-opaque background pill matching the code block theme to prevent overlap with code content, and expose descriptive `aria-label`s (with `aria-pressed` on the wrap toggle) for screen reader users. IconButton now honours a caller-supplied `aria-label`, falling back to the icon name when none is provided.

--- a/.changeset/fix-codeblock-button-overlap.md
+++ b/.changeset/fix-codeblock-button-overlap.md
@@ -2,4 +2,4 @@
 "@clickhouse/click-ui": patch
 ---
 
-Prevent CodeBlock copy/wrap buttons from overlapping code content. Adds right padding to the highlighted code area proportional to the number of action buttons displayed.
+CodeBlock action buttons (copy, wrap) are now hidden by default and revealed on hover or focus-within with a fade transition. Buttons display a semi-opaque background pill matching the code block theme to prevent overlap with code content.

--- a/.changeset/fix-codeblock-button-overlap.md
+++ b/.changeset/fix-codeblock-button-overlap.md
@@ -1,0 +1,5 @@
+---
+"@clickhouse/click-ui": patch
+---
+
+Prevent CodeBlock copy/wrap buttons from overlapping code content. Adds right padding to the highlighted code area proportional to the number of action buttons displayed.

--- a/src/components/CodeBlock/CodeBlock.test.tsx
+++ b/src/components/CodeBlock/CodeBlock.test.tsx
@@ -1,0 +1,40 @@
+import { CodeBlock } from '@/components/CodeBlock';
+import { fireEvent } from '@testing-library/react';
+import { renderCUI } from '@/utils/test-utils';
+
+describe('CodeBlock', () => {
+  it('exposes accessible labels for the action buttons', () => {
+    const { getByRole } = renderCUI(
+      <CodeBlock
+        language="sql"
+        showWrapButton
+      >
+        SELECT 1
+      </CodeBlock>
+    );
+
+    expect(getByRole('button', { name: 'Copy code' })).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Wrap long lines' })).toBeInTheDocument();
+  });
+
+  it('toggles the wrap button label and pressed state when clicked', () => {
+    const { getByRole } = renderCUI(
+      <CodeBlock
+        language="sql"
+        showWrapButton
+      >
+        SELECT 1
+      </CodeBlock>
+    );
+
+    const wrapButton = getByRole('button', { name: 'Wrap long lines' });
+    expect(wrapButton).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(wrapButton);
+
+    expect(getByRole('button', { name: 'Disable line wrapping' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+  });
+});

--- a/src/components/CodeBlock/CodeBlock.tsx
+++ b/src/components/CodeBlock/CodeBlock.tsx
@@ -65,8 +65,7 @@ const CodeBlockContainer = styled.div<{ $theme?: CodeThemeType }>`
   width: fill-available;
   width: stretch;
   position: relative;
-  &:hover ${ButtonContainer},
-  &:focus-within ${ButtonContainer} {
+  &:hover ${ButtonContainer}, &:focus-within ${ButtonContainer} {
     opacity: 1;
   }
   ${({ theme, $theme }) => {
@@ -106,7 +105,6 @@ const CodeContent = styled.code`
   font-family: inherit;
   color: inherit;
 `;
-
 
 export const CodeBlock = ({
   children,

--- a/src/components/CodeBlock/CodeBlock.tsx
+++ b/src/components/CodeBlock/CodeBlock.tsx
@@ -87,8 +87,11 @@ const CodeContent = styled.code`
 const ButtonContainer = styled.div`
   position: absolute;
   display: flex;
+  z-index: 1;
+  padding-left: 1rem;
+  background: inherit;
   ${({ theme }) => `
-    gap:  0.625rem;
+    gap: 0.625rem;
     top: ${theme.click.codeblock.space.y};
     right: ${theme.click.codeblock.space.x};
   `}

--- a/src/components/CodeBlock/CodeBlock.tsx
+++ b/src/components/CodeBlock/CodeBlock.tsx
@@ -55,8 +55,8 @@ const ButtonContainer = styled.div<{ $theme?: CodeThemeType }>`
       gap: 0.625rem;
       border-radius: ${theme.click.codeblock.radii.all};
       padding: ${theme.sizes[1]};
-      top: calc(${theme.click.codeblock.space.y} - ${theme.sizes[1]});
-      right: calc(${theme.click.codeblock.space.x} - ${theme.sizes[1]});
+      top: ${theme.click.codeblock.space.y};
+      right: ${theme.click.codeblock.space.x};
       background: color-mix(in srgb, ${bg} 90%, transparent);
     `;
   }}

--- a/src/components/CodeBlock/CodeBlock.tsx
+++ b/src/components/CodeBlock/CodeBlock.tsx
@@ -40,6 +40,25 @@ interface CustomRendererProps {
   useInlineStyles: boolean;
 }
 
+const ButtonContainer = styled.div<{ $theme?: CodeThemeType }>`
+  position: absolute;
+  display: flex;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  border-radius: 0.25rem;
+  padding: 0.25rem;
+  ${({ theme, $theme }) => {
+    const themeName = ($theme ?? theme.name) as CodeThemeType;
+    const bg = theme.click.codeblock[`${themeName}Mode`].color.background.default;
+    return `
+      gap: 0.625rem;
+      top: calc(${theme.click.codeblock.space.y} - 0.25rem);
+      right: calc(${theme.click.codeblock.space.x} - 0.25rem);
+      background: ${bg}e6;
+    `;
+  }}
+`;
+
 const CodeBlockContainer = styled.div<{ $theme?: CodeThemeType }>`
   width: 100%;
   width: -webkit-fill-available;
@@ -88,24 +107,6 @@ const CodeContent = styled.code`
   color: inherit;
 `;
 
-const ButtonContainer = styled.div<{ $theme?: CodeThemeType }>`
-  position: absolute;
-  display: flex;
-  opacity: 0;
-  transition: opacity 0.15s ease;
-  border-radius: 0.25rem;
-  padding: 0.25rem;
-  ${({ theme, $theme }) => {
-    const themeName = ($theme ?? theme.name) as CodeThemeType;
-    const bg = theme.click.codeblock[`${themeName}Mode`].color.background.default;
-    return `
-      gap: 0.625rem;
-      top: calc(${theme.click.codeblock.space.y} - 0.25rem);
-      right: calc(${theme.click.codeblock.space.x} - 0.25rem);
-      background: ${bg}e6;
-    `;
-  }}
-`;
 
 export const CodeBlock = ({
   children,

--- a/src/components/CodeBlock/CodeBlock.tsx
+++ b/src/components/CodeBlock/CodeBlock.tsx
@@ -45,16 +45,19 @@ const ButtonContainer = styled.div<{ $theme?: CodeThemeType }>`
   display: flex;
   opacity: 0;
   transition: opacity 0.15s ease;
-  border-radius: 0.25rem;
-  padding: 0.25rem;
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
   ${({ theme, $theme }) => {
     const themeName = ($theme ?? theme.name) as CodeThemeType;
     const bg = theme.click.codeblock[`${themeName}Mode`].color.background.default;
     return `
       gap: 0.625rem;
-      top: calc(${theme.click.codeblock.space.y} - 0.25rem);
-      right: calc(${theme.click.codeblock.space.x} - 0.25rem);
-      background: ${bg}e6;
+      border-radius: ${theme.click.codeblock.radii.all};
+      padding: ${theme.sizes[1]};
+      top: calc(${theme.click.codeblock.space.y} - ${theme.sizes[1]});
+      right: calc(${theme.click.codeblock.space.x} - ${theme.sizes[1]});
+      background: color-mix(in srgb, ${bg} 90%, transparent);
     `;
   }}
 `;

--- a/src/components/CodeBlock/CodeBlock.tsx
+++ b/src/components/CodeBlock/CodeBlock.tsx
@@ -40,12 +40,37 @@ interface CustomRendererProps {
   useInlineStyles: boolean;
 }
 
+const ButtonContainer = styled.div<{ $theme?: CodeThemeType }>`
+  position: absolute;
+  display: flex;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
+  ${({ theme, $theme }) => {
+    const themeName = ($theme ?? theme.name) as CodeThemeType;
+    const bg = theme.click.codeblock[`${themeName}Mode`].color.background.default;
+    return `
+      gap: ${theme.sizes[3]};
+      border-radius: ${theme.click.codeblock.radii.all};
+      padding: ${theme.sizes[2]};
+      top: ${theme.click.codeblock.space.y};
+      right: ${theme.click.codeblock.space.x};
+      background: color-mix(in srgb, ${bg} 90%, transparent);
+    `;
+  }}
+`;
+
 const CodeBlockContainer = styled.div<{ $theme?: CodeThemeType }>`
   width: 100%;
   width: -webkit-fill-available;
   width: fill-available;
   width: stretch;
   position: relative;
+  &:hover ${ButtonContainer}, &:focus-within ${ButtonContainer} {
+    opacity: 1;
+  }
   ${({ theme, $theme }) => {
     const themeName = theme.name as CodeThemeType;
 
@@ -82,16 +107,6 @@ const Highlighter = styled(SyntaxHighlighter)`
 const CodeContent = styled.code`
   font-family: inherit;
   color: inherit;
-`;
-
-const ButtonContainer = styled.div`
-  position: absolute;
-  display: flex;
-  ${({ theme }) => `
-    gap:  0.625rem;
-    top: ${theme.click.codeblock.space.y};
-    right: ${theme.click.codeblock.space.x};
-  `}
 `;
 
 export const CodeBlock = ({
@@ -140,13 +155,15 @@ export const CodeBlock = ({
       $theme={theme}
       {...props}
     >
-      <ButtonContainer>
+      <ButtonContainer $theme={theme}>
         {showWrapButton && (
           <CodeButton
             as={IconButton}
             $copied={false}
             $error={false}
             icon="document"
+            aria-label={wrap ? 'Disable line wrapping' : 'Wrap long lines'}
+            aria-pressed={wrap}
             onClick={wrapElement}
           />
         )}
@@ -155,6 +172,9 @@ export const CodeBlock = ({
           $copied={copied}
           $error={errorCopy}
           icon={copied ? 'check' : errorCopy ? 'warning' : 'copy'}
+          aria-label={
+            copied ? 'Code copied' : errorCopy ? 'Failed to copy code' : 'Copy code'
+          }
           onClick={copyCodeToClipboard}
         />
       </ButtonContainer>

--- a/src/components/CodeBlock/CodeBlock.tsx
+++ b/src/components/CodeBlock/CodeBlock.tsx
@@ -46,6 +46,10 @@ const CodeBlockContainer = styled.div<{ $theme?: CodeThemeType }>`
   width: fill-available;
   width: stretch;
   position: relative;
+  &:hover ${ButtonContainer},
+  &:focus-within ${ButtonContainer} {
+    opacity: 1;
+  }
   ${({ theme, $theme }) => {
     const themeName = theme.name as CodeThemeType;
 
@@ -84,17 +88,23 @@ const CodeContent = styled.code`
   color: inherit;
 `;
 
-const ButtonContainer = styled.div`
+const ButtonContainer = styled.div<{ $theme?: CodeThemeType }>`
   position: absolute;
   display: flex;
-  z-index: 1;
-  padding-left: 1rem;
-  background: inherit;
-  ${({ theme }) => `
-    gap: 0.625rem;
-    top: ${theme.click.codeblock.space.y};
-    right: ${theme.click.codeblock.space.x};
-  `}
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  border-radius: 0.25rem;
+  padding: 0.25rem;
+  ${({ theme, $theme }) => {
+    const themeName = ($theme ?? theme.name) as CodeThemeType;
+    const bg = theme.click.codeblock[`${themeName}Mode`].color.background.default;
+    return `
+      gap: 0.625rem;
+      top: calc(${theme.click.codeblock.space.y} - 0.25rem);
+      right: calc(${theme.click.codeblock.space.x} - 0.25rem);
+      background: ${bg}e6;
+    `;
+  }}
 `;
 
 export const CodeBlock = ({
@@ -143,7 +153,7 @@ export const CodeBlock = ({
       $theme={theme}
       {...props}
     >
-      <ButtonContainer>
+      <ButtonContainer $theme={theme}>
         {showWrapButton && (
           <CodeButton
             as={IconButton}

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -26,7 +26,19 @@ const iconButtonVariants = cva(styles.iconbutton, {
 });
 
 export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
-  ({ type = 'primary', htmlType, icon, size, disabled, className, ...props }, ref) => {
+  (
+    {
+      type = 'primary',
+      htmlType,
+      icon,
+      size,
+      disabled,
+      className,
+      'aria-label': ariaLabel,
+      ...props
+    },
+    ref
+  ) => {
     const iconName = icon ? icon.toString() : 'unknown icon';
 
     return (
@@ -37,7 +49,7 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
         disabled={disabled}
         ref={ref}
         role="button"
-        aria-label={iconName}
+        aria-label={ariaLabel ?? iconName}
       >
         <Icon
           name={icon}


### PR DESCRIPTION
## Why?

CodeBlock action buttons (copy, wrap lines) are positioned absolutely over the code content, causing text overlap on long first lines. This is especially noticeable when both buttons are visible.

## How?

- Buttons are now hidden by default (`opacity: 0`) and fade in on hover or `focus-within` (`opacity: 1` with `0.15s` ease transition)
- Buttons get a semi-opaque background pill matching the code block's theme background, so any code behind them is obscured when visible
- Small `border-radius` and `padding` on the button container for a clean pill appearance

## Contribution checklist?

- [x] You've done enough research before writing
- [x] You have reviewed the PR