### PR TITLE
feat(datetimerangepicker): fix background transparency; allow setting default date tab

### DIFF
--- a/.changeset/wet-monkeys-ring.md
+++ b/.changeset/wet-monkeys-ring.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': minor
+---
+
+Adds the ability to set a default date tab between startDate and endDate (defaults to startDate)

--- a/src/components/DatePicker/Common.tsx
+++ b/src/components/DatePicker/Common.tsx
@@ -25,21 +25,19 @@ import { getMonthNames, DAYS, MONTHS, YEARS, DAYS_IN_WEEK } from '@/utils/date';
 import { Dropdown } from '@/components/Dropdown';
 
 const explicitWidth = '250px';
-const TXT_ON_MONTH_SELECT = 'Month';
-const TXT_ON_YEAR_SELECT = 'Year';
 
-const VIEW_GRID_MONTHS = {
+const viewGridMonths = {
   columns: 4,
   rows: 3,
 } as const;
 
-const VIEW_GRID_YEARS = {
+const viewGridYears = {
   columns: 3,
   rows: 3,
 } as const;
 
-const VIEW_TOTAL_YEARS = VIEW_GRID_YEARS.columns * VIEW_GRID_YEARS.rows;
-const VIEW_NAVIGATION_OFFSET_YEARS = Math.floor(VIEW_TOTAL_YEARS / 2);
+const totalYears = viewGridYears.columns * viewGridYears.rows;
+const yearsOffset = Math.floor(totalYears / 2);
 
 const HighlightedInputWrapper = styled(InputWrapper)<{
   $isActive: boolean;
@@ -299,18 +297,18 @@ const DatePickerContainer = styled(Container)`
 `;
 
 const ClickableTitle = styled.button`
+  background: transparent;
+  border: 1px solid transparent;
+  cursor: pointer;
+  outline: none;
+  padding: 0.25rem 0.5rem;
+  user-select: none;
+
   ${({ theme }) => `
+    border-radius: ${theme.click.datePicker.dateOption.radii.default};
     color: ${theme.click.datePicker.color.title.default};
     font: ${theme.click.datePicker.typography.title.default};
-    border: 1px solid transparent;
-  `}
-
-  background: transparent;
-  cursor: pointer;
-  user-select: none;
-  padding: 0.25rem 0.5rem;
-  border-radius: ${({ theme }) => theme.click.datePicker.dateOption.radii.default};
-  outline: none;
+  `};
 
   &:hover {
     background: ${({ theme }) =>
@@ -324,14 +322,14 @@ const ClickableTitle = styled.button`
 `;
 
 const UnselectableTitle = styled.h2`
+  margin: 0;
+  padding: 0;
+  user-select: none;
+
   ${({ theme }) => `
     color: ${theme.click.datePicker.color.title.default};
     font: ${theme.click.datePicker.typography.title.default};
   `}
-
-  margin: 0;
-  padding: 0;
-  user-select: none;
 `;
 
 const GridContainer = styled.div`
@@ -344,22 +342,30 @@ const GridContainer = styled.div`
 `;
 
 const MonthsGrid = styled(GridContainer)`
-  grid-template-columns: repeat(${VIEW_GRID_MONTHS.columns}, 1fr);
-  grid-template-rows: repeat(${VIEW_GRID_MONTHS.rows}, 1fr);
+  grid-template-columns: repeat(${viewGridMonths.columns}, 1fr);
+  grid-template-rows: repeat(${viewGridMonths.rows}, 1fr);
 `;
 
 const YearsGrid = styled(GridContainer)`
-  grid-template-columns: repeat(${VIEW_GRID_YEARS.columns}, 1fr);
-  grid-template-rows: repeat(${VIEW_GRID_YEARS.rows}, 1fr);
+  grid-template-columns: repeat(${viewGridYears.columns}, 1fr);
+  grid-template-rows: repeat(${viewGridYears.rows}, 1fr);
 `;
 
 const GridCell = styled.button<{ $isActive?: boolean; $isPresent?: boolean }>`
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  min-height: 26px;
+  padding: 8px 4px;
+  text-align: center;
+
   ${({ theme }) => `
+    background: ${theme.click.datePicker.dateOption.color.background.default};
     border: ${theme.click.datePicker.dateOption.stroke} solid ${theme.click.datePicker.dateOption.color.stroke.default};
     border-radius: ${theme.click.datePicker.dateOption.radii.default};
-    font: ${theme.click.datePicker.dateOption.typography.label.default};
     color: ${theme.click.datePicker.dateOption.color.label.default};
-    background: ${theme.click.datePicker.dateOption.color.background.default};
+    font: ${theme.click.datePicker.dateOption.typography.label.default};
   `}
 
   ${({ $isActive, theme }) =>
@@ -373,14 +379,6 @@ const GridCell = styled.button<{ $isActive?: boolean; $isPresent?: boolean }>`
     $isPresent &&
     !$isActive &&
     `background: ${theme.click.datePicker.dateOption.color.background.range};`}
-
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 8px 4px;
-  cursor: pointer;
-  text-align: center;
-  min-height: 26px;
 
   ${({ theme }) => `
     &:hover {
@@ -596,7 +594,7 @@ export const CalendarRenderer = ({
   const [selectedYear, setSelectedYear] = useState<number | null>(null);
   const [yearOffset, setYearOffset] = useState(0);
   const [focusedMonthIndex, setFocusedMonthIndex] = useState(month);
-  const [focusedYearIndex, setFocusedYearIndex] = useState(VIEW_NAVIGATION_OFFSET_YEARS);
+  const [focusedYearIndex, setFocusedYearIndex] = useState(yearsOffset);
 
   const monthGridRef = useRef<Array<HTMLButtonElement | null>>([]);
   const yearGridRef = useRef<Array<HTMLButtonElement | null>>([]);
@@ -612,7 +610,7 @@ export const CalendarRenderer = ({
 
   const onNextClick = useCallback(() => {
     if (view === YEARS) {
-      setYearOffset(prev => prev + VIEW_TOTAL_YEARS);
+      setYearOffset(prev => prev + totalYears);
     } else {
       navigation.toNext();
     }
@@ -620,7 +618,7 @@ export const CalendarRenderer = ({
 
   const onPreviousClick = useCallback(() => {
     if (view === YEARS) {
-      setYearOffset(prev => prev - VIEW_TOTAL_YEARS);
+      setYearOffset(prev => prev - totalYears);
       return;
     }
 
@@ -689,7 +687,7 @@ export const CalendarRenderer = ({
 
   const onMonthGridKeyDown = useCallback(
     (e: KeyboardEvent<HTMLButtonElement>, index: number) => {
-      const columns = VIEW_GRID_MONTHS.columns;
+      const columns = viewGridMonths.columns;
       const totalItems = 12;
       let newIndex = index;
 
@@ -727,8 +725,8 @@ export const CalendarRenderer = ({
 
   const onYearGridKeyDown = useCallback(
     (e: KeyboardEvent<HTMLButtonElement>, index: number, yearValue: number) => {
-      const columns = VIEW_GRID_YEARS.columns;
-      const totalItems = VIEW_TOTAL_YEARS;
+      const columns = viewGridYears.columns;
+      const totalItems = totalYears;
       let newIndex = index;
 
       switch (e.key) {
@@ -769,11 +767,11 @@ export const CalendarRenderer = ({
 
   const getHeaderTitle = (view: DateViewOption) => {
     if (view === MONTHS) {
-      return TXT_ON_MONTH_SELECT;
+      return 'Month';
     }
 
     if (view === YEARS) {
-      return TXT_ON_YEAR_SELECT;
+      return 'Year';
     }
 
     return headerDateFormatter.format(headerDate);
@@ -820,7 +818,7 @@ export const CalendarRenderer = ({
     const todayYear = new Date().getFullYear();
     const selectedYear = selectedDate?.getFullYear();
 
-    for (let i = -VIEW_NAVIGATION_OFFSET_YEARS; i <= VIEW_NAVIGATION_OFFSET_YEARS; i++) {
+    for (let i = -yearsOffset; i <= yearsOffset; i++) {
       years.push(baseYear + i);
     }
 

--- a/src/components/DatePicker/DateTimeRangePicker.stories.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.stories.tsx
@@ -244,3 +244,30 @@ export const DateTimeFutureStartDatesDisabled: Story = {
     predefinedTimesList: [],
   },
 };
+
+export const DefaultActiveTabEndDate: Story = {
+  args: {
+    maxRangeLength: 15,
+    predefinedTimesList: [],
+  },
+  render: (args: Args) => {
+    const endDate = args.endDate ? new Date(args.endDate) : undefined;
+    const startDate = args.startDate ? new Date(args.startDate) : undefined;
+
+    return (
+      <DateTimeRangePicker
+        key="default"
+        defaultActiveTab="endDate"
+        disabled={args.disabled}
+        endDate={endDate}
+        futureDatesDisabled={args.futureDatesDisabled}
+        futureStartDatesDisabled={args.futureStartDatesDisabled}
+        maxRangeLength={args.maxRangeLength}
+        onSelectDateRange={args.onSelectDateRange}
+        placeholder={args.placeholder}
+        startDate={startDate}
+        shouldShowSeconds={args.shouldShowSeconds}
+      />
+    );
+  },
+};

--- a/src/components/DatePicker/DateTimeRangePicker.test.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.test.tsx
@@ -529,6 +529,107 @@ describe('DateTimeRangePicker', () => {
         'active'
       );
     });
+
+    describe('useEffect syncing defaultActiveTab', () => {
+      it('updates the active tab when defaultActiveTab prop changes after mount', async () => {
+        const handleSelectDate = vi.fn();
+
+        const { getByTestId, rerender } = renderCUI(
+          <DateTimeRangePicker
+            defaultActiveTab="startDate"
+            onSelectDateRange={handleSelectDate}
+          />
+        );
+
+        await userEvent.click(getByTestId('datetimepicker-input'));
+
+        expect(getByTestId('tabbed-calendar-trigger-start')).toHaveAttribute(
+          'data-state',
+          'active'
+        );
+
+        rerender(
+          <DateTimeRangePicker
+            defaultActiveTab="endDate"
+            onSelectDateRange={handleSelectDate}
+          />
+        );
+
+        expect(getByTestId('tabbed-calendar-trigger-end')).toHaveAttribute(
+          'data-state',
+          'active'
+        );
+        expect(getByTestId('tabbed-calendar-trigger-start')).toHaveAttribute(
+          'data-state',
+          'inactive'
+        );
+      });
+
+      it('preserves the user-selected tab when defaultActiveTab prop changes', async () => {
+        const handleSelectDate = vi.fn();
+
+        const { getByTestId, rerender } = renderCUI(
+          <DateTimeRangePicker
+            defaultActiveTab="startDate"
+            onSelectDateRange={handleSelectDate}
+          />
+        );
+
+        await userEvent.click(getByTestId('datetimepicker-input'));
+        await userEvent.click(getByTestId('tabbed-calendar-trigger-end'));
+
+        expect(getByTestId('tabbed-calendar-trigger-end')).toHaveAttribute(
+          'data-state',
+          'active'
+        );
+
+        rerender(
+          <DateTimeRangePicker
+            defaultActiveTab="startDate"
+            onSelectDateRange={handleSelectDate}
+          />
+        );
+
+        expect(getByTestId('tabbed-calendar-trigger-end')).toHaveAttribute(
+          'data-state',
+          'active'
+        );
+        expect(getByTestId('tabbed-calendar-trigger-start')).toHaveAttribute(
+          'data-state',
+          'inactive'
+        );
+      });
+
+      it('keeps the active tab stable when defaultActiveTab prop is set to the same value', async () => {
+        const handleSelectDate = vi.fn();
+
+        const { getByTestId, rerender } = renderCUI(
+          <DateTimeRangePicker
+            defaultActiveTab="endDate"
+            onSelectDateRange={handleSelectDate}
+          />
+        );
+
+        await userEvent.click(getByTestId('datetimepicker-input'));
+
+        expect(getByTestId('tabbed-calendar-trigger-end')).toHaveAttribute(
+          'data-state',
+          'active'
+        );
+
+        rerender(
+          <DateTimeRangePicker
+            defaultActiveTab="endDate"
+            onSelectDateRange={handleSelectDate}
+          />
+        );
+
+        expect(getByTestId('tabbed-calendar-trigger-end')).toHaveAttribute(
+          'data-state',
+          'active'
+        );
+      });
+    });
   });
 
   describe('predefined times', () => {

--- a/src/components/DatePicker/DateTimeRangePicker.test.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.test.tsx
@@ -396,6 +396,141 @@ describe('DateTimeRangePicker', () => {
     });
   });
 
+  describe('setting a default acttive tab', () => {
+    beforeEach(() => {
+      vi.setSystemTime(new Date('07-04-2020 11:30 AM'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('defaults to start date tab when not provided', async () => {
+      const handleSelectDate = vi.fn();
+
+      const { getByTestId } = renderCUI(
+        <DateTimeRangePicker onSelectDateRange={handleSelectDate} />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+
+      expect(getByTestId('tabbed-calendar-trigger-start')).toHaveAttribute(
+        'data-state',
+        'active'
+      );
+      expect(getByTestId('tabbed-calendar-trigger-end')).toHaveAttribute(
+        'data-state',
+        'inactive'
+      );
+    });
+
+    it('activates the start date tab when defaultActiveTab="startDate"', async () => {
+      const handleSelectDate = vi.fn();
+
+      const { getByTestId } = renderCUI(
+        <DateTimeRangePicker
+          defaultActiveTab="startDate"
+          onSelectDateRange={handleSelectDate}
+        />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+
+      expect(getByTestId('tabbed-calendar-trigger-start')).toHaveAttribute(
+        'data-state',
+        'active'
+      );
+      expect(getByTestId('tabbed-calendar-trigger-end')).toHaveAttribute(
+        'data-state',
+        'inactive'
+      );
+    });
+
+    it('activates the end date tab when defaultActiveTab="endDate"', async () => {
+      const handleSelectDate = vi.fn();
+
+      const { getByTestId } = renderCUI(
+        <DateTimeRangePicker
+          defaultActiveTab="endDate"
+          onSelectDateRange={handleSelectDate}
+        />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+
+      expect(getByTestId('tabbed-calendar-trigger-end')).toHaveAttribute(
+        'data-state',
+        'active'
+      );
+      expect(getByTestId('tabbed-calendar-trigger-start')).toHaveAttribute(
+        'data-state',
+        'inactive'
+      );
+    });
+
+    it('applies the clicked date to the end date when defaultActiveTab="endDate"', async () => {
+      const handleSelectDate = vi.fn();
+
+      const { getByTestId, getByText } = renderCUI(
+        <DateTimeRangePicker
+          defaultActiveTab="endDate"
+          onSelectDateRange={handleSelectDate}
+        />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+      await userEvent.click(getByText('15'));
+
+      expect(getByTestId('datetimepicker-input').textContent).toBe(
+        'start date – Jul 15, 12:00 pm'
+      );
+    });
+
+    it('allows switching tabs after opening with defaultActiveTab="endDate"', async () => {
+      const handleSelectDate = vi.fn();
+
+      const { getByTestId } = renderCUI(
+        <DateTimeRangePicker
+          defaultActiveTab="endDate"
+          onSelectDateRange={handleSelectDate}
+        />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+      await userEvent.click(getByTestId('tabbed-calendar-trigger-start'));
+
+      expect(getByTestId('tabbed-calendar-trigger-start')).toHaveAttribute(
+        'data-state',
+        'active'
+      );
+      expect(getByTestId('tabbed-calendar-trigger-end')).toHaveAttribute(
+        'data-state',
+        'inactive'
+      );
+    });
+
+    it('honors defaultActiveTab when rendered alongside a predefinedTimesList', async () => {
+      const handleSelectDate = vi.fn();
+      const predefinedTimesList = getPredefinedTimePeriodsForDateTimePicker();
+
+      const { getByTestId, getByText } = renderCUI(
+        <DateTimeRangePicker
+          defaultActiveTab="endDate"
+          onSelectDateRange={handleSelectDate}
+          predefinedTimesList={predefinedTimesList}
+        />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+      await userEvent.click(getByText('Since a specific date and time'));
+
+      expect(getByTestId('tabbed-calendar-trigger-end')).toHaveAttribute(
+        'data-state',
+        'active'
+      );
+    });
+  });
+
   describe('predefined times', () => {
     beforeEach(() => {
       vi.setSystemTime(new Date('07-04-2020 11:30 AM'));

--- a/src/components/DatePicker/DateTimeRangePicker.test.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.test.tsx
@@ -396,7 +396,7 @@ describe('DateTimeRangePicker', () => {
     });
   });
 
-  describe('setting a default acttive tab', () => {
+  describe('setting a default active tab', () => {
     beforeEach(() => {
       vi.setSystemTime(new Date('07-04-2020 11:30 AM'));
     });
@@ -565,7 +565,7 @@ describe('DateTimeRangePicker', () => {
         );
       });
 
-      it('preserves the user-selected tab when defaultActiveTab prop changes', async () => {
+      it('preserves user-selected tab when defaultActiveTab is re-rendered with the same value', async () => {
         const handleSelectDate = vi.fn();
 
         const { getByTestId, rerender } = renderCUI(
@@ -629,6 +629,101 @@ describe('DateTimeRangePicker', () => {
           'active'
         );
       });
+    });
+  });
+
+  describe('closing the date picker on selecting a date range', () => {
+    beforeEach(() => {
+      vi.setSystemTime(new Date('07-04-2020 11:30 AM'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('keeps the picker open by default once both start and end dates are selected', async () => {
+      const handleSelectDate = vi.fn();
+
+      const { getByTestId, getByText, queryByTestId } = renderCUI(
+        <DateTimeRangePicker onSelectDateRange={handleSelectDate} />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+
+      await userEvent.click(getByText('4'));
+      await userEvent.click(getByTestId('tabbed-calendar-trigger-end'));
+      await userEvent.click(getByText('10'));
+
+      expect(handleSelectDate).toHaveBeenCalledOnce();
+      expect(queryByTestId('datepicker-calendar-container')).toBeVisible();
+    });
+
+    it('closes the picker when closeOnDateRangeSelected is true and both dates are selected', async () => {
+      const handleSelectDate = vi.fn();
+
+      const { getByTestId, getByText, queryByTestId } = renderCUI(
+        <DateTimeRangePicker
+          closeOnDateRangeSelected
+          onSelectDateRange={handleSelectDate}
+        />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+
+      await userEvent.click(getByText('4'));
+      await userEvent.click(getByTestId('tabbed-calendar-trigger-end'));
+      await userEvent.click(getByText('10'));
+
+      expect(queryByTestId('datepicker-calendar-container')).not.toBeInTheDocument();
+    });
+
+    it('closes the picker when closeOnDateRangeSelected is true and start date is selected after end date', async () => {
+      const handleSelectDate = vi.fn();
+
+      const { getByTestId, getByText, queryByTestId } = renderCUI(
+        <DateTimeRangePicker
+          closeOnDateRangeSelected
+          onSelectDateRange={handleSelectDate}
+        />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+
+      await userEvent.click(getByTestId('tabbed-calendar-trigger-end'));
+      await userEvent.click(getByText('10'));
+      await userEvent.click(getByTestId('tabbed-calendar-trigger-start'));
+      await userEvent.click(getByText('4'));
+
+      expect(queryByTestId('datepicker-calendar-container')).not.toBeInTheDocument();
+    });
+
+    it('keeps the picker open when only the start date has been selected', async () => {
+      const handleSelectDate = vi.fn();
+
+      const { getByTestId, getByText, queryByTestId } = renderCUI(
+        <DateTimeRangePicker onSelectDateRange={handleSelectDate} />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+      await userEvent.click(getByText('4'));
+
+      expect(handleSelectDate).not.toHaveBeenCalled();
+      expect(queryByTestId('datepicker-calendar-container')).toBeVisible();
+    });
+
+    it('keeps the picker open when only the end date has been selected', async () => {
+      const handleSelectDate = vi.fn();
+
+      const { getByTestId, getByText, queryByTestId } = renderCUI(
+        <DateTimeRangePicker onSelectDateRange={handleSelectDate} />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+      await userEvent.click(getByTestId('tabbed-calendar-trigger-end'));
+      await userEvent.click(getByText('10'));
+
+      expect(handleSelectDate).not.toHaveBeenCalled();
+      expect(queryByTestId('datepicker-calendar-container')).toBeVisible();
     });
   });
 

--- a/src/components/DatePicker/DateTimeRangePicker.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.tsx
@@ -378,10 +378,6 @@ const parseTimeString = (
     return { isValid: false };
   }
 
-  if (!parsedDate.isValid()) {
-    return { isValid: false };
-  }
-
   return { isValid: true, parsedDate };
 };
 
@@ -600,9 +596,7 @@ const TabbedCalendar = ({
   const [activeTab, setActiveTab] = useState<Tab>(defaultActiveTab);
 
   useEffect(() => {
-    if (activeTab !== defaultActiveTab) {
-      setActiveTab(activeTab);
-    }
+    setActiveTab(defaultActiveTab);
   }, [defaultActiveTab]);
 
   const handleTabChange = useCallback((newTab: string) => {

--- a/src/components/DatePicker/DateTimeRangePicker.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.tsx
@@ -99,7 +99,6 @@ type SetDate = (date: Date) => void;
 interface CalendarProps {
   calendarBody: Body;
   calendarType: CalendarType;
-  closeDatePicker?: () => void;
   futureDatesDisabled: boolean;
   futureStartDatesDisabled: boolean;
   maxRangeLength: number;
@@ -564,10 +563,9 @@ const TimeInput = ({ date, setDate, shouldShowSeconds }: TimeInputProps) => {
   );
 };
 
-type Tab = 'startDate' | 'endDate';
+export type Tab = 'startDate' | 'endDate';
 
 interface TabbedCalendarProps {
-  closeDatePicker: () => void;
   defaultActiveTab?: Tab;
   endDate: Date | undefined;
   futureDatesDisabled: boolean;
@@ -581,7 +579,6 @@ interface TabbedCalendarProps {
 }
 
 const TabbedCalendar = ({
-  closeDatePicker,
   defaultActiveTab = 'startDate',
   endDate,
   futureDatesDisabled,
@@ -659,7 +656,6 @@ const TabbedCalendar = ({
             <Calendar
               calendarBody={body}
               calendarType="startDate"
-              closeDatePicker={closeDatePicker}
               endDate={endDate}
               futureDatesDisabled={futureDatesDisabled}
               futureStartDatesDisabled={futureStartDatesDisabled}
@@ -681,7 +677,6 @@ const TabbedCalendar = ({
             <Calendar
               calendarBody={body}
               calendarType="endDate"
-              closeDatePicker={closeDatePicker}
               endDate={endDate}
               futureDatesDisabled={futureDatesDisabled}
               futureStartDatesDisabled={futureStartDatesDisabled}
@@ -702,6 +697,7 @@ const TabbedCalendar = ({
 };
 
 export interface DateTimeRangePickerProps {
+  closeOnDateRangeSelected?: boolean;
   defaultActiveTab?: Tab;
   disabled?: boolean;
   endDate?: Date;
@@ -717,6 +713,7 @@ export interface DateTimeRangePickerProps {
 }
 
 export const DateTimeRangePicker = ({
+  closeOnDateRangeSelected = false,
   defaultActiveTab,
   disabled = false,
   endDate,
@@ -796,6 +793,10 @@ export const DateTimeRangePicker = ({
 
         if (selectedEndDate) {
           onSelectDateRange(selectedDate, selectedEndDate);
+
+          if (closeOnDateRangeSelected) {
+            closeDatePicker();
+          }
         }
       }
 
@@ -804,6 +805,10 @@ export const DateTimeRangePicker = ({
 
         if (selectedStartDate) {
           onSelectDateRange(selectedStartDate, selectedDate);
+
+          if (closeOnDateRangeSelected) {
+            closeDatePicker();
+          }
         }
       }
     },
@@ -864,7 +869,6 @@ export const DateTimeRangePicker = ({
                   ref={calendarContainerRef}
                 >
                   <TabbedCalendar
-                    closeDatePicker={closeDatePicker}
                     defaultActiveTab={defaultActiveTab}
                     endDate={selectedEndDate}
                     futureDatesDisabled={futureDatesDisabled}
@@ -882,7 +886,6 @@ export const DateTimeRangePicker = ({
           ) : (
             <>
               <TabbedCalendar
-                closeDatePicker={closeDatePicker}
                 defaultActiveTab={defaultActiveTab}
                 endDate={selectedEndDate}
                 futureDatesDisabled={futureDatesDisabled}

--- a/src/components/DatePicker/DateTimeRangePicker.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.tsx
@@ -44,6 +44,8 @@ type OpenDirection = 'left' | 'right';
 
 // left value of 259px is the width of the PredefinedTimesContainer + 1 pixel for border
 const CalendarRendererContainer = styled.div<{ $openDirection?: OpenDirection }>`
+  background: ${({ theme }) =>
+    `${theme.click.datePicker.dateOption.color.background.default}`};
   border: ${({ theme }) =>
     `${theme.click.datePicker.dateOption.stroke} solid ${theme.click.datePicker.dateOption.color.background.range}`};
   border-radius: ${({ theme }) => theme.click.datePicker.dateOption.radii.default};
@@ -570,6 +572,7 @@ type Tab = 'startDate' | 'endDate';
 
 interface TabbedCalendarProps {
   closeDatePicker: () => void;
+  defaultActiveTab?: Tab;
   endDate: Date | undefined;
   futureDatesDisabled: boolean;
   futureStartDatesDisabled: boolean;
@@ -583,6 +586,7 @@ interface TabbedCalendarProps {
 
 const TabbedCalendar = ({
   closeDatePicker,
+  defaultActiveTab = 'startDate',
   endDate,
   futureDatesDisabled,
   futureStartDatesDisabled,
@@ -593,7 +597,13 @@ const TabbedCalendar = ({
   shouldShowSeconds,
   startDate,
 }: TabbedCalendarProps) => {
-  const [activeTab, setActiveTab] = useState<Tab>('startDate');
+  const [activeTab, setActiveTab] = useState<Tab>(defaultActiveTab);
+
+  useEffect(() => {
+    if (activeTab !== defaultActiveTab) {
+      setActiveTab(activeTab);
+    }
+  }, [defaultActiveTab]);
 
   const handleTabChange = useCallback((newTab: string) => {
     setActiveTab(newTab as Tab);
@@ -698,8 +708,9 @@ const TabbedCalendar = ({
 };
 
 export interface DateTimeRangePickerProps {
-  endDate?: Date;
+  defaultActiveTab?: Tab;
   disabled?: boolean;
+  endDate?: Date;
   futureDatesDisabled?: boolean;
   futureStartDatesDisabled?: boolean;
   onSelectDateRange: (selectedStartDate: Date, selectedEndDate: Date) => void;
@@ -712,9 +723,9 @@ export interface DateTimeRangePickerProps {
 }
 
 export const DateTimeRangePicker = ({
-  endDate,
-  startDate,
+  defaultActiveTab,
   disabled = false,
+  endDate,
   futureDatesDisabled = false,
   futureStartDatesDisabled = false,
   maxRangeLength = -1,
@@ -723,6 +734,7 @@ export const DateTimeRangePicker = ({
   placeholder = 'start date – end date',
   predefinedTimesList,
   shouldShowSeconds,
+  startDate,
 }: DateTimeRangePickerProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [selectedStartDate, setSelectedStartDate] = useState<Date>();
@@ -859,6 +871,7 @@ export const DateTimeRangePicker = ({
                 >
                   <TabbedCalendar
                     closeDatePicker={closeDatePicker}
+                    defaultActiveTab={defaultActiveTab}
                     endDate={selectedEndDate}
                     futureDatesDisabled={futureDatesDisabled}
                     futureStartDatesDisabled={futureStartDatesDisabled}
@@ -876,6 +889,7 @@ export const DateTimeRangePicker = ({
             <>
               <TabbedCalendar
                 closeDatePicker={closeDatePicker}
+                defaultActiveTab={defaultActiveTab}
                 endDate={selectedEndDate}
                 futureDatesDisabled={futureDatesDisabled}
                 futureStartDatesDisabled={futureStartDatesDisabled}

--- a/src/components/DatePicker/index.ts
+++ b/src/components/DatePicker/index.ts
@@ -4,4 +4,4 @@ export { DateTimeRangePicker } from './DateTimeRangePicker';
 
 export type { DatePickerProps } from './DatePicker.types';
 export type { DateRangePickerProps } from './DateRangePicker';
-export type { DateTimeRangePickerProps } from './DateTimeRangePicker';
+export type { DateTimeRangePickerProps, Tab } from './DateTimeRangePicker';


### PR DESCRIPTION
- When testing `DateTimeRangePicker` in an app, the background was transparent, which isn't apparent in the storybook. This fixes that.

- This also adds the ability to set the default date tab to `startDate` or `endDate` for instances where picked dates will be in the past

- Cleans up some of the common code as well