### PR TITLE
fix(vercel-cli): 🐛 pin version to prevent broken @vercel/hono dependency install

### DIFF
--- a/.github/workflows/storybook-vercel.yml
+++ b/.github/workflows/storybook-vercel.yml
@@ -47,7 +47,7 @@ jobs:
         run: yarn install --immutable
 
       - name: Install Vercel CLI
-        run: npm install --global vercel@latest
+        run: npm install --global vercel@41.7.3
 
       - name: Build Storybook
         run: yarn storybook:build

--- a/.github/workflows/storybook-vercel.yml
+++ b/.github/workflows/storybook-vercel.yml
@@ -47,6 +47,7 @@ jobs:
         run: yarn install --immutable
 
       - name: Install Vercel CLI
+        # NOTE: Pinned to avoid broken @vercel/hono@0.2.67 dep in newer versions can revisit when Vercel publishes a fix
         run: npm install --global vercel@41.7.3
 
       - name: Build Storybook


### PR DESCRIPTION
## Why?

NPM is trying to fetch @vercel/hono@0.2.67.tgz from the npm registry, but that version doesn't exist. The latest published version of @vercel/hono on npm is 0.2.64, published about 16 hours ago. [npm](https://www.npmjs.com/package/@vercel/hono) Version 0.2.67 was never actually published to the registry, but the latest vercel CLI package declared it as a dependency.

## How?

- Verified NPM registry
- Declare fixed version in CI/CD where the issue originally occurs

## Tickets?

N/A

## Contribution checklist?

- [x] You've done enough research before writing
- [x] You have reviewed the PR
- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] For documentation, guides or references, you've tested the commands

## Security checklist?

- [ ] All user inputs are validated and sanitized
- [ ] No usage of `dangerouslySetInnerHTML`
- [ ] Sensitive data has been identified and is being protected properly
- [x] Build output contains no secrets or API keys

## Preview?

```
❯ npm view vercel@latest dependencies

{
  ...
  '@vercel/hono': '0.2.67',
  ...
}
```