### PR TITLE
feat: add validation states to datetimerangepicker

### DIFF
--- a/.changeset/ninety-hounds-leave.md
+++ b/.changeset/ninety-hounds-leave.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': minor
+---
+
+Adds validation for date ranges and validation states for DateTimeRangePicker. When invalid, the input will be highlighted in red and the reason will be displayed below the date input.

--- a/src/components/DatePicker/Common.tsx
+++ b/src/components/DatePicker/Common.tsx
@@ -15,6 +15,7 @@ import { useCalendar, UseCalendarOptions } from '@h6s/calendar';
 import { IconButton, IconButtonSize } from '@/components/IconButton';
 import { Text } from '@/components/Text';
 import {
+  dateRangeIsValid,
   formatDateHeader,
   formatSelectedDate,
   formatSelectedDateTime,
@@ -44,13 +45,18 @@ const yearsOffset = Math.floor(totalYears / 2);
 const HighlightedInputWrapper = styled(InputWrapper)<{
   $isActive: boolean;
   $width?: string;
+  error?: boolean;
 }>`
-  ${({ $isActive, $width, theme }) => {
-    return `border: ${theme.click.datePicker.dateOption.stroke} solid ${
-      $isActive
-        ? theme.click.datePicker.dateOption.color.stroke.active
-        : theme.click.field.color.stroke.default
-    };
+  ${({ $isActive, $width, error, theme }) => {
+    let borderColor = $isActive
+      ? theme.click.datePicker.dateOption.color.stroke.active
+      : theme.click.field.color.stroke.default;
+
+    if (error) {
+      borderColor = theme.click.field.color.stroke.error;
+    }
+
+    return `border: ${theme.click.datePicker.dateOption.stroke} solid ${borderColor};
     width: ${$width ? $width : explicitWidth};
     ${$width && `min-width: ${explicitWidth};`}
     `;
@@ -281,12 +287,21 @@ export const DateTimeRangePickerInput = ({
     );
   }
 
+  const startDateIsAfterEndDate =
+    selectedStartDate &&
+    selectedEndDate &&
+    !dateRangeIsValid({
+      startDate: selectedStartDate,
+      endDate: selectedEndDate,
+    });
+
   return (
     <HighlightedInputWrapper
       $isActive={isActive}
-      disabled={disabled}
-      id={id ?? defaultId}
       $width="max-content"
+      disabled={disabled}
+      error={startDateIsAfterEndDate}
+      id={id ?? defaultId}
     >
       <InputStartContent>
         <Icon name="calendar" />

--- a/src/components/DatePicker/DateTimeRangePicker.stories.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.stories.tsx
@@ -321,6 +321,41 @@ export const TimezoneLocalVsUTC: Story = {
   },
 };
 
+export const DontFireIfInvalid: Story = {
+  args: {
+    maxRangeLength: 15,
+    predefinedTimesList: [],
+    shouldShowSeconds: true,
+  },
+  render: (args: Args) => {
+    const endDate = args.endDate
+      ? new Date(args.endDate)
+      : new Date('2026-05-01T12:00:00Z');
+    const startDate = args.startDate
+      ? new Date(args.startDate)
+      : new Date(endDate.getTime() - 3600);
+
+    const futureDatesDisabled = args.futureDatesDisabled ?? true;
+
+    return (
+      <DateTimeRangePicker
+        key="default"
+        defaultActiveTab="endDate"
+        endDate={endDate}
+        disabled={args.disabled}
+        futureDatesDisabled={futureDatesDisabled}
+        futureStartDatesDisabled={args.futureStartDatesDisabled}
+        maxRangeLength={args.maxRangeLength}
+        onSelectDateRange={args.onSelectDateRange}
+        placeholder={args.placeholder}
+        startDate={startDate}
+        shouldFireIfInvalid={false}
+        shouldShowSeconds={args.shouldShowSeconds}
+      />
+    );
+  },
+};
+
 export const DefaultActiveTabEndDate: Story = {
   args: {
     maxRangeLength: 15,

--- a/src/components/DatePicker/DateTimeRangePicker.test.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.test.tsx
@@ -749,6 +749,275 @@ describe('DateTimeRangePicker', () => {
     });
   });
 
+  describe('not firing onSelectedDate on invalid date ranges', () => {
+    beforeEach(() => {
+      vi.setSystemTime(new Date('07-10-2020 11:30 AM'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    describe('when shouldFireIfInvalid is true', () => {
+      it('fires the callback when a new end date lands before the existing start date', async () => {
+        const handleSelectDate = vi.fn();
+        const startDate = new Date('07-10-2020 12:00');
+        const endDate = new Date('07-15-2020 12:00');
+
+        const { getByTestId, getByText } = renderCUI(
+          <DateTimeRangePicker
+            startDate={startDate}
+            endDate={endDate}
+            defaultActiveTab="endDate"
+            onSelectDateRange={handleSelectDate}
+          />
+        );
+
+        await userEvent.click(getByTestId('datetimepicker-input'));
+        await userEvent.click(getByText('5'));
+
+        expect(handleSelectDate).toHaveBeenCalledOnce();
+      });
+
+      it('fires the callback when a new start date lands after the existing end date', async () => {
+        const handleSelectDate = vi.fn();
+        const startDate = new Date('07-10-2020 12:00');
+        const endDate = new Date('07-15-2020 12:00');
+
+        const { getByTestId, getByText } = renderCUI(
+          <DateTimeRangePicker
+            startDate={startDate}
+            endDate={endDate}
+            defaultActiveTab="startDate"
+            onSelectDateRange={handleSelectDate}
+          />
+        );
+
+        await userEvent.click(getByTestId('datetimepicker-input'));
+        await userEvent.click(getByText('20'));
+
+        expect(handleSelectDate).toHaveBeenCalledOnce();
+      });
+    });
+
+    describe('when shouldFireIfInvalid is false', () => {
+      it('does not fire the callback when a new end date lands before the existing start date', async () => {
+        const handleSelectDate = vi.fn();
+        const startDate = new Date('07-10-2020 12:00');
+        const endDate = new Date('07-15-2020 12:00');
+
+        const { getByTestId, getByText } = renderCUI(
+          <DateTimeRangePicker
+            startDate={startDate}
+            endDate={endDate}
+            defaultActiveTab="endDate"
+            shouldFireIfInvalid={false}
+            onSelectDateRange={handleSelectDate}
+          />
+        );
+
+        await userEvent.click(getByTestId('datetimepicker-input'));
+        await userEvent.click(getByText('5'));
+
+        expect(handleSelectDate).not.toHaveBeenCalled();
+      });
+
+      it('does not fire the callback when a new start date lands after the existing end date', async () => {
+        const handleSelectDate = vi.fn();
+        const startDate = new Date('07-10-2020 12:00');
+        const endDate = new Date('07-15-2020 12:00');
+
+        const { getByTestId, getByText } = renderCUI(
+          <DateTimeRangePicker
+            startDate={startDate}
+            endDate={endDate}
+            defaultActiveTab="startDate"
+            shouldFireIfInvalid={false}
+            onSelectDateRange={handleSelectDate}
+          />
+        );
+
+        await userEvent.click(getByTestId('datetimepicker-input'));
+        await userEvent.click(getByText('20'));
+
+        expect(handleSelectDate).not.toHaveBeenCalled();
+      });
+
+      it('reflects the invalid selection in the input even though the callback is suppressed', async () => {
+        const handleSelectDate = vi.fn();
+        const startDate = new Date('07-10-2020 12:00');
+        const endDate = new Date('07-15-2020 12:00');
+
+        const { getByTestId, getByText } = renderCUI(
+          <DateTimeRangePicker
+            startDate={startDate}
+            endDate={endDate}
+            defaultActiveTab="endDate"
+            shouldFireIfInvalid={false}
+            onSelectDateRange={handleSelectDate}
+          />
+        );
+
+        await userEvent.click(getByTestId('datetimepicker-input'));
+        await userEvent.click(getByText('5'));
+
+        expect(getByTestId('datetimepicker-input').textContent).toBe(
+          'Jul 10, 12:00 pm – Jul 05, 12:00 pm'
+        );
+      });
+
+      it('fires the callback once the range returns to a valid state', async () => {
+        const handleSelectDate = vi.fn();
+        const startDate = new Date('07-10-2020 12:00');
+        const endDate = new Date('07-15-2020 12:00');
+
+        const { getByTestId, getByText } = renderCUI(
+          <DateTimeRangePicker
+            startDate={startDate}
+            endDate={endDate}
+            defaultActiveTab="endDate"
+            shouldFireIfInvalid={false}
+            onSelectDateRange={handleSelectDate}
+          />
+        );
+
+        await userEvent.click(getByTestId('datetimepicker-input'));
+        await userEvent.click(getByText('5'));
+        expect(handleSelectDate).not.toHaveBeenCalled();
+
+        await userEvent.click(getByText('20'));
+        expect(handleSelectDate).toHaveBeenCalledOnce();
+      });
+    });
+  });
+
+  describe('showing a validation message', () => {
+    beforeEach(() => {
+      vi.setSystemTime(new Date('07-10-2020 11:30 AM'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('displays the message when an out-of-order range is provided via props', async () => {
+      const startDate = new Date('07-15-2020 12:00');
+      const endDate = new Date('07-10-2020 12:00');
+
+      const { getByTestId, getByText } = renderCUI(
+        <DateTimeRangePicker
+          startDate={startDate}
+          endDate={endDate}
+          onSelectDateRange={vi.fn()}
+        />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+
+      expect(getByText('End date and time must be after start')).toBeVisible();
+    });
+
+    it('shows no message when the range is in order', async () => {
+      const startDate = new Date('07-10-2020 12:00');
+      const endDate = new Date('07-15-2020 12:00');
+
+      const { getByTestId, queryByText } = renderCUI(
+        <DateTimeRangePicker
+          startDate={startDate}
+          endDate={endDate}
+          onSelectDateRange={vi.fn()}
+        />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+
+      expect(
+        queryByText('End date and time must be after start')
+      ).not.toBeInTheDocument();
+    });
+
+    it('omits the message when only one endpoint is set', async () => {
+      const { getByTestId, queryByText } = renderCUI(
+        <DateTimeRangePicker
+          startDate={new Date('07-15-2020 12:00')}
+          onSelectDateRange={vi.fn()}
+        />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+
+      expect(
+        queryByText('End date and time must be after start')
+      ).not.toBeInTheDocument();
+    });
+
+    it('appears after a user selection creates an out-of-order range', async () => {
+      const startDate = new Date('07-10-2020 12:00');
+      const endDate = new Date('07-15-2020 12:00');
+
+      const { getByTestId, getByText, queryByText } = renderCUI(
+        <DateTimeRangePicker
+          startDate={startDate}
+          endDate={endDate}
+          defaultActiveTab="endDate"
+          onSelectDateRange={vi.fn()}
+        />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+      expect(
+        queryByText('End date and time must be after start')
+      ).not.toBeInTheDocument();
+
+      await userEvent.click(getByText('5'));
+
+      expect(getByText('End date and time must be after start')).toBeVisible();
+    });
+
+    it('disappears once the user corrects the range', async () => {
+      const startDate = new Date('07-15-2020 12:00');
+      const endDate = new Date('07-10-2020 12:00');
+
+      const { getByTestId, getByText, queryByText } = renderCUI(
+        <DateTimeRangePicker
+          startDate={startDate}
+          endDate={endDate}
+          defaultActiveTab="endDate"
+          onSelectDateRange={vi.fn()}
+        />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+      expect(getByText('End date and time must be after start')).toBeVisible();
+
+      await userEvent.click(getByText('25'));
+
+      expect(
+        queryByText('End date and time must be after start')
+      ).not.toBeInTheDocument();
+    });
+
+    it('remains visible after switching between the start and end tabs', async () => {
+      const startDate = new Date('07-15-2020 12:00');
+      const endDate = new Date('07-10-2020 12:00');
+
+      const { getByTestId, getByText } = renderCUI(
+        <DateTimeRangePicker
+          startDate={startDate}
+          endDate={endDate}
+          defaultActiveTab="startDate"
+          onSelectDateRange={vi.fn()}
+        />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+      expect(getByText('End date and time must be after start')).toBeVisible();
+
+      await userEvent.click(getByTestId('tabbed-calendar-trigger-end'));
+      expect(getByText('End date and time must be after start')).toBeVisible();
+    });
+  });
+
   describe('predefined times', () => {
     beforeEach(() => {
       vi.setSystemTime(new Date('07-04-2020 11:30 AM'));

--- a/src/components/DatePicker/DateTimeRangePicker.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.tsx
@@ -29,12 +29,14 @@ import {
   Meridiem,
   Timezone,
   shiftToTimezone,
+  dateRangeIsValid,
 } from './utils';
 import { dayjs, Dayjs } from '@/utils/date';
 import { Tabs } from '../Tabs/Tabs';
 import { TextField } from '@/components/TextField';
 import { ButtonGroup } from '../ButtonGroup/ButtonGroup';
 import { Label } from '../Label/Label';
+import { Text } from '../Text';
 
 const calendarFullWidth = '258px';
 
@@ -64,10 +66,18 @@ const CalendarRendererContainer = styled.div<{ $openDirection?: OpenDirection }>
   top: 0;
 `;
 
+const NoOverflowDropdownContent = styled(Dropdown.Content)`
+  overflow-y: hidden;
+`;
+
 // Height of 221px is height the height the calendar needs to match the PredefinedTimesContainer
 const StyledCalendarRenderer = styled(CalendarRenderer)`
   border-radius: ${({ theme }) => theme.click.datePicker.dateOption.radii.default};
   min-height: 221px;
+`;
+
+const BottomPaddingTabs = styled(Tabs)`
+  padding-bottom: ${({ theme }) => `${theme.sizes[3]};`};
 `;
 
 const StyledTriggerList = styled(Tabs.TriggersList)`
@@ -549,14 +559,15 @@ const TimeInput = ({ date, setDate, shouldShowSeconds, timezone }: TimeInputProp
       padding="xs"
       maxWidth={`${calendarFullWidth}`}
       orientation="horizontal"
+      justifyContent="end"
     >
-      <Container maxWidth="10%">
+      <Container maxWidth="8%">
         <Label htmlFor="date-time-picker-time-input">Time</Label>
       </Container>
       <Container
-        gap="md"
         justifyContent="space-evenly"
         orientation="horizontal"
+        maxWidth="85%"
       >
         <Container
           maxWidth="45%"
@@ -664,8 +675,11 @@ const TabbedCalendar = ({
     endDateCalendarOptions.defaultDate = endDate;
   }
 
+  const startDateIsAfterEndDate =
+    startDate && endDate && !dateRangeIsValid({ startDate, endDate });
+
   return (
-    <Tabs
+    <BottomPaddingTabs
       onValueChange={handleTabChange}
       value={activeTab}
     >
@@ -735,7 +749,16 @@ const TabbedCalendar = ({
           timezone={timezone}
         />
       </Tabs.Content>
-    </Tabs>
+      {startDateIsAfterEndDate && (
+        <Text
+          align="center"
+          color="danger"
+          fillWidth
+        >
+          End date and time must be after start
+        </Text>
+      )}
+    </BottomPaddingTabs>
   );
 };
 
@@ -751,6 +774,7 @@ export interface DateTimeRangePickerProps {
   placeholder?: string;
   predefinedTimesList?: DateRangeListItem[];
   maxRangeLength?: number;
+  shouldFireIfInvalid?: boolean;
   shouldShowSeconds?: boolean;
   startDate?: Date;
   timezone?: Timezone;
@@ -768,6 +792,7 @@ export const DateTimeRangePicker = ({
   openDirection = 'right',
   placeholder = 'start date – end date',
   predefinedTimesList,
+  shouldFireIfInvalid = true,
   shouldShowSeconds,
   startDate,
   timezone = 'system',
@@ -870,6 +895,13 @@ export const DateTimeRangePicker = ({
         setSelectedStartDate(selectedDate);
 
         if (selectedEndDate) {
+          if (
+            !shouldFireIfInvalid &&
+            !dateRangeIsValid({ startDate: selectedDate, endDate: selectedEndDate })
+          ) {
+            return;
+          }
+
           onSelectDateRange(selectedDate, selectedEndDate);
 
           if (closeOnDateRangeSelected) {
@@ -882,6 +914,13 @@ export const DateTimeRangePicker = ({
         setSelectedEndDate(selectedDate);
 
         if (selectedStartDate) {
+          if (
+            !shouldFireIfInvalid &&
+            !dateRangeIsValid({ startDate: selectedStartDate, endDate: selectedDate })
+          ) {
+            return;
+          }
+
           onSelectDateRange(selectedStartDate, selectedDate);
 
           if (closeOnDateRangeSelected) {
@@ -896,6 +935,7 @@ export const DateTimeRangePicker = ({
       onSelectDateRange,
       selectedEndDate,
       selectedStartDate,
+      shouldFireIfInvalid,
       timezone,
     ]
   );
@@ -930,7 +970,7 @@ export const DateTimeRangePicker = ({
           timezone={timezone}
         />
       </Dropdown.Trigger>
-      <Dropdown.Content align="start">
+      <NoOverflowDropdownContent align="start">
         <Container orientation="horizontal">
           {shouldShowPredefinedTimes ? (
             <PredefinedCalendarContainer
@@ -988,7 +1028,7 @@ export const DateTimeRangePicker = ({
             </>
           )}
         </Container>
-      </Dropdown.Content>
+      </NoOverflowDropdownContent>
     </Dropdown>
   );
 };

--- a/src/components/DatePicker/utils.test.ts
+++ b/src/components/DatePicker/utils.test.ts
@@ -1,4 +1,6 @@
 import {
+  DateRange,
+  dateRangeIsValid,
   datesAreWithinMaxRange,
   formatSelectedDate,
   formatSelectedDateTime,
@@ -89,7 +91,7 @@ describe('DatePicker utils', () => {
   });
 
   describe('formatting dates in UTC mode', () => {
-    it('renders the calendar day from the UTC fields of the instant', () => {
+    it('renders the calendar day from the UTC fields of the date', () => {
       const date = new Date('2026-04-30T01:00:00Z');
       expect(formatSelectedDate('UTC', date)).toBe('Apr 30, 2026');
     });
@@ -100,7 +102,104 @@ describe('DatePicker utils', () => {
     });
   });
 
-  describe('translating an instant for the calendar grid', () => {
+  describe('validating a date range', () => {
+    it('rejects a range with no start date', () => {
+      expect(
+        dateRangeIsValid({
+          startDate: undefined as unknown as Date,
+          endDate: new Date('2026-04-30'),
+        })
+      ).toBe(false);
+    });
+
+    it('rejects a range with no end date', () => {
+      expect(
+        dateRangeIsValid({
+          startDate: new Date('2026-04-01'),
+          endDate: undefined as unknown as Date,
+        })
+      ).toBe(false);
+    });
+
+    it('rejects a null date range', () => {
+      expect(dateRangeIsValid(null as unknown as DateRange)).toBe(false);
+    });
+
+    it('rejects a start date that is a date-shaped string', () => {
+      expect(
+        dateRangeIsValid({
+          startDate: '2026-04-01' as unknown as Date,
+          endDate: new Date('2026-04-30'),
+        })
+      ).toBe(false);
+    });
+
+    it('rejects an end date that is a date-shaped string', () => {
+      expect(
+        dateRangeIsValid({
+          startDate: new Date('2026-04-01'),
+          endDate: '2026-04-30' as unknown as Date,
+        })
+      ).toBe(false);
+    });
+
+    it('rejects a start date that is a Date holding NaN', () => {
+      expect(
+        dateRangeIsValid({
+          startDate: new Date('not-a-date'),
+          endDate: new Date('2026-04-30'),
+        })
+      ).toBe(false);
+    });
+
+    it('rejects an end date that is a Date holding NaN', () => {
+      expect(
+        dateRangeIsValid({
+          startDate: new Date('2026-04-01'),
+          endDate: new Date('not-a-date'),
+        })
+      ).toBe(false);
+    });
+
+    it('rejects a range whose start date is after its end date', () => {
+      expect(
+        dateRangeIsValid({
+          startDate: new Date('2026-04-30'),
+          endDate: new Date('2026-04-01'),
+        })
+      ).toBe(false);
+    });
+
+    it('accepts a range spanning multiple days', () => {
+      expect(
+        dateRangeIsValid({
+          startDate: new Date('2026-04-01'),
+          endDate: new Date('2026-04-30'),
+        })
+      ).toBe(true);
+    });
+
+    it('accepts a range where start and end are the same date', () => {
+      const date = new Date('2026-04-15T12:00:00Z');
+      expect(
+        dateRangeIsValid({
+          startDate: date,
+          endDate: new Date(date.getTime()),
+        })
+      ).toBe(true);
+    });
+
+    it('accepts a range starting at the unix epoch', () => {
+      expect(
+        dateRangeIsValid({
+          startDate: new Date(0),
+          endDate: new Date('2026-04-30'),
+        })
+      ).toBe(true);
+    });
+  });
+
+  describe('translating an date for the calendar grid', () => {
     describe('when running in local mode', () => {
       it('passes the date through unchanged in both directions', () => {
         const date = new Date('2026-04-30T01:00:00Z');
@@ -119,7 +218,7 @@ describe('DatePicker utils', () => {
         offsetSpy.mockRestore();
       });
 
-      it('shifts the instant forward by the host offset so local-time getters yield UTC values', () => {
+      it('shifts the date forward by the host offset so local-time getters yield UTC values', () => {
         const original = new Date('2026-04-30T01:00:00Z');
         const shifted = shiftToTimezone(original, 'UTC');
         expect(shifted.getTime() - original.getTime()).toBe(420 * 60_000);

--- a/src/components/DatePicker/utils.ts
+++ b/src/components/DatePicker/utils.ts
@@ -206,3 +206,23 @@ export const isDateRangeTheWholeMonth = (
 
   return startDateIsFirstDay && endDateIsLastDay;
 };
+
+export const dateRangeIsValid = (dateRange: DateRange): boolean => {
+  if (!dateRange?.startDate || !dateRange?.endDate) {
+    return false;
+  }
+
+  if (!(dateRange.startDate instanceof Date) || !dayjs(dateRange.startDate).isValid()) {
+    return false;
+  }
+
+  if (!(dateRange.endDate instanceof Date) || !dayjs(dateRange.endDate).isValid()) {
+    return false;
+  }
+
+  if (dateRange.startDate.getTime() > dateRange.endDate.getTime()) {
+    return false;
+  }
+
+  return true;
+};


### PR DESCRIPTION
After using the DateTimeRangePicker in a feature, it became clear from a UX standpoint we need a validation state. Not letting users enter invalid dates makes using the date picker much more tedious; the user needs to switch between the start date and end date tabs many more times to change dates that are already selected.

- Adds a date range validator function
- Adds a property to not fire the date selection callback when dates are invalid
- When date ranges are invalid, the input will be highlighted in red
  - Works with second level precision

<img width="488" height="475" alt="Screenshot 2026-05-11 at 4 18 54 PM" src="https://github.com/user-attachments/assets/ba9d9456-3326-4ccd-a66f-d8c92eefe567" />

https://github.com/user-attachments/assets/b1c14629-2215-4265-916a-7dc9d28ccb9f

