### PR TITLE
chore(publish.yml): remove upgrading npm step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,10 +79,6 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: '22.x'  # Node 22 includes npm >= 11.5.1 with OIDC support
-      - name: Upgrade npm for OIDC support
-        run: |
-          npm install -g npm@latest
-          echo "npm version: $(npm --version)"
       - name: Enable Corepack
         run: corepack enable
       - name: Install dependencies


### PR DESCRIPTION
We're trying to fix publishing to npm