### PR TITLE
fix(CardHorizontla): 🐛 button event bubbling (double onClick)

### DIFF
--- a/.changeset/fix-card-horizontal-double-click.md
+++ b/.changeset/fix-card-horizontal-double-click.md
@@ -1,0 +1,5 @@
+---
+"@clickhouse/click-ui": patch
+---
+
+Fix CardHorizontal double onClick handler bug where clicking the inner Button would invoke onButtonClick and window.open(infoUrl) twice due to event bubbling. Added e.stopPropagation() to the button's click handler.

--- a/.changeset/fix-card-horizontal-double-click.md
+++ b/.changeset/fix-card-horizontal-double-click.md
@@ -2,4 +2,4 @@
 "@clickhouse/click-ui": patch
 ---
 
-Fix CardHorizontal double onClick handler bug where clicking the inner Button would invoke onButtonClick and window.open(infoUrl) twice due to event bubbling. Added e.stopPropagation() to the button's click handler.
+Fix `CardHorizontal` double `onClick` handler bug where clicking the inner Button would invoke `onButtonClick` and window.open(infoUrl) twice due to event bubbling. Added e.stopPropagation() to the button's click handler.

--- a/src/components/CardHorizontal/CardHorizontal.test.tsx
+++ b/src/components/CardHorizontal/CardHorizontal.test.tsx
@@ -1,4 +1,5 @@
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { CardHorizontal, CardHorizontalProps } from '@/components/CardHorizontal';
 import { renderCUI } from '@/utils/test-utils';
 
@@ -186,5 +187,18 @@ describe('CardHorizontal Component', () => {
 
     expect(windowOpenSpy).not.toHaveBeenCalled();
     windowOpenSpy.mockRestore();
+  });
+
+  it('should call onButtonClick only once when inner button is clicked', async () => {
+    const onButtonClick = vitest.fn();
+    const { getByRole } = renderCard({
+      title: 'Test Card',
+      infoText: 'Click me',
+      onButtonClick,
+    });
+
+    await userEvent.click(getByRole('button'));
+
+    expect(onButtonClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/CardHorizontal/CardHorizontal.test.tsx
+++ b/src/components/CardHorizontal/CardHorizontal.test.tsx
@@ -201,4 +201,18 @@ describe('CardHorizontal Component', () => {
 
     expect(onButtonClick).toHaveBeenCalledTimes(1);
   });
+
+  it('should open infoUrl only once when inner button is clicked', async () => {
+    const windowOpenSpy = vitest.spyOn(window, 'open').mockImplementation(() => null);
+    const { getByRole } = renderCard({
+      title: 'Test Card',
+      infoText: 'Click me',
+      infoUrl: 'https://example.com',
+    });
+
+    await userEvent.click(getByRole('button'));
+
+    expect(windowOpenSpy).toHaveBeenCalledTimes(1);
+    windowOpenSpy.mockRestore();
+  });
 });

--- a/src/components/CardHorizontal/CardHorizontal.tsx
+++ b/src/components/CardHorizontal/CardHorizontal.tsx
@@ -209,7 +209,7 @@ export const CardHorizontal = ({
     }
   };
 
-  const onClickButtonHandler = (e: React.MouseEvent<HTMLElement>) => {
+  const handleButtonClick = (e: React.MouseEvent<HTMLElement>) => {
     e.stopPropagation();
     handleClick(e);
   };
@@ -285,7 +285,7 @@ export const CardHorizontal = ({
           >
             <Button
               label={infoText}
-              onClick={onClickButtonHandler}
+              onClick={handleButtonClick}
               disabled={disabled}
               fillWidth
             />

--- a/src/components/CardHorizontal/CardHorizontal.tsx
+++ b/src/components/CardHorizontal/CardHorizontal.tsx
@@ -208,6 +208,11 @@ export const CardHorizontal = ({
       window.open(infoUrl, '_blank');
     }
   };
+
+  const onClickButtonHandler = (e: React.MouseEvent<HTMLElement>) => {
+    e.stopPropagation();
+    handleClick(e);
+  };
   return (
     <Wrapper
       $disabled={disabled}
@@ -280,7 +285,7 @@ export const CardHorizontal = ({
           >
             <Button
               label={infoText}
-              onClick={handleClick}
+              onClick={onClickButtonHandler}
               disabled={disabled}
               fillWidth
             />

--- a/src/components/CardHorizontal/CardHorizontal.tsx
+++ b/src/components/CardHorizontal/CardHorizontal.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { styled } from 'styled-components';
 import { Badge } from '@/components/Badge';
 import { Button } from '@/components/Button';
@@ -195,24 +196,30 @@ export const CardHorizontal = ({
   onButtonClick,
   ...props
 }: CardHorizontalProps) => {
-  const handleClick = (e: React.MouseEvent<HTMLElement>) => {
-    if (disabled) {
-      e.preventDefault();
-      return;
-    }
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLElement>) => {
+      if (disabled) {
+        e.preventDefault();
+        return;
+      }
 
-    if (typeof onButtonClick === 'function') {
-      onButtonClick(e);
-    }
-    if (infoUrl && infoUrl.length > 0) {
-      window.open(infoUrl, '_blank');
-    }
-  };
+      if (typeof onButtonClick === 'function') {
+        onButtonClick(e);
+      }
+      if (infoUrl && infoUrl.length > 0) {
+        window.open(infoUrl, '_blank');
+      }
+    },
+    [disabled, onButtonClick, infoUrl]
+  );
 
-  const handleButtonClick = (e: React.MouseEvent<HTMLElement>) => {
-    e.stopPropagation();
-    handleClick(e);
-  };
+  const handleButtonClick = useCallback(
+    (e: React.MouseEvent<HTMLElement>) => {
+      e.stopPropagation();
+      handleClick(e);
+    },
+    [handleClick]
+  );
   return (
     <Wrapper
       $disabled={disabled}

--- a/src/components/CardHorizontal/CardHorizontal.tsx
+++ b/src/components/CardHorizontal/CardHorizontal.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, type MouseEvent } from 'react';
 import { styled } from 'styled-components';
 import { Badge } from '@/components/Badge';
 import { Button } from '@/components/Button';
@@ -197,7 +197,7 @@ export const CardHorizontal = ({
   ...props
 }: CardHorizontalProps) => {
   const handleClick = useCallback(
-    (e: React.MouseEvent<HTMLElement>) => {
+    (e: MouseEvent<HTMLElement>) => {
       if (disabled) {
         e.preventDefault();
         return;
@@ -214,7 +214,7 @@ export const CardHorizontal = ({
   );
 
   const handleButtonClick = useCallback(
-    (e: React.MouseEvent<HTMLElement>) => {
+    (e: MouseEvent<HTMLElement>) => {
       e.stopPropagation();
       handleClick(e);
     },


### PR DESCRIPTION
## Why?

To fix `CardHorizontal` double `onClick` handler bug, where clicking the inner Button would invoke `onButtonClick` and window.open(infoUrl) twice due to event bubbling. Fixed by adding event stop propagation method to the button's click handler.

## How?

- Created a handler
- Add e.stopPropagation()
- Call original

## Tickets?

N/A

## Contribution checklist?

- [ ] You've done enough research before writing
- [x] You have reviewed the PR
- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] For documentation, guides or references, you've tested the commands

## Preview?

N/A