### PR TITLE
ci: fix prepare after removing husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -383,7 +383,7 @@
     "lint:code:fix": "eslint src --report-unused-disable-directives --fix",
     "lint:css": "stylelint \"src/**/*.css\"",
     "lint:css:fix": "stylelint \"src/**/*.css\" --fix",
-    "prepare": "husky",
+    "prepare": "yarn test && yarn format && yarn lint && yarn changeset:verify && yarn circular-dependency:check",
     "prettify": "yarn format:fix",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
## Why?

https://github.com/ClickHouse/click-ui/pull/1016/ removed husky since it ran on local commits. Unfortunately it also ran as part of building, which [failed](https://github.com/ClickHouse/click-ui/actions/runs/25321142756/job/74230207003) when trying to release 0.2.0-rc.8. This adds back in the commands that husky ran so that running `yarn prepare` is identical to the pre-commit hooks we used to have.