### PR TITLE
fix(datetimerangepicker): allow selecting end dates in the past when end and start date are selected

### DIFF
--- a/.changeset/fine-impalas-sing.md
+++ b/.changeset/fine-impalas-sing.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': patch
+---
+
+Fixes a bug in DateTimeRangePicker that does't allow setting the end date when start date and end date are set

--- a/src/components/DatePicker/DateTimeRangePicker.stories.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.stories.tsx
@@ -238,6 +238,37 @@ export const DateTimeWithMaxRange: Story = {
   },
 };
 
+export const SetStartAndEndDate: Story = {
+  args: {
+    maxRangeLength: 15,
+    predefinedTimesList: [],
+  },
+  render: (args: Args) => {
+    const endDate = args.endDate ? new Date(args.endDate) : new Date();
+    const startDate = args.startDate
+      ? new Date(args.startDate)
+      : new Date(endDate.getTime() - 3600);
+
+    const futureDatesDisabled = args.futureDatesDisabled ?? true;
+
+    return (
+      <DateTimeRangePicker
+        key="default"
+        defaultActiveTab="endDate"
+        endDate={endDate}
+        disabled={args.disabled}
+        futureDatesDisabled={futureDatesDisabled}
+        futureStartDatesDisabled={args.futureStartDatesDisabled}
+        maxRangeLength={args.maxRangeLength}
+        onSelectDateRange={args.onSelectDateRange}
+        placeholder={args.placeholder}
+        startDate={startDate}
+        shouldShowSeconds={args.shouldShowSeconds}
+      />
+    );
+  },
+};
+
 export const DateTimeFutureStartDatesDisabled: Story = {
   args: {
     futureStartDatesDisabled: true,

--- a/src/components/DatePicker/DateTimeRangePicker.test.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.test.tsx
@@ -394,6 +394,28 @@ describe('DateTimeRangePicker', () => {
       await userEvent.click(getByText('15'));
       expect(handleSelectDate).toHaveBeenCalled();
     });
+
+    it('allows picking an end date before the start date when an end date is already set', async () => {
+      const handleSelectDate = vi.fn();
+      const startDate = new Date('07-10-2020 12:00');
+      const endDate = new Date('07-15-2020 12:00');
+
+      const { getByTestId, getByText } = renderCUI(
+        <DateTimeRangePicker
+          startDate={startDate}
+          endDate={endDate}
+          defaultActiveTab="endDate"
+          onSelectDateRange={handleSelectDate}
+        />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+      await userEvent.click(getByText('5'));
+
+      expect(getByTestId('datetimepicker-input').textContent).toBe(
+        'Jul 10, 12:00 pm – Jul 05, 12:00 pm'
+      );
+    });
   });
 
   describe('setting a default active tab', () => {

--- a/src/components/DatePicker/DateTimeRangePicker.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.tsx
@@ -162,6 +162,7 @@ const Calendar = ({
           // start date is selected, end date is not; disable anything before start date
           if (
             calendarType === 'endDate' &&
+            !endDate &&
             startDate &&
             startDate > fullDate &&
             !isSameDate(startDate, fullDate)


### PR DESCRIPTION
When both `startDate` and `endDate` were selected, you couldn't change the end date. This allows that.