### PR TITLE
feat(datepickers): add option to display in utc or local timezone

### DIFF
--- a/.changeset/empty-socks-talk.md
+++ b/.changeset/empty-socks-talk.md
@@ -1,0 +1,40 @@
+---
+'@clickhouse/click-ui': minor
+---
+
+Adds `timezone` field to `DatePicker`, `DateRangePicker` and `DateTimeRangePicker`, allowing the user to configure whether to display dates in local or utc.
+
+Defaults to `local`
+
+### Usage
+
+#### DatePicker
+```ts
+<DatePicker
+  onSelectDate={handleDateSelect}
+  timezone="local"
+/>
+
+```
+
+#### DateRangePicker
+```ts
+<DateRangePicker
+  onSelectDateRange={(startDate, endDate) =>
+    setStartDate(startDate);
+    setEndDate(endDate);
+  }
+  timezone="UTC"
+/>
+
+```
+
+#### DateTimeRangePicker
+```ts
+<DateTimeRangePicker
+  endDate={endDate}
+  onSelectDateRange={handleDateRangeSelected}
+  startDate={startDate}
+  timezone="local"
+/>
+```

--- a/.changeset/empty-socks-talk.md
+++ b/.changeset/empty-socks-talk.md
@@ -2,9 +2,13 @@
 '@clickhouse/click-ui': minor
 ---
 
-Adds `timezone` field to `DatePicker`, `DateRangePicker` and `DateTimeRangePicker`, allowing the user to configure whether to display dates in local or utc.
+Adds `timezone` field to `DatePicker`, `DateRangePicker` and `DateTimeRangePicker`, allowing the user to configure whether to display dates in system (local) or utc.
 
-Defaults to `local`
+```ts
+type Timezone = 'system' | 'UTC'
+````
+
+Defaults to `system`
 
 ### Usage
 
@@ -12,7 +16,7 @@ Defaults to `local`
 ```ts
 <DatePicker
   onSelectDate={handleDateSelect}
-  timezone="local"
+  timezone="system"
 />
 
 ```
@@ -35,6 +39,6 @@ Defaults to `local`
   endDate={endDate}
   onSelectDateRange={handleDateRangeSelected}
   startDate={startDate}
-  timezone="local"
+  timezone="system"
 />
 ```

--- a/src/components/DatePicker/Common.tsx
+++ b/src/components/DatePicker/Common.tsx
@@ -15,11 +15,13 @@ import { useCalendar, UseCalendarOptions } from '@h6s/calendar';
 import { IconButton, IconButtonSize } from '@/components/IconButton';
 import { Text } from '@/components/Text';
 import {
-  headerDateFormatter,
-  selectedDateFormatter,
-  selectedDateTimeFormatter,
-  selectedDateTimeFormatterWithSeconds,
-  weekdayFormatter,
+  formatDateHeader,
+  formatSelectedDate,
+  formatSelectedDateTime,
+  formatSelectedDateTimeWithSeconds,
+  formatWeekday,
+  shiftToTimezone,
+  Timezone,
 } from './utils';
 import { getMonthNames, DAYS, MONTHS, YEARS, DAYS_IN_WEEK } from '@/utils/date';
 import { Dropdown } from '@/components/Dropdown';
@@ -63,23 +65,31 @@ interface DatePickerInputProps {
   partialYear?: number;
   placeholder?: string;
   selectedDate?: Date;
+  timezone?: Timezone;
 }
 
 const formatPartialDate = (
+  timezone: Timezone,
   selectedDate?: Date,
   partialYear?: number,
   partialMonth?: number
 ): string => {
   if (typeof partialYear === 'number' && typeof partialMonth === 'number') {
-    const date = new Date(partialYear, partialMonth, 1);
-    return headerDateFormatter.format(date);
+    const date =
+      timezone === 'UTC'
+        ? new Date(Date.UTC(partialYear, partialMonth, 1))
+        : new Date(partialYear, partialMonth, 1);
+    return formatDateHeader(timezone, date);
   }
+
   if (typeof partialYear === 'number') {
     return String(partialYear);
   }
+
   if (selectedDate instanceof Date) {
-    return selectedDateFormatter.format(selectedDate);
+    return formatSelectedDate(timezone, selectedDate);
   }
+
   return '';
 };
 
@@ -91,9 +101,11 @@ export const DatePickerInput = ({
   partialYear,
   placeholder,
   selectedDate,
+  timezone = 'local',
 }: DatePickerInputProps) => {
   const defaultId = useId();
   const formattedSelectedDate = formatPartialDate(
+    timezone,
     selectedDate,
     partialYear,
     partialMonth
@@ -126,6 +138,7 @@ interface DateRangePickerInputProps {
   placeholder?: string;
   selectedEndDate?: Date;
   selectedStartDate?: Date;
+  timezone?: Timezone;
 }
 
 export const DateRangePickerInput = ({
@@ -135,6 +148,7 @@ export const DateRangePickerInput = ({
   placeholder,
   selectedEndDate,
   selectedStartDate,
+  timezone = 'local',
 }: DateRangePickerInputProps) => {
   const defaultId = useId();
 
@@ -150,14 +164,14 @@ export const DateRangePickerInput = ({
     if (selectedEndDate) {
       formattedValue = (
         <span>
-          {selectedDateFormatter.format(selectedStartDate)} –{' '}
-          {selectedDateFormatter.format(selectedEndDate)}
+          {formatSelectedDate(timezone, selectedStartDate)} –{' '}
+          {formatSelectedDate(timezone, selectedEndDate)}
         </span>
       );
     } else {
       formattedValue = (
         <span>
-          {selectedDateFormatter.format(selectedStartDate)}{' '}
+          {formatSelectedDate(timezone, selectedStartDate)}{' '}
           <Text
             color="muted"
             component="span"
@@ -197,6 +211,7 @@ interface DateTimeRangePickerInputProps {
   selectedEndDate?: Date;
   selectedStartDate?: Date;
   shouldShowSeconds?: boolean;
+  timezone?: Timezone;
 }
 
 export const DateTimeRangePickerInput = ({
@@ -207,12 +222,20 @@ export const DateTimeRangePickerInput = ({
   selectedEndDate,
   selectedStartDate,
   shouldShowSeconds,
+  timezone = 'local',
 }: DateTimeRangePickerInputProps) => {
   const defaultId = useId();
 
-  const dateTimeFormatter = shouldShowSeconds
-    ? selectedDateTimeFormatterWithSeconds
-    : selectedDateTimeFormatter;
+  const formatDateTime = useCallback(
+    (date: Date) => {
+      if (shouldShowSeconds) {
+        return formatSelectedDateTimeWithSeconds(timezone, date);
+      }
+
+      return formatSelectedDateTime(timezone, date);
+    },
+    [shouldShowSeconds, timezone]
+  );
 
   let formattedValue = (
     <Text
@@ -222,28 +245,19 @@ export const DateTimeRangePickerInput = ({
       {placeholder ?? ''}
     </Text>
   );
+
   if (selectedStartDate) {
     if (selectedEndDate) {
       formattedValue = (
         <span>
-          {dateTimeFormatter
-            .format(selectedStartDate)
-            .replace('AM', 'am')
-            .replace('PM', 'pm')}{' '}
-          –{' '}
-          {dateTimeFormatter
-            .format(selectedEndDate)
-            .replace('AM', 'am')
-            .replace('PM', 'pm')}
+          {formatDateTime(selectedStartDate).replace('AM', 'am').replace('PM', 'pm')} –{' '}
+          {formatDateTime(selectedEndDate).replace('AM', 'am').replace('PM', 'pm')}
         </span>
       );
     } else {
       formattedValue = (
         <span>
-          {dateTimeFormatter
-            .format(selectedStartDate)
-            .replace('AM', 'am')
-            .replace('PM', 'pm')}{' '}
+          {formatDateTime(selectedStartDate).replace('AM', 'am').replace('PM', 'pm')}{' '}
           <Text
             color="muted"
             component="span"
@@ -262,10 +276,7 @@ export const DateTimeRangePickerInput = ({
         >
           start date –{' '}
         </Text>
-        {dateTimeFormatter
-          .format(selectedEndDate)
-          .replace('AM', 'am')
-          .replace('PM', 'pm')}
+        {formatDateTime(selectedEndDate).replace('AM', 'am').replace('PM', 'pm')}
       </span>
     );
   }
@@ -508,6 +519,7 @@ interface CalendarRendererProps {
   onYearSelect?: (year: number) => void;
   onMonthSelect?: (year: number, month: number) => void;
   selectedDate?: Date;
+  timezone?: Timezone;
 }
 
 const monthAbbreviations = getMonthNames('short');
@@ -583,11 +595,20 @@ export const CalendarRenderer = ({
   onYearSelect,
   onMonthSelect,
   selectedDate,
+  timezone = 'local',
   ...props
 }: CalendarRendererProps) => {
+  // useCalendar reads dates as local; shiftToTimezone is a no-op in local mode.
+  const shiftedCalendarOptions: UseCalendarOptions =
+    calendarOptions.defaultDate instanceof Date
+      ? {
+          ...calendarOptions,
+          defaultDate: shiftToTimezone(calendarOptions.defaultDate, timezone),
+        }
+      : calendarOptions;
   const { body, headers, month, navigation, year } = useCalendar({
     defaultWeekStart: 1,
-    ...calendarOptions,
+    ...shiftedCalendarOptions,
   });
 
   const [view, setView] = useState<DateViewOption>(DAYS);
@@ -686,31 +707,31 @@ export const CalendarRenderer = ({
   );
 
   const onMonthGridKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLButtonElement>, index: number) => {
+    (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
       const columns = viewGridMonths.columns;
       const totalItems = 12;
       let newIndex = index;
 
-      switch (e.key) {
+      switch (event.key) {
         case 'ArrowRight':
-          e.preventDefault();
+          event.preventDefault();
           newIndex = (index + 1) % totalItems;
           break;
         case 'ArrowLeft':
-          e.preventDefault();
+          event.preventDefault();
           newIndex = (index - 1 + totalItems) % totalItems;
           break;
         case 'ArrowDown':
-          e.preventDefault();
+          event.preventDefault();
           newIndex = (index + columns) % totalItems;
           break;
         case 'ArrowUp':
-          e.preventDefault();
+          event.preventDefault();
           newIndex = (index - columns + totalItems) % totalItems;
           break;
         case 'Enter':
         case ' ':
-          e.preventDefault();
+          event.preventDefault();
           onMonthSelection(index);
           return;
         default:
@@ -724,31 +745,31 @@ export const CalendarRenderer = ({
   );
 
   const onYearGridKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLButtonElement>, index: number, yearValue: number) => {
+    (event: KeyboardEvent<HTMLButtonElement>, index: number, yearValue: number) => {
       const columns = viewGridYears.columns;
       const totalItems = totalYears;
       let newIndex = index;
 
-      switch (e.key) {
+      switch (event.key) {
         case 'ArrowRight':
-          e.preventDefault();
+          event.preventDefault();
           newIndex = (index + 1) % totalItems;
           break;
         case 'ArrowLeft':
-          e.preventDefault();
+          event.preventDefault();
           newIndex = (index - 1 + totalItems) % totalItems;
           break;
         case 'ArrowDown':
-          e.preventDefault();
+          event.preventDefault();
           newIndex = (index + columns) % totalItems;
           break;
         case 'ArrowUp':
-          e.preventDefault();
+          event.preventDefault();
           newIndex = (index - columns + totalItems) % totalItems;
           break;
         case 'Enter':
         case ' ':
-          e.preventDefault();
+          event.preventDefault();
           onYearSelection(yearValue);
           return;
         default:
@@ -774,15 +795,19 @@ export const CalendarRenderer = ({
       return 'Year';
     }
 
-    return headerDateFormatter.format(headerDate);
+    // headerDate already has the right month/year in its local fields.
+    return formatDateHeader('local', headerDate);
   };
 
   const renderMonthsGrid = () => {
-    const today = new Date();
-    const todayMonth = today.getMonth();
-    const todayYear = today.getFullYear();
-    const selectedMonth = selectedDate?.getMonth();
-    const selectedYear = selectedDate?.getFullYear();
+    const today = shiftToTimezone(new Date(), timezone);
+    const thisMonth = today.getMonth();
+    const thisYear = today.getFullYear();
+    const shiftedSelected = selectedDate
+      ? shiftToTimezone(selectedDate, timezone)
+      : undefined;
+    const selectedMonth = shiftedSelected?.getMonth();
+    const selectedYear = shiftedSelected?.getFullYear();
 
     return (
       <MonthsGrid
@@ -790,24 +815,36 @@ export const CalendarRenderer = ({
         role="grid"
         aria-label="Select month"
       >
-        {monthAbbreviations.map((abbr, index) => (
-          <GridCell
-            key={abbr}
-            type="button"
-            ref={el => {
-              monthGridRef.current[index] = el;
-            }}
-            $isActive={selectedDate && index === selectedMonth && year === selectedYear}
-            $isPresent={index === todayMonth && year === todayYear}
-            onClick={() => onMonthSelection(index)}
-            onKeyDown={e => onMonthGridKeyDown(e, index)}
-            data-testid={`month-cell-${index}`}
-            tabIndex={index === focusedMonthIndex ? 0 : -1}
-            aria-label={abbr}
-          >
-            {abbr}
-          </GridCell>
-        ))}
+        {monthAbbreviations.map((month, index) => {
+          const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+            onMonthGridKeyDown(event, index);
+          };
+
+          const handleClick = () => {
+            onMonthSelection(index);
+          };
+
+          const ref = (element: HTMLButtonElement) => {
+            monthGridRef.current[index] = element;
+          };
+
+          return (
+            <GridCell
+              key={month}
+              type="button"
+              ref={ref}
+              $isActive={selectedDate && index === selectedMonth && year === selectedYear}
+              $isPresent={index === thisMonth && year === thisYear}
+              onClick={handleClick}
+              onKeyDown={handleKeyDown}
+              data-testid={`month-cell-${index}`}
+              tabIndex={index === focusedMonthIndex ? 0 : -1}
+              aria-label={month}
+            >
+              {month}
+            </GridCell>
+          );
+        })}
       </MonthsGrid>
     );
   };
@@ -815,8 +852,10 @@ export const CalendarRenderer = ({
   const renderYearsGrid = () => {
     const years: Array<number> = [];
     const baseYear = year + yearOffset;
-    const todayYear = new Date().getFullYear();
-    const selectedYear = selectedDate?.getFullYear();
+    const thisYear = shiftToTimezone(new Date(), timezone).getFullYear();
+    const selectedYear = selectedDate
+      ? shiftToTimezone(selectedDate, timezone).getFullYear()
+      : undefined;
 
     for (let i = -yearsOffset; i <= yearsOffset; i++) {
       years.push(baseYear + i);
@@ -828,24 +867,36 @@ export const CalendarRenderer = ({
         role="grid"
         aria-label="Select year"
       >
-        {years.map((currYear, index) => (
-          <GridCell
-            key={currYear}
-            type="button"
-            ref={el => {
-              yearGridRef.current[index] = el;
-            }}
-            $isActive={selectedDate && currYear === selectedYear}
-            $isPresent={currYear === todayYear}
-            onClick={() => onYearSelection(currYear)}
-            onKeyDown={e => onYearGridKeyDown(e, index, currYear)}
-            data-testid={`year-cell-${currYear}`}
-            tabIndex={index === focusedYearIndex ? 0 : -1}
-            aria-label={String(currYear)}
-          >
-            {currYear}
-          </GridCell>
-        ))}
+        {years.map((currentYear, index) => {
+          const ref = (element: HTMLButtonElement) => {
+            yearGridRef.current[index] = element;
+          };
+
+          const handleClick = () => {
+            onYearSelection(currentYear);
+          };
+
+          const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+            onYearGridKeyDown(event, index, currentYear);
+          };
+
+          return (
+            <GridCell
+              key={currentYear}
+              type="button"
+              ref={ref}
+              $isActive={selectedDate && currentYear === selectedYear}
+              $isPresent={currentYear === thisYear}
+              onClick={handleClick}
+              onKeyDown={handleKeyDown}
+              data-testid={`year-cell-${currentYear}`}
+              tabIndex={index === focusedYearIndex ? 0 : -1}
+              aria-label={String(currentYear)}
+            >
+              {currentYear}
+            </GridCell>
+          );
+        })}
       </YearsGrid>
     );
   };
@@ -878,7 +929,7 @@ export const CalendarRenderer = ({
             {headers.weekDays.map(({ key, value: date }) => {
               return (
                 <DateTableHeader key={key}>
-                  {weekdayFormatter.format(date)}
+                  {formatWeekday('local', date)}
                 </DateTableHeader>
               );
             })}

--- a/src/components/DatePicker/Common.tsx
+++ b/src/components/DatePicker/Common.tsx
@@ -101,7 +101,7 @@ export const DatePickerInput = ({
   partialYear,
   placeholder,
   selectedDate,
-  timezone = 'local',
+  timezone = 'system',
 }: DatePickerInputProps) => {
   const defaultId = useId();
   const formattedSelectedDate = formatPartialDate(
@@ -148,7 +148,7 @@ export const DateRangePickerInput = ({
   placeholder,
   selectedEndDate,
   selectedStartDate,
-  timezone = 'local',
+  timezone = 'system',
 }: DateRangePickerInputProps) => {
   const defaultId = useId();
 
@@ -222,7 +222,7 @@ export const DateTimeRangePickerInput = ({
   selectedEndDate,
   selectedStartDate,
   shouldShowSeconds,
-  timezone = 'local',
+  timezone = 'system',
 }: DateTimeRangePickerInputProps) => {
   const defaultId = useId();
 
@@ -595,7 +595,7 @@ export const CalendarRenderer = ({
   onYearSelect,
   onMonthSelect,
   selectedDate,
-  timezone = 'local',
+  timezone = 'system',
   ...props
 }: CalendarRendererProps) => {
   // useCalendar reads dates as local; shiftToTimezone is a no-op in local mode.
@@ -796,7 +796,7 @@ export const CalendarRenderer = ({
     }
 
     // headerDate already has the right month/year in its local fields.
-    return formatDateHeader('local', headerDate);
+    return formatDateHeader('system', headerDate);
   };
 
   const renderMonthsGrid = () => {
@@ -929,7 +929,7 @@ export const CalendarRenderer = ({
             {headers.weekDays.map(({ key, value: date }) => {
               return (
                 <DateTableHeader key={key}>
-                  {formatWeekday('local', date)}
+                  {formatWeekday('system', date)}
                 </DateTableHeader>
               );
             })}

--- a/src/components/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DatePicker/DatePicker.stories.tsx
@@ -1,6 +1,8 @@
 import { Args } from '@storybook/react-vite';
+import { dayjs } from '@/utils/date';
 import { DatePicker } from '@/components/DatePicker';
 import { getNextNDatesForDatePickerAllowOnlyList } from './utils';
+import { Text } from '../Text';
 
 const defaultStory = {
   args: {
@@ -52,5 +54,33 @@ export const DatePickerAllowOnlyNext30Days = {
   args: {
     ...defaultStory.args,
     allowOnlyDatesList: getNextNDatesForDatePickerAllowOnlyList(30),
+  },
+};
+
+export const TimezoneLocalVsUTC = {
+  ...defaultStory,
+  render: (args: Args) => {
+    const date = args.date ? new Date(args.date) : new Date('2026-04-30T01:00:00Z');
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <Text>For local tz date {dayjs(date).format('YYYY/DD/MM HH:mm')}</Text>
+        <div>
+          <Text>local</Text>
+          <DatePicker
+            date={date}
+            onSelectDate={date => console.log('local selected:', date.toISOString())}
+            timezone="local"
+          />
+        </div>
+        <div>
+          <Text>UTC</Text>
+          <DatePicker
+            date={date}
+            onSelectDate={date => console.log('UTC selected:', date.toISOString())}
+            timezone="UTC"
+          />
+        </div>
+      </div>
+    );
   },
 };

--- a/src/components/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DatePicker/DatePicker.stories.tsx
@@ -63,13 +63,13 @@ export const TimezoneLocalVsUTC = {
     const date = args.date ? new Date(args.date) : new Date('2026-04-30T01:00:00Z');
     return (
       <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-        <Text>For local tz date {dayjs(date).format('YYYY/DD/MM HH:mm')}</Text>
+        <Text>For system tz date {dayjs(date).format('YYYY/DD/MM HH:mm')}</Text>
         <div>
-          <Text>local</Text>
+          <Text>system</Text>
           <DatePicker
             date={date}
-            onSelectDate={date => console.log('local selected:', date.toISOString())}
-            timezone="local"
+            onSelectDate={date => console.log('system selected:', date.toISOString())}
+            timezone="system"
           />
         </div>
         <div>

--- a/src/components/DatePicker/DatePicker.test.tsx
+++ b/src/components/DatePicker/DatePicker.test.tsx
@@ -168,6 +168,40 @@ describe('DatePicker', () => {
     });
   });
 
+  describe('when configured for the UTC timezone', () => {
+    it('renders the selected date from its UTC fields', () => {
+      const date = new Date('2026-04-30T01:00:00Z');
+      const { getByDisplayValue } = renderCUI(
+        <DatePicker
+          date={date}
+          onSelectDate={vi.fn()}
+          timezone="UTC"
+        />
+      );
+
+      expect(getByDisplayValue('Apr 30, 2026')).toBeInTheDocument();
+    });
+
+    it('emits midnight UTC when the user picks a calendar day', async () => {
+      const handleSelectDate = vi.fn();
+      const date = new Date('2026-04-15T12:00:00Z');
+
+      const { getByTestId, getByText } = renderCUI(
+        <DatePicker
+          date={date}
+          onSelectDate={handleSelectDate}
+          timezone="UTC"
+        />
+      );
+
+      await userEvent.click(getByTestId('datepicker-input'));
+      await userEvent.click(getByText('22'));
+
+      const selectedDate = handleSelectDate.mock.lastCall?.[0] as Date;
+      expect(selectedDate.toISOString()).toBe('2026-04-22T00:00:00.000Z');
+    });
+  });
+
   describe('two phased date selection', () => {
     it('shows progressive input updates during year and month selection', async () => {
       const onSelectDate = vi.fn();

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -1,9 +1,9 @@
-import { KeyboardEvent, useCallback, useEffect, useRef, useState } from 'react';
+import { KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { isSameDate, UseCalendarOptions } from '@h6s/calendar';
 import * as Popover from '@radix-ui/react-popover';
 import { styled } from 'styled-components';
 import { Body, CalendarRenderer, DatePickerInput, DateTableCell } from './Common';
-import { DatePickerProps } from './DatePicker.types';
+import { shiftFromTimezone, shiftToTimezone, Timezone } from './utils';
 
 const DAYS_IN_WEEK = 7;
 
@@ -47,6 +47,7 @@ interface CalendarProps {
   selectedDate?: Date;
   setSelectedDate: (selectedDate: Date) => void;
   autoFocus?: boolean;
+  timezone: Timezone;
 }
 
 const Calendar = ({
@@ -57,13 +58,27 @@ const Calendar = ({
   selectedDate,
   setSelectedDate,
   autoFocus = false,
+  timezone,
 }: CalendarProps) => {
   const allDays = calendarBody.value.flatMap(week => week.value);
   const totalDays = allDays.length;
 
-  const today = new Date();
+  const today = shiftToTimezone(new Date(), timezone);
+
+  const shiftedSelected = selectedDate
+    ? shiftToTimezone(selectedDate, timezone)
+    : undefined;
+
+  const shiftedAllowList = useMemo(() => {
+    return allowOnlyDatesList?.map(date => {
+      return shiftToTimezone(date, timezone);
+    });
+  }, [allowOnlyDatesList, timezone]);
+
   const initialFocusIndex = allDays.findIndex(day =>
-    selectedDate ? isSameDate(selectedDate, day.value) : isSameDate(today, day.value)
+    shiftedSelected
+      ? isSameDate(shiftedSelected, day.value)
+      : isSameDate(today, day.value)
   );
 
   const [focusedDayIndex, setFocusedDayIndex] = useState<number>(
@@ -86,35 +101,35 @@ const Calendar = ({
 
   const onDayKeyDown = useCallback(
     (
-      e: KeyboardEvent<HTMLTableCellElement>,
+      event: KeyboardEvent<HTMLTableCellElement>,
       index: number,
       fullDate: Date,
       isDisabled: boolean
     ) => {
       let newIndex = index;
 
-      switch (e.key) {
+      switch (event.key) {
         case 'ArrowRight':
-          e.preventDefault();
+          event.preventDefault();
           newIndex = (index + 1) % totalDays;
           break;
         case 'ArrowLeft':
-          e.preventDefault();
+          event.preventDefault();
           newIndex = (index - 1 + totalDays) % totalDays;
           break;
         case 'ArrowDown':
-          e.preventDefault();
+          event.preventDefault();
           newIndex = (index + DAYS_IN_WEEK) % totalDays;
           break;
         case 'ArrowUp':
-          e.preventDefault();
+          event.preventDefault();
           newIndex = (index - DAYS_IN_WEEK + totalDays) % totalDays;
           break;
         case 'Enter':
         case ' ':
-          e.preventDefault();
+          event.preventDefault();
           if (!isDisabled) {
-            setSelectedDate(fullDate);
+            setSelectedDate(shiftFromTimezone(fullDate, timezone));
             closeDatepicker();
           }
           return;
@@ -125,7 +140,7 @@ const Calendar = ({
       setFocusedDayIndex(newIndex);
       dayRefs.current[newIndex]?.focus();
     },
-    [totalDays, setSelectedDate, closeDatepicker]
+    [totalDays, setSelectedDate, closeDatepicker, timezone]
   );
 
   let dayIndex = 0;
@@ -134,12 +149,16 @@ const Calendar = ({
     return (
       <tr key={weekKey}>
         {week.map(({ date, isCurrentMonth, key: dayKey, value: fullDate }) => {
-          const isSelected = selectedDate && isSameDate(selectedDate, fullDate);
+          const isSelected = shiftedSelected && isSameDate(shiftedSelected, fullDate);
           const isPresent = isSameDate(today, fullDate);
+
           const isNotAllowed =
-            allowOnlyDatesList &&
-            allowOnlyDatesList.length > 0 &&
-            !allowOnlyDatesList.some(d => isSameDate(d, fullDate));
+            shiftedAllowList &&
+            shiftedAllowList.length > 0 &&
+            !shiftedAllowList.some((shiftedDate: Date) => {
+              return isSameDate(shiftedDate, fullDate);
+            });
+
           const isFutureDisabled = futureDatesDisabled && fullDate > today;
           const isDisabled = isNotAllowed || isFutureDisabled;
           const currentIndex = dayIndex;
@@ -149,7 +168,7 @@ const Calendar = ({
             if (isDisabled) {
               return false;
             }
-            setSelectedDate(fullDate);
+            setSelectedDate(shiftFromTimezone(fullDate, timezone));
             closeDatepicker();
           };
 
@@ -178,6 +197,16 @@ const Calendar = ({
   });
 };
 
+export interface DatePickerProps {
+  allowOnlyDatesList?: Array<Date>;
+  date?: Date;
+  disabled?: boolean;
+  futureDatesDisabled?: boolean;
+  onSelectDate: (selectedDate: Date) => void;
+  placeholder?: string;
+  timezone?: Timezone;
+}
+
 export const DatePicker = ({
   allowOnlyDatesList,
   date,
@@ -185,6 +214,7 @@ export const DatePicker = ({
   futureDatesDisabled = false,
   onSelectDate,
   placeholder,
+  timezone = 'local',
 }: DatePickerProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [selectedDate, setSelectedDate] = useState<Date>();
@@ -269,6 +299,7 @@ export const DatePicker = ({
           partialYear={partialYear}
           placeholder={placeholder}
           selectedDate={selectedDate}
+          timezone={timezone}
         />
       </PopoverTrigger>
       <Popover.Portal>
@@ -281,6 +312,7 @@ export const DatePicker = ({
             onYearSelect={onYearSelect}
             onMonthSelect={onMonthSelect}
             selectedDate={selectedDate}
+            timezone={timezone}
           >
             {body => (
               <Calendar
@@ -291,6 +323,7 @@ export const DatePicker = ({
                 futureDatesDisabled={futureDatesDisabled}
                 selectedDate={selectedDate}
                 setSelectedDate={onDateSelect}
+                timezone={timezone}
               />
             )}
           </CalendarRenderer>

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -214,7 +214,7 @@ export const DatePicker = ({
   futureDatesDisabled = false,
   onSelectDate,
   placeholder,
-  timezone = 'local',
+  timezone = 'system',
 }: DatePickerProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [selectedDate, setSelectedDate] = useState<Date>();

--- a/src/components/DatePicker/DatePicker.types.ts
+++ b/src/components/DatePicker/DatePicker.types.ts
@@ -1,9 +1,0 @@
-export interface DatePickerProps {
-  allowOnlyDatesList?: Array<Date>;
-  date?: Date;
-  disabled?: boolean;
-  futureDatesDisabled?: boolean;
-  onSelectDate: (selectedDate: Date) => void;
-  placeholder?: string;
-  responsivePositioning?: boolean;
-}

--- a/src/components/DatePicker/DateRangePicker.stories.tsx
+++ b/src/components/DatePicker/DateRangePicker.stories.tsx
@@ -192,21 +192,21 @@ export const TimezoneLocalVsUTC: Story = {
       <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
         <div>
           <Text>
-            For local tz start date {dayjs(startDate).format('YYYY/DD/MM HH:mm')} and end
+            For system tz start date {dayjs(startDate).format('YYYY/DD/MM HH:mm')} and end
             date {dayjs(endDate).format('YYYY/DD/MM HH:mm')}
           </Text>
-          <Text>local</Text>
+          <Text>system</Text>
           <DateRangePicker
             endDate={endDate}
             onSelectDateRange={(startDate, endDate) =>
               console.log(
-                'local selected:',
+                'system selected:',
                 startDate.toISOString(),
                 endDate.toISOString()
               )
             }
             startDate={startDate}
-            timezone="local"
+            timezone="system"
           />
         </div>
         <div>

--- a/src/components/DatePicker/DateRangePicker.stories.tsx
+++ b/src/components/DatePicker/DateRangePicker.stories.tsx
@@ -1,6 +1,8 @@
 import { Args, Meta, StoryObj } from '@storybook/react-vite';
+import dayjs from 'dayjs';
 import { DateRangePicker } from './DateRangePicker';
 import { getPredefinedMonthsForDateRangePicker } from './utils';
+import { Text } from '../Text';
 
 const meta: Meta<typeof DateRangePicker> = {
   component: DateRangePicker,
@@ -173,6 +175,52 @@ export const PredefinedDatesArbitraryDates: Story = {
         predefinedDatesList={predefinedDatesList}
         startDate={startDate}
       />
+    );
+  },
+};
+
+export const TimezoneLocalVsUTC: Story = {
+  render: (args: Args) => {
+    const startDate = args.startDate
+      ? new Date(args.startDate)
+      : new Date('2026-04-15T01:00:00Z');
+    const endDate = args.endDate
+      ? new Date(args.endDate)
+      : new Date('2026-04-30T01:00:00Z');
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <div>
+          <Text>
+            For local tz start date {dayjs(startDate).format('YYYY/DD/MM HH:mm')} and end
+            date {dayjs(endDate).format('YYYY/DD/MM HH:mm')}
+          </Text>
+          <Text>local</Text>
+          <DateRangePicker
+            endDate={endDate}
+            onSelectDateRange={(startDate, endDate) =>
+              console.log(
+                'local selected:',
+                startDate.toISOString(),
+                endDate.toISOString()
+              )
+            }
+            startDate={startDate}
+            timezone="local"
+          />
+        </div>
+        <div>
+          <Text>UTC</Text>
+          <DateRangePicker
+            endDate={endDate}
+            onSelectDateRange={(startDate, endDate) =>
+              console.log('UTC selected:', startDate.toISOString(), endDate.toISOString())
+            }
+            startDate={startDate}
+            timezone="UTC"
+          />
+        </div>
+      </div>
     );
   },
 };

--- a/src/components/DatePicker/DateRangePicker.test.tsx
+++ b/src/components/DatePicker/DateRangePicker.test.tsx
@@ -382,4 +382,45 @@ describe('DateRangePicker', () => {
       expect(getByText('Oct 2019')).toBeInTheDocument();
     });
   });
+
+  describe('when configured for the UTC timezone', () => {
+    it('renders both endpoints from their UTC fields', () => {
+      const startDate = new Date('2026-04-30T01:00:00Z');
+      const endDate = new Date('2026-05-30T01:00:00Z');
+
+      const { getByText } = renderCUI(
+        <DateRangePicker
+          endDate={endDate}
+          onSelectDateRange={vi.fn()}
+          startDate={startDate}
+          timezone="UTC"
+        />
+      );
+
+      expect(getByText('Apr 30, 2026 – May 30, 2026')).toBeInTheDocument();
+    });
+
+    it('emits midnight UTC for the new endpoint when the user picks a calendar day', async () => {
+      const handleSelectDateRange = vi.fn();
+      const startDate = new Date('2026-04-15T12:00:00Z');
+
+      const { getByTestId, getByText } = renderCUI(
+        <DateRangePicker
+          onSelectDateRange={handleSelectDateRange}
+          startDate={startDate}
+          timezone="UTC"
+        />
+      );
+
+      await userEvent.click(getByTestId('daterangepicker-input'));
+      await userEvent.click(getByText('22'));
+
+      const [emittedStart, emittedEnd] = handleSelectDateRange.mock.lastCall as [
+        Date,
+        Date,
+      ];
+      expect(emittedStart.toISOString()).toBe('2026-04-15T12:00:00.000Z');
+      expect(emittedEnd.toISOString()).toBe('2026-04-22T00:00:00.000Z');
+    });
+  });
 });

--- a/src/components/DatePicker/DateRangePicker.tsx
+++ b/src/components/DatePicker/DateRangePicker.tsx
@@ -25,8 +25,12 @@ import { Icon } from '@/components/Icon';
 import {
   DateRange,
   datesAreWithinMaxRange,
+  formatDateHeader,
+  formatSelectedDate,
+  shiftFromTimezone,
   isDateRangeTheWholeMonth,
-  selectedDateFormatter,
+  Timezone,
+  shiftToTimezone,
 } from './utils';
 
 type OpenDirection = 'left' | 'right';
@@ -88,6 +92,7 @@ interface CalendarProps {
   setSelectedDate: (selectedDate: Date) => void;
   startDate?: Date;
   endDate?: Date;
+  timezone: Timezone;
 }
 
 const Calendar = ({
@@ -99,8 +104,13 @@ const Calendar = ({
   setSelectedDate,
   startDate,
   endDate,
+  timezone,
 }: CalendarProps) => {
   const [hoveredDate, setHoveredDate] = useState<Date>();
+
+  const today = shiftToTimezone(new Date(), timezone);
+  const shiftedStart = startDate ? shiftToTimezone(startDate, timezone) : undefined;
+  const shiftedEnd = endDate ? shiftToTimezone(endDate, timezone) : undefined;
 
   const handleMouseOut = (): void => {
     setHoveredDate(undefined);
@@ -110,14 +120,13 @@ const Calendar = ({
     return (
       <tr key={weekKey}>
         {week.map(({ date, isCurrentMonth, key: dayKey, value: fullDate }) => {
-          const today = new Date();
           const isSelected =
-            (startDate && isSameDate(startDate, fullDate)) ||
-            (endDate && isSameDate(endDate, fullDate));
+            (shiftedStart && isSameDate(shiftedStart, fullDate)) ||
+            (shiftedEnd && isSameDate(shiftedEnd, fullDate));
           const isPresent = isSameDate(today, fullDate);
 
           const isBetweenStartAndEndDates = Boolean(
-            startDate && endDate && fullDate > startDate && fullDate < endDate
+            shiftedStart && shiftedEnd && fullDate > shiftedStart && fullDate < shiftedEnd
           );
 
           let isDisabled = false;
@@ -125,22 +134,25 @@ const Calendar = ({
             isDisabled = true;
           }
 
-          if (futureStartDatesDisabled && !startDate && fullDate > today) {
+          if (futureStartDatesDisabled && !shiftedStart && fullDate > today) {
             isDisabled = true;
           }
 
           if (
             maxRangeLength > 1 &&
-            startDate &&
-            !datesAreWithinMaxRange(startDate, fullDate, maxRangeLength)
+            shiftedStart &&
+            !datesAreWithinMaxRange(shiftedStart, fullDate, maxRangeLength)
           ) {
             isDisabled = true;
           }
 
           const shouldShowRangeIndicator =
-            !endDate &&
+            !shiftedEnd &&
             Boolean(
-              startDate && hoveredDate && fullDate > startDate && fullDate < hoveredDate
+              shiftedStart &&
+              hoveredDate &&
+              fullDate > shiftedStart &&
+              fullDate < hoveredDate
             );
 
           const handleMouseEnter = () => {
@@ -151,21 +163,21 @@ const Calendar = ({
             if (isDisabled) {
               return false;
             }
-            setSelectedDate(fullDate);
+            setSelectedDate(shiftFromTimezone(fullDate, timezone));
 
             // User has a date range selected and clicked a new date.
             // This will cause the selected date to be reset, thus do not close the datepicker.
-            if (startDate && endDate) {
+            if (shiftedStart && shiftedEnd) {
               return;
             }
 
             // The user has selected a new start date, don't close
-            if (startDate && fullDate < startDate) {
+            if (shiftedStart && fullDate < shiftedStart) {
               return;
             }
 
             // Only close the datepicker if the user hasn't clicked the selected start date.
-            if (startDate && !isSameDate(fullDate, startDate)) {
+            if (shiftedStart && !isSameDate(fullDate, shiftedStart)) {
               closeDatepicker();
               return;
             }
@@ -193,12 +205,6 @@ const Calendar = ({
   });
 };
 
-const locale = 'en-US';
-const monthFormatter = new Intl.DateTimeFormat(locale, {
-  month: 'short',
-  year: 'numeric',
-});
-
 interface PredefinedDatesProps {
   onSelectDateRange: (selectedStartDate: Date, selectedEndDate: Date) => void;
   predefinedDatesList: DateRange[];
@@ -208,6 +214,7 @@ interface PredefinedDatesProps {
   setStartDate: Dispatch<SetStateAction<Date | undefined>>;
   shouldShowCustomRange: boolean;
   showCustomDateRange: Dispatch<SetStateAction<boolean>>;
+  timezone: Timezone;
 }
 
 const PredefinedDates = ({
@@ -219,6 +226,7 @@ const PredefinedDates = ({
   setStartDate,
   shouldShowCustomRange,
   showCustomDateRange,
+  timezone,
 }: PredefinedDatesProps) => {
   const handleCustomTimePeriodClick = (event: MouseEvent) => {
     event.preventDefault();
@@ -245,13 +253,11 @@ const PredefinedDates = ({
             selectedStartDate &&
             isSameDate(selectedStartDate, startDate);
 
-          const isWholeMonth = isDateRangeTheWholeMonth({ startDate, endDate });
+          const isWholeMonth = isDateRangeTheWholeMonth({ startDate, endDate }, timezone);
 
           const formattedText = isWholeMonth
-            ? monthFormatter.format(startDate)
-            : `${selectedDateFormatter.format(
-                startDate
-              )} – ${selectedDateFormatter.format(endDate)}`.trim();
+            ? formatDateHeader(timezone, startDate)
+            : `${formatSelectedDate(timezone, startDate)} – ${formatSelectedDate(timezone, endDate)}`.trim();
 
           return (
             <StyledDropdownItem
@@ -296,6 +302,7 @@ export interface DateRangePickerProps {
   maxRangeLength?: number;
   startDate?: Date;
   responsivePositioning?: boolean;
+  timezone?: Timezone;
 }
 
 export const DateRangePicker = ({
@@ -310,6 +317,7 @@ export const DateRangePicker = ({
   placeholder = 'start date – end date',
   predefinedDatesList,
   responsivePositioning = true,
+  timezone = 'local',
 }: DateRangePickerProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [selectedStartDate, setSelectedStartDate] = useState<Date>();
@@ -431,6 +439,7 @@ export const DateRangePicker = ({
           placeholder={placeholder}
           selectedEndDate={selectedEndDate}
           selectedStartDate={selectedStartDate}
+          timezone={timezone}
         />
       </Dropdown.Trigger>
       <Dropdown.Content
@@ -452,6 +461,7 @@ export const DateRangePicker = ({
               setStartDate={setSelectedStartDate}
               shouldShowCustomRange={shouldShowCustomRange}
               showCustomDateRange={setShouldShowCustomRange}
+              timezone={timezone}
             />
 
             {shouldShowCustomRange && (
@@ -463,6 +473,7 @@ export const DateRangePicker = ({
                   calendarOptions={calendarOptions}
                   allowYearMonthSelection={false}
                   selectedDate={selectedStartDate}
+                  timezone={timezone}
                 >
                   {(body: Body) => (
                     <Calendar
@@ -474,6 +485,7 @@ export const DateRangePicker = ({
                       setSelectedDate={handleSelectDate}
                       startDate={selectedStartDate}
                       endDate={selectedEndDate}
+                      timezone={timezone}
                     />
                   )}
                 </StyledCalendarRenderer>
@@ -485,6 +497,7 @@ export const DateRangePicker = ({
             calendarOptions={calendarOptions}
             allowYearMonthSelection={false}
             selectedDate={selectedStartDate}
+            timezone={timezone}
           >
             {(body: Body) => (
               <Calendar
@@ -496,6 +509,7 @@ export const DateRangePicker = ({
                 setSelectedDate={handleSelectDate}
                 startDate={selectedStartDate}
                 endDate={selectedEndDate}
+                timezone={timezone}
               />
             )}
           </CalendarRenderer>

--- a/src/components/DatePicker/DateRangePicker.tsx
+++ b/src/components/DatePicker/DateRangePicker.tsx
@@ -317,7 +317,7 @@ export const DateRangePicker = ({
   placeholder = 'start date – end date',
   predefinedDatesList,
   responsivePositioning = true,
-  timezone = 'local',
+  timezone = 'system',
 }: DateRangePickerProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [selectedStartDate, setSelectedStartDate] = useState<Date>();

--- a/src/components/DatePicker/DateTimeRangePicker.stories.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.stories.tsx
@@ -100,7 +100,7 @@ export const PredefinedDatesScrollable: Story = {
   render: (args: Args) => {
     const endDate = args.endDate ? new Date(args.endDate) : undefined;
     const startDate = args.startDate ? new Date(args.startDate) : undefined;
-    const now = dayjs();
+    const now = dayjs('2026-05-01T12:00:00Z');
     const predefinedTimesList: DateRangeListItem[] = [
       {
         dateRange: {
@@ -245,7 +245,9 @@ export const SetStartAndEndDate: Story = {
     predefinedTimesList: [],
   },
   render: (args: Args) => {
-    const endDate = args.endDate ? new Date(args.endDate) : new Date();
+    const endDate = args.endDate
+      ? new Date(args.endDate)
+      : new Date('2026-05-01T12:00:00Z');
     const startDate = args.startDate
       ? new Date(args.startDate)
       : new Date(endDate.getTime() - 3600);
@@ -281,8 +283,10 @@ export const TimezoneLocalVsUTC: Story = {
   render: (args: Args) => {
     const startDate = args.startDate
       ? new Date(args.startDate)
-      : dayjs().subtract(6, 'hour').toDate();
-    const endDate = args.endDate ? new Date(args.endDate) : dayjs().toDate();
+      : dayjs('2026-05-01T12:00:00Z').subtract(6, 'hour').toDate();
+    const endDate = args.endDate
+      ? new Date(args.endDate)
+      : new Date('2026-05-01T12:00:00Z');
 
     return (
       <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
@@ -298,7 +302,7 @@ export const TimezoneLocalVsUTC: Story = {
               )
             }
             startDate={startDate}
-            timezone="local"
+            timezone="system"
           />
         </div>
         <div>

--- a/src/components/DatePicker/DateTimeRangePicker.stories.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.stories.tsx
@@ -2,6 +2,7 @@ import { Args, Meta, StoryObj } from '@storybook/react-vite';
 import { DateTimeRangePicker } from './DateTimeRangePicker';
 import { DateRangeListItem, getPredefinedTimePeriodsForDateTimePicker } from './utils';
 import dayjs from 'dayjs';
+import { Text } from '../Text';
 
 const meta: Meta<typeof DateTimeRangePicker> = {
   component: DateTimeRangePicker,
@@ -273,6 +274,46 @@ export const DateTimeFutureStartDatesDisabled: Story = {
   args: {
     futureStartDatesDisabled: true,
     predefinedTimesList: [],
+  },
+};
+
+export const TimezoneLocalVsUTC: Story = {
+  render: (args: Args) => {
+    const startDate = args.startDate
+      ? new Date(args.startDate)
+      : dayjs().subtract(6, 'hour').toDate();
+    const endDate = args.endDate ? new Date(args.endDate) : dayjs().toDate();
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+        <div>
+          <Text>local</Text>
+          <DateTimeRangePicker
+            endDate={endDate}
+            onSelectDateRange={(startDate, endDate) =>
+              console.log(
+                'local selected:',
+                startDate.toISOString(),
+                endDate.toISOString()
+              )
+            }
+            startDate={startDate}
+            timezone="local"
+          />
+        </div>
+        <div>
+          <Text>UTC</Text>
+          <DateTimeRangePicker
+            endDate={endDate}
+            onSelectDateRange={(startDate, endDate) =>
+              console.log('UTC selected:', startDate.toISOString(), endDate.toISOString())
+            }
+            startDate={startDate}
+            timezone="UTC"
+          />
+        </div>
+      </div>
+    );
   },
 };
 

--- a/src/components/DatePicker/DateTimeRangePicker.test.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.test.tsx
@@ -809,4 +809,43 @@ describe('DateTimeRangePicker', () => {
       );
     });
   });
+
+  describe('when configured for the UTC timezone', () => {
+    it('renders both endpoints from their UTC date and time fields', () => {
+      const startDate = new Date('2026-04-30T08:00:00Z');
+      const endDate = new Date('2026-04-30T14:30:00Z');
+
+      const { getByTestId } = renderCUI(
+        <DateTimeRangePicker
+          endDate={endDate}
+          onSelectDateRange={vi.fn()}
+          startDate={startDate}
+          timezone="UTC"
+        />
+      );
+
+      expect(getByTestId('datetimepicker-input').textContent).toBe(
+        'Apr 30, 08:00 am – Apr 30, 02:30 pm'
+      );
+    });
+
+    it('populates the time input with the UTC hour and minute of the active side', async () => {
+      const startDate = new Date('2026-04-30T08:00:00Z');
+      const endDate = new Date('2026-04-30T14:30:00Z');
+
+      const { getAllByTestId, getByTestId } = renderCUI(
+        <DateTimeRangePicker
+          endDate={endDate}
+          onSelectDateRange={vi.fn()}
+          startDate={startDate}
+          timezone="UTC"
+        />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+
+      const timeInputs = getAllByTestId('date-time-picker-time-input');
+      expect((timeInputs[0] as HTMLInputElement).value).toBe('08:00');
+    });
+  });
 });

--- a/src/components/DatePicker/DateTimeRangePicker.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.tsx
@@ -22,7 +22,14 @@ import {
 import { Container } from '../Container/Container';
 import { Panel } from '../Panel/Panel';
 import { Icon } from '../Icon/Icon';
-import { DateRangeListItem, datesAreWithinMaxRange, Meridiem } from './utils';
+import {
+  DateRangeListItem,
+  datesAreWithinMaxRange,
+  shiftFromTimezone,
+  Meridiem,
+  Timezone,
+  shiftToTimezone,
+} from './utils';
 import { dayjs, Dayjs } from '@/utils/date';
 import { Tabs } from '../Tabs/Tabs';
 import { TextField } from '@/components/TextField';
@@ -105,6 +112,7 @@ interface CalendarProps {
   setSelectedDate: SetSelectedDate;
   startDate?: Date;
   endDate?: Date;
+  timezone: Timezone;
 }
 
 const Calendar = ({
@@ -116,8 +124,13 @@ const Calendar = ({
   setSelectedDate,
   startDate,
   endDate,
+  timezone,
 }: CalendarProps) => {
   const [hoveredDate, setHoveredDate] = useState<Date>();
+
+  const today = shiftToTimezone(new Date(), timezone);
+  const shiftedStart = startDate ? shiftToTimezone(startDate, timezone) : undefined;
+  const shiftedEnd = endDate ? shiftToTimezone(endDate, timezone) : undefined;
 
   const handleMouseOut = (): void => {
     setHoveredDate(undefined);
@@ -128,14 +141,12 @@ const Calendar = ({
       <tr key={weekKey}>
         {week.map(({ date, isCurrentMonth, key: dayKey, value: fullDate }) => {
           const isSelected =
-            (startDate && isSameDate(startDate, fullDate)) ||
-            (endDate && isSameDate(endDate, fullDate));
-
-          const today = new Date();
+            (shiftedStart && isSameDate(shiftedStart, fullDate)) ||
+            (shiftedEnd && isSameDate(shiftedEnd, fullDate));
 
           const isCurrentDate = isSameDate(today, fullDate);
           const isBetweenStartAndEndDates = Boolean(
-            startDate && endDate && fullDate > startDate && fullDate < endDate
+            shiftedStart && shiftedEnd && fullDate > shiftedStart && fullDate < shiftedEnd
           );
 
           let isDisabled = false;
@@ -153,8 +164,8 @@ const Calendar = ({
 
           if (
             maxRangeLength > 1 &&
-            startDate &&
-            !datesAreWithinMaxRange(startDate, fullDate, maxRangeLength)
+            shiftedStart &&
+            !datesAreWithinMaxRange(shiftedStart, fullDate, maxRangeLength)
           ) {
             isDisabled = true;
           }
@@ -162,10 +173,10 @@ const Calendar = ({
           // start date is selected, end date is not; disable anything before start date
           if (
             calendarType === 'endDate' &&
-            !endDate &&
-            startDate &&
-            startDate > fullDate &&
-            !isSameDate(startDate, fullDate)
+            !shiftedEnd &&
+            shiftedStart &&
+            shiftedStart > fullDate &&
+            !isSameDate(shiftedStart, fullDate)
           ) {
             isDisabled = true;
           }
@@ -173,25 +184,28 @@ const Calendar = ({
           // start date isn't selected, but end date is; disable anything after end date
           if (
             calendarType === 'startDate' &&
-            !startDate &&
-            endDate &&
-            fullDate > endDate
+            !shiftedStart &&
+            shiftedEnd &&
+            fullDate > shiftedEnd
           ) {
             isDisabled = true;
           }
 
           const startDateSelectedAndIsSelectingEndDate =
             calendarType === 'endDate' &&
-            !endDate &&
+            !shiftedEnd &&
             Boolean(
-              startDate && hoveredDate && fullDate > startDate && fullDate < hoveredDate
+              shiftedStart &&
+              hoveredDate &&
+              fullDate > shiftedStart &&
+              fullDate < hoveredDate
             );
 
           const endDateSelectedAndIsSelectingStartDate =
             calendarType === 'startDate' &&
-            !startDate &&
+            !shiftedStart &&
             Boolean(
-              endDate && hoveredDate && fullDate < endDate && fullDate > hoveredDate
+              shiftedEnd && hoveredDate && fullDate < shiftedEnd && fullDate > hoveredDate
             );
 
           const shouldShowRangeIndicator =
@@ -207,23 +221,37 @@ const Calendar = ({
               return false;
             }
 
+            const originalFullDate = shiftFromTimezone(fullDate, timezone);
+
             // If the user selects a start date and changes the start date
             // use any hours, minutes, seconds they've already set
             if (calendarType === 'startDate' && startDate) {
-              fullDate.setHours(startDate.getHours());
-              fullDate.setMinutes(startDate.getMinutes());
-              fullDate.setSeconds(startDate.getSeconds());
+              if (timezone === 'UTC') {
+                originalFullDate.setUTCHours(startDate.getUTCHours());
+                originalFullDate.setUTCMinutes(startDate.getUTCMinutes());
+                originalFullDate.setUTCSeconds(startDate.getUTCSeconds());
+              } else {
+                originalFullDate.setHours(startDate.getHours());
+                originalFullDate.setMinutes(startDate.getMinutes());
+                originalFullDate.setSeconds(startDate.getSeconds());
+              }
             }
 
             // If the user selects an end date and changes the end date
             // use any hours, minutes, seconds they've already set
             if (calendarType === 'endDate' && endDate) {
-              fullDate.setHours(endDate.getHours());
-              fullDate.setMinutes(endDate.getMinutes());
-              fullDate.setSeconds(endDate.getSeconds());
+              if (timezone === 'UTC') {
+                originalFullDate.setUTCHours(endDate.getUTCHours());
+                originalFullDate.setUTCMinutes(endDate.getUTCMinutes());
+                originalFullDate.setUTCSeconds(endDate.getUTCSeconds());
+              } else {
+                originalFullDate.setHours(endDate.getHours());
+                originalFullDate.setMinutes(endDate.getMinutes());
+                originalFullDate.setSeconds(endDate.getSeconds());
+              }
             }
 
-            setSelectedDate(fullDate, calendarType);
+            setSelectedDate(originalFullDate, calendarType);
           };
 
           return (
@@ -387,10 +415,12 @@ interface TimeInputProps {
   date: Date | undefined;
   setDate: (date: Date) => void;
   shouldShowSeconds: boolean;
+  timezone: Timezone;
 }
 
-const TimeInput = ({ date, setDate, shouldShowSeconds }: TimeInputProps) => {
-  let dayjsDate = dayjs(date);
+const TimeInput = ({ date, setDate, shouldShowSeconds, timezone }: TimeInputProps) => {
+  let dayjsDate = timezone === 'UTC' ? dayjs.utc(date) : dayjs(date);
+
   if (!date) {
     dayjsDate = dayjsDate.hour(12).minute(0);
   }
@@ -577,6 +607,7 @@ interface TabbedCalendarProps {
   setStartDate: SetDate;
   shouldShowSeconds: boolean;
   startDate: Date | undefined;
+  timezone: Timezone;
 }
 
 const TabbedCalendar = ({
@@ -590,6 +621,7 @@ const TabbedCalendar = ({
   setStartDate,
   shouldShowSeconds,
   startDate,
+  timezone,
 }: TabbedCalendarProps) => {
   const [activeTab, setActiveTab] = useState<Tab>(defaultActiveTab);
 
@@ -652,7 +684,10 @@ const TabbedCalendar = ({
         </Tabs.Trigger>
       </StyledTriggerList>
       <Tabs.Content value="startDate">
-        <StyledCalendarRenderer calendarOptions={startDateCalendarOptions}>
+        <StyledCalendarRenderer
+          calendarOptions={startDateCalendarOptions}
+          timezone={timezone}
+        >
           {(body: Body) => (
             <Calendar
               calendarBody={body}
@@ -663,6 +698,7 @@ const TabbedCalendar = ({
               maxRangeLength={maxRangeLength}
               setSelectedDate={setSelectedDate}
               startDate={startDate}
+              timezone={timezone}
             />
           )}
         </StyledCalendarRenderer>
@@ -670,10 +706,14 @@ const TabbedCalendar = ({
           date={startDate}
           setDate={handleSetStartDate}
           shouldShowSeconds={shouldShowSeconds}
+          timezone={timezone}
         />
       </Tabs.Content>
       <Tabs.Content value="endDate">
-        <StyledCalendarRenderer calendarOptions={endDateCalendarOptions}>
+        <StyledCalendarRenderer
+          calendarOptions={endDateCalendarOptions}
+          timezone={timezone}
+        >
           {(body: Body) => (
             <Calendar
               calendarBody={body}
@@ -684,6 +724,7 @@ const TabbedCalendar = ({
               maxRangeLength={maxRangeLength}
               setSelectedDate={setSelectedDate}
               startDate={startDate}
+              timezone={timezone}
             />
           )}
         </StyledCalendarRenderer>
@@ -691,6 +732,7 @@ const TabbedCalendar = ({
           date={endDate}
           setDate={handleSetEndDate}
           shouldShowSeconds={shouldShowSeconds}
+          timezone={timezone}
         />
       </Tabs.Content>
     </Tabs>
@@ -711,6 +753,7 @@ export interface DateTimeRangePickerProps {
   maxRangeLength?: number;
   shouldShowSeconds?: boolean;
   startDate?: Date;
+  timezone?: Timezone;
 }
 
 export const DateTimeRangePicker = ({
@@ -727,6 +770,7 @@ export const DateTimeRangePicker = ({
   predefinedTimesList,
   shouldShowSeconds,
   startDate,
+  timezone = 'local',
 }: DateTimeRangePickerProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [selectedStartDate, setSelectedStartDate] = useState<Date>();
@@ -737,22 +781,44 @@ export const DateTimeRangePicker = ({
   const calendarContainerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (startDate) {
-      if (startDate.getHours() === 0) {
-        startDate.setHours(12);
-      }
-      setSelectedStartDate(startDate);
+    if (!startDate) {
+      return;
     }
-  }, [startDate]);
+
+    const startDateCopy = new Date(startDate);
+
+    const hours =
+      timezone === 'UTC' ? startDateCopy.getUTCHours() : startDateCopy.getHours();
+
+    if (hours === 0) {
+      if (timezone === 'UTC') {
+        startDateCopy.setUTCHours(12);
+      } else {
+        startDateCopy.setHours(12);
+      }
+    }
+
+    setSelectedStartDate(startDateCopy);
+  }, [startDate, timezone]);
 
   useEffect(() => {
-    if (endDate) {
-      if (endDate.getHours() === 0) {
-        endDate.setHours(12);
-      }
-      setSelectedEndDate(endDate);
+    if (!endDate) {
+      return;
     }
-  }, [endDate]);
+
+    const endDateCopy = new Date(endDate);
+
+    const hours = timezone === 'UTC' ? endDateCopy.getUTCHours() : endDateCopy.getHours();
+    if (hours === 0) {
+      if (timezone === 'UTC') {
+        endDateCopy.setUTCHours(12);
+      } else {
+        endDateCopy.setHours(12);
+      }
+    }
+
+    setSelectedEndDate(endDateCopy);
+  }, [endDate, timezone]);
 
   useLayoutEffect(() => {
     if (shouldShowCustomRange && calendarContainerRef.current) {
@@ -781,12 +847,23 @@ export const DateTimeRangePicker = ({
 
   const handleSelectDate = useCallback(
     (selectedDate: Date, calendarType: CalendarType): void => {
-      if (
-        selectedDate.getHours() === 0 &&
-        selectedDate.getMinutes() === 0 &&
-        selectedDate.getSeconds() === 0
-      ) {
-        selectedDate.setHours(12); // set the time to 12 noon if time hasn't been set yet
+      const isMidnight =
+        timezone === 'UTC'
+          ? selectedDate.getUTCHours() === 0 &&
+            selectedDate.getUTCMinutes() === 0 &&
+            selectedDate.getUTCSeconds() === 0
+          : selectedDate.getHours() === 0 &&
+            selectedDate.getMinutes() === 0 &&
+            selectedDate.getSeconds() === 0;
+
+      if (isMidnight) {
+        // set the time to 12 noon if time hasn't been set yet
+
+        if (timezone === 'UTC') {
+          selectedDate.setUTCHours(12);
+        } else {
+          selectedDate.setHours(12);
+        }
       }
 
       if (calendarType === 'startDate') {
@@ -813,7 +890,14 @@ export const DateTimeRangePicker = ({
         }
       }
     },
-    [onSelectDateRange, selectedEndDate, selectedStartDate]
+    [
+      closeDatePicker,
+      closeOnDateRangeSelected,
+      onSelectDateRange,
+      selectedEndDate,
+      selectedStartDate,
+      timezone,
+    ]
   );
 
   const onTriggerKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>) => {
@@ -843,6 +927,7 @@ export const DateTimeRangePicker = ({
           selectedEndDate={selectedEndDate}
           selectedStartDate={selectedStartDate}
           shouldShowSeconds={shouldShowSeconds}
+          timezone={timezone}
         />
       </Dropdown.Trigger>
       <Dropdown.Content align="start">
@@ -880,6 +965,7 @@ export const DateTimeRangePicker = ({
                     setStartDate={setSelectedStartDate}
                     shouldShowSeconds={Boolean(shouldShowSeconds)}
                     startDate={selectedStartDate}
+                    timezone={timezone}
                   />
                 </CalendarRendererContainer>
               )}
@@ -897,6 +983,7 @@ export const DateTimeRangePicker = ({
                 setStartDate={setSelectedStartDate}
                 shouldShowSeconds={Boolean(shouldShowSeconds)}
                 startDate={selectedStartDate}
+                timezone={timezone}
               />
             </>
           )}

--- a/src/components/DatePicker/DateTimeRangePicker.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.tsx
@@ -770,7 +770,7 @@ export const DateTimeRangePicker = ({
   predefinedTimesList,
   shouldShowSeconds,
   startDate,
-  timezone = 'local',
+  timezone = 'system',
 }: DateTimeRangePickerProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [selectedStartDate, setSelectedStartDate] = useState<Date>();

--- a/src/components/DatePicker/index.ts
+++ b/src/components/DatePicker/index.ts
@@ -2,6 +2,7 @@ export { DatePicker } from './DatePicker';
 export { DateRangePicker } from './DateRangePicker';
 export { DateTimeRangePicker } from './DateTimeRangePicker';
 
-export type { DatePickerProps } from './DatePicker.types';
+export type { DatePickerProps } from './DatePicker';
 export type { DateRangePickerProps } from './DateRangePicker';
 export type { DateTimeRangePickerProps, Tab } from './DateTimeRangePicker';
+export type { Timezone } from './utils';

--- a/src/components/DatePicker/utils.test.ts
+++ b/src/components/DatePicker/utils.test.ts
@@ -104,8 +104,8 @@ describe('DatePicker utils', () => {
     describe('when running in local mode', () => {
       it('passes the date through unchanged in both directions', () => {
         const date = new Date('2026-04-30T01:00:00Z');
-        expect(shiftToTimezone(date, 'local')).toBe(date);
-        expect(shiftFromTimezone(date, 'local')).toBe(date);
+        expect(shiftToTimezone(date, 'system')).toBe(date);
+        expect(shiftFromTimezone(date, 'system')).toBe(date);
       });
     });
 

--- a/src/components/DatePicker/utils.test.ts
+++ b/src/components/DatePicker/utils.test.ts
@@ -1,4 +1,11 @@
-import { datesAreWithinMaxRange, isDateRangeTheWholeMonth } from './utils';
+import {
+  datesAreWithinMaxRange,
+  formatSelectedDate,
+  formatSelectedDateTime,
+  shiftFromTimezone,
+  isDateRangeTheWholeMonth,
+  shiftToTimezone,
+} from './utils';
 
 describe('DatePicker utils', () => {
   describe('checking if two dates are fall within a range', () => {
@@ -70,6 +77,81 @@ describe('DatePicker utils', () => {
       startDate = new Date('02-01-2024');
       endDate = new Date('02-28-2024');
       expect(isDateRangeTheWholeMonth({ startDate, endDate })).toBeFalsy();
+    });
+
+    describe('when checking against UTC calendar boundaries', () => {
+      it('treats a range that spans a full UTC month as the whole month', () => {
+        const startDate = new Date('2026-04-01T00:00:00Z');
+        const endDate = new Date('2026-04-30T23:59:59.999Z');
+        expect(isDateRangeTheWholeMonth({ startDate, endDate }, 'UTC')).toBeTruthy();
+      });
+    });
+  });
+
+  describe('formatting dates in UTC mode', () => {
+    it('renders the calendar day from the UTC fields of the instant', () => {
+      const date = new Date('2026-04-30T01:00:00Z');
+      expect(formatSelectedDate('UTC', date)).toBe('Apr 30, 2026');
+    });
+
+    it('renders the time of day from the UTC hour and minute', () => {
+      const date = new Date('2026-04-30T14:30:00Z');
+      expect(formatSelectedDateTime('UTC', date)).toMatch(/02:30\s?PM/);
+    });
+  });
+
+  describe('translating an instant for the calendar grid', () => {
+    describe('when running in local mode', () => {
+      it('passes the date through unchanged in both directions', () => {
+        const date = new Date('2026-04-30T01:00:00Z');
+        expect(shiftToTimezone(date, 'local')).toBe(date);
+        expect(shiftFromTimezone(date, 'local')).toBe(date);
+      });
+    });
+
+    describe('when running in UTC mode on a host west of UTC', () => {
+      // Pretend the host is UTC-7 (PDT, offset = 420 min).
+      let offsetSpy: ReturnType<typeof vi.spyOn>;
+      beforeEach(() => {
+        offsetSpy = vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(420);
+      });
+      afterEach(() => {
+        offsetSpy.mockRestore();
+      });
+
+      it('shifts the instant forward by the host offset so local-time getters yield UTC values', () => {
+        const original = new Date('2026-04-30T01:00:00Z');
+        const shifted = shiftToTimezone(original, 'UTC');
+        expect(shifted.getTime() - original.getTime()).toBe(420 * 60_000);
+      });
+
+      it('recovers midnight UTC when un-shifting a midnight-local cell from the calendar grid', () => {
+        // Midnight Apr 30 on a UTC-7 host = 2026-04-30T07:00:00Z.
+        const cell = new Date('2026-04-30T07:00:00Z');
+        expect(shiftFromTimezone(cell, 'UTC').toISOString()).toBe(
+          '2026-04-30T00:00:00.000Z'
+        );
+      });
+    });
+
+    describe('when a round-trip crosses a DST transition', () => {
+      it('drifts by one hour because each direction reads its own offset', () => {
+        // Fake a DST transition at 10:00Z (offset 480 → 420). Forward shift
+        // crosses into DST; reverse shift uses the smaller offset, drifting +1h.
+        const dstStart = new Date('2026-03-08T10:00:00Z').getTime();
+        const offsetSpy = vi
+          .spyOn(Date.prototype, 'getTimezoneOffset')
+          .mockImplementation(function (this: Date) {
+            return this.getTime() < dstStart ? 480 : 420;
+          });
+        try {
+          const original = new Date('2026-03-08T07:30:00Z');
+          const restored = shiftFromTimezone(shiftToTimezone(original, 'UTC'), 'UTC');
+          expect(restored.getTime() - original.getTime()).toBe(60 * 60_000);
+        } finally {
+          offsetSpy.mockRestore();
+        }
+      });
     });
   });
 });

--- a/src/components/DatePicker/utils.ts
+++ b/src/components/DatePicker/utils.ts
@@ -1,6 +1,6 @@
 import { dayjs } from '@/utils/date';
 
-export type Timezone = 'local' | 'UTC';
+export type Timezone = 'system' | 'UTC';
 
 export interface DateRange {
   startDate: Date;
@@ -192,7 +192,7 @@ export const datesAreWithinMaxRange = (
 
 export const isDateRangeTheWholeMonth = (
   { startDate, endDate }: DateRange,
-  timezone: Timezone = 'local'
+  timezone: Timezone = 'system'
 ): boolean => {
   const start = timezone === 'UTC' ? dayjs.utc(startDate) : dayjs(startDate);
   const end = timezone === 'UTC' ? dayjs.utc(endDate) : dayjs(endDate);

--- a/src/components/DatePicker/utils.ts
+++ b/src/components/DatePicker/utils.ts
@@ -1,4 +1,6 @@
-import dayjs from 'dayjs';
+import { dayjs } from '@/utils/date';
+
+export type Timezone = 'local' | 'UTC';
 
 export interface DateRange {
   startDate: Date;
@@ -19,22 +21,34 @@ export interface DateRangeListItem {
   label: string;
 }
 
-export const selectedDateFormatter = new Intl.DateTimeFormat(locale, {
+const createFormatter = (options: Intl.DateTimeFormatOptions) => {
+  const timezoneFormatters: Partial<Record<Timezone, Intl.DateTimeFormat>> = {};
+
+  return (timezone: Timezone, date: Date): string => {
+    if (!timezoneFormatters[timezone]) {
+      const opts = timezone === 'UTC' ? { ...options, timeZone: 'UTC' } : options;
+      timezoneFormatters[timezone] = new Intl.DateTimeFormat(locale, opts);
+    }
+    return timezoneFormatters[timezone].format(date);
+  };
+};
+
+export const formatSelectedDate = createFormatter({
   day: '2-digit',
   month: 'short',
   year: 'numeric',
 });
 
-export const weekdayFormatter = new Intl.DateTimeFormat(locale, { weekday: 'short' });
+export const formatWeekday = createFormatter({ weekday: 'short' });
 
-export const selectedDateTimeFormatter = new Intl.DateTimeFormat(locale, {
+export const formatSelectedDateTime = createFormatter({
   day: '2-digit',
   month: 'short',
   hour: '2-digit',
   minute: '2-digit',
 });
 
-export const selectedDateTimeFormatterWithSeconds = new Intl.DateTimeFormat(locale, {
+export const formatSelectedDateTimeWithSeconds = createFormatter({
   day: '2-digit',
   month: 'short',
   hour: '2-digit',
@@ -42,20 +56,30 @@ export const selectedDateTimeFormatterWithSeconds = new Intl.DateTimeFormat(loca
   second: '2-digit',
 });
 
-export const selectedDateTimeDateFormatter = new Intl.DateTimeFormat(locale, {
-  day: '2-digit',
-  month: 'short',
-});
-
-export const timeFormatter = new Intl.DateTimeFormat(locale, {
-  hour: '2-digit',
-  minute: '2-digit',
-});
-
-export const headerDateFormatter = new Intl.DateTimeFormat(locale, {
+export const formatDateHeader = createFormatter({
   month: 'short',
   year: 'numeric',
 });
+
+// In UTC mode, shift by the host offset so local-time getters return UTC
+// values. shiftFromTimezone reverses it.
+//
+// Caveat: round-tripping across a DST boundary drifts by an hour — each
+// direction reads getTimezoneOffset on its own input. Call sites don't
+// round-trip the same Date, so this hasn't bitten us.
+export const shiftToTimezone = (date: Date, timezone: Timezone): Date => {
+  if (timezone !== 'UTC') {
+    return date;
+  }
+  return new Date(date.getTime() + date.getTimezoneOffset() * 60_000);
+};
+
+export const shiftFromTimezone = (date: Date, timezone: Timezone): Date => {
+  if (timezone !== 'UTC') {
+    return date;
+  }
+  return new Date(date.getTime() - date.getTimezoneOffset() * 60_000);
+};
 
 export const getPredefinedMonthsForDateRangePicker = (
   numberOfMonths: number
@@ -166,13 +190,17 @@ export const datesAreWithinMaxRange = (
   return daysDifference <= maxRangeLength;
 };
 
-export const isDateRangeTheWholeMonth = ({ startDate, endDate }: DateRange): boolean => {
-  if (startDate.getMonth() !== endDate.getMonth()) {
+export const isDateRangeTheWholeMonth = (
+  { startDate, endDate }: DateRange,
+  timezone: Timezone = 'local'
+): boolean => {
+  const start = timezone === 'UTC' ? dayjs.utc(startDate) : dayjs(startDate);
+  const end = timezone === 'UTC' ? dayjs.utc(endDate) : dayjs(endDate);
+
+  if (start.month() !== end.month()) {
     return false;
   }
 
-  const start = dayjs(startDate);
-  const end = dayjs(endDate);
   const startDateIsFirstDay = start.isSame(start.startOf('month'), 'day');
   const endDateIsLastDay = end.isSame(end.endOf('month'), 'day');
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,7 @@ export type { DateRangePickerProps } from './components/DatePicker/DateRangePick
 export { DateTimeRangePicker } from './components/DatePicker/DateTimeRangePicker';
 export type { DateTimeRangePickerProps } from './components/DatePicker/DateTimeRangePicker';
 export { getPredefinedMonthsForDateRangePicker } from './components/DatePicker/utils';
-export type { DateRange } from './components/DatePicker/utils';
+export type { DateRange, Timezone } from './components/DatePicker/utils';
 
 // Dialog
 export { Dialog } from './components/Dialog';


### PR DESCRIPTION
Adds `timezone` field to `DatePicker`, `DateRangePicker` and `DateTimeRangePicker`, allowing the user to configure whether to display dates in system or utc, defaulting to `system` to maintain backwards compatibility.

### Usage

#### DatePicker
```ts
<DatePicker
  onSelectDate={handleDateSelect}
  timezone="system"
/>

```

#### DateRangePicker
```ts
<DateRangePicker
  onSelectDateRange={(startDate, endDate) =>
    setStartDate(startDate);
    setEndDate(endDate);
  }
  timezone="UTC"
/>

```

#### DateTimeRangePicker
```ts
<DateTimeRangePicker
  endDate={endDate}
  onSelectDateRange={handleDateRangeSelected}
  startDate={startDate}
  timezone="system"
/>
```
