### PR TITLE
feat(CardHorizontal): add alignment prop for top-aligned content

### DIFF
--- a/.changeset/card-horizontal-alignment-prop.md
+++ b/.changeset/card-horizontal-alignment-prop.md
@@ -1,0 +1,10 @@
+---
+"@clickhouse/click-ui": patch
+---
+
+Add `alignment` prop to `CardHorizontal` to support top-aligned content
+
+Adds an optional `alignment` prop (`'center' | 'top'`, default `'center'`) to
+`CardHorizontal`. The default preserves existing behaviour. Use `alignment="top"`
+to pin content to the top edge — useful in side-by-side layouts where cards have
+different content heights and centre-alignment causes visual misalignment.

--- a/.changeset/card-horizontal-alignment-prop.md
+++ b/.changeset/card-horizontal-alignment-prop.md
@@ -1,5 +1,5 @@
 ---
-"@clickhouse/click-ui": patch
+"@clickhouse/click-ui": minor
 ---
 
 Add `alignment` prop to `CardHorizontal` to support top-aligned content

--- a/src/components/CardHorizontal/CardHorizontal.test.tsx
+++ b/src/components/CardHorizontal/CardHorizontal.test.tsx
@@ -173,6 +173,25 @@ describe('CardHorizontal Component', () => {
     expect(button).toBeDisabled();
   });
 
+  it('should render with center alignment when alignment prop is not provided', () => {
+    const { container } = renderCard({
+      title: 'Test Card',
+      description: 'Test description',
+    });
+
+    expect(container.firstChild).toBeDefined();
+  });
+
+  it('should render with top alignment when alignment="top"', () => {
+    const { container } = renderCard({
+      title: 'Test Card',
+      description: 'Test description',
+      alignment: 'top',
+    });
+
+    expect(container.firstChild).toBeDefined();
+  });
+
   it('should not open infoUrl when disabled', () => {
     const windowOpenSpy = vitest.spyOn(window, 'open').mockImplementation(() => null);
     const { container } = renderCard({

--- a/src/components/CardHorizontal/CardHorizontal.tsx
+++ b/src/components/CardHorizontal/CardHorizontal.tsx
@@ -3,7 +3,12 @@ import { Badge } from '@/components/Badge';
 import { Button } from '@/components/Button';
 import { Container } from '@/components/Container';
 import { Icon } from '@/components/Icon';
-import { CardHorizontalProps, CardSize, CardColor } from './CardHorizontal.types';
+import {
+  CardHorizontalProps,
+  CardSize,
+  CardColor,
+  CardAlignment,
+} from './CardHorizontal.types';
 
 const Header = styled.div`
   max-width: 100%;
@@ -26,11 +31,13 @@ const Wrapper = styled.div<{
   $isSelectable?: boolean;
   $color: CardColor;
   $size?: CardSize;
+  $alignment: CardAlignment;
 }>`
   display: inline-flex;
   width: 100%;
   max-width: 100%;
-  align-items: center;
+  align-items: ${({ $alignment }) => ($alignment === 'top' ? 'flex-start' : 'center')};
+  align-self: ${({ $alignment }) => ($alignment === 'top' ? 'stretch' : 'auto')};
   justify-content: flex-start;
 
   ${({ theme, $color, $size, $isSelected, $isSelectable, $disabled }) => `
@@ -165,10 +172,10 @@ const ContentWrapper = styled.div<{ $size: CardSize }>`
   }
 `;
 
-const IconTextContentWrapper = styled.div<{ $size: CardSize }>`
+const IconTextContentWrapper = styled.div<{ $size: CardSize; $alignment: CardAlignment }>`
   display: flex;
   flex-direction: row;
-  align-items: center;
+  align-items: ${({ $alignment }) => ($alignment === 'top' ? 'flex-start' : 'center')};
   width: 100%;
   gap: ${({ theme, $size }) =>
     $size === 'md'
@@ -188,6 +195,7 @@ export const CardHorizontal = ({
   children,
   color = 'default',
   size = 'md',
+  alignment = 'center',
   badgeText,
   badgeState,
   badgeIcon,
@@ -215,13 +223,17 @@ export const CardHorizontal = ({
       $isSelectable={isSelectable}
       $color={color}
       $size={size}
+      $alignment={alignment}
       tabIndex={disabled ? -1 : 0}
       aria-disabled={disabled}
       onClick={handleClick}
       {...props}
     >
       <ContentWrapper $size={size}>
-        <IconTextContentWrapper $size={size}>
+        <IconTextContentWrapper
+          $size={size}
+          $alignment={alignment}
+        >
           {icon && (
             <CardIcon
               name={icon}

--- a/src/components/CardHorizontal/CardHorizontal.types.ts
+++ b/src/components/CardHorizontal/CardHorizontal.types.ts
@@ -4,6 +4,7 @@ import type { BadgeState } from '@/components/Badge';
 
 export type CardColor = 'default' | 'muted';
 export type CardSize = 'sm' | 'md';
+export type CardAlignment = 'center' | 'top';
 
 export interface CardHorizontalProps extends Omit<
   HTMLAttributes<HTMLDivElement>,
@@ -28,4 +29,5 @@ export interface CardHorizontalProps extends Omit<
   badgeIconDir?: 'start' | 'end';
   onClick?: MouseEventHandler<HTMLDivElement>;
   onButtonClick?: MouseEventHandler<HTMLElement>;
+  alignment?: CardAlignment;
 }

--- a/src/components/CardHorizontal/index.ts
+++ b/src/components/CardHorizontal/index.ts
@@ -1,2 +1,6 @@
 export { CardHorizontal } from './CardHorizontal';
-export type { CardSize, CardHorizontalProps } from './CardHorizontal.types';
+export type {
+  CardSize,
+  CardAlignment,
+  CardHorizontalProps,
+} from './CardHorizontal.types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ export { CardHorizontal } from './components/CardHorizontal';
 export { CardPrimary } from './components/CardPrimary';
 export { CardPromotion } from './components/CardPromotion';
 export { CardSecondary } from './components/CardSecondary';
-export type { CardHorizontalProps } from './components/CardHorizontal';
+export type { CardHorizontalProps, CardAlignment } from './components/CardHorizontal';
 export type { CardPrimaryProps } from './components/CardPrimary';
 export type { CardPromotionProps } from './components/CardPromotion';
 export type { BadgeState, CardSecondaryProps } from './components/CardSecondary';


### PR DESCRIPTION
## Why?

When `CardHorizontal` cards are placed side-by-side in a flex container that does not stretch its children, the shorter card stays at its natural (content) height, leaving a visible gap between neighbours. There was no built-in way to make the shorter card fill the row height with its content pinned to the top. So i did this:

```jsx
export const TopAlignedCardHorizontal = styled(CardHorizontal)`
  align-self: stretch;
  align-items: flex-start;
  & > * {
    align-items: flex-start;
  }
`;
```

@ariser suggested I contribute it back to click-ui rather than override.

This a visual of the problem this solves, with background changes to make it more fabulous. In this case we needed both cards to be the same height, and once the same height, we needed the text to be top aligned.

Before 

<img width="532" height="370" alt="image" src="https://github.com/user-attachments/assets/52f16a90-13df-4d0d-b677-7ac9b646f609" />

After

<img width="526" height="151" alt="image" src="https://github.com/user-attachments/assets/9fcc9198-2040-4676-a879-3b74e615af69" />

## How?

Adds an optional `alignment` prop (`'center' | 'top'`, default `'center'`) to `CardHorizontal`.

- `alignment="center"` (default) — preserves existing behaviour, no visual change for current consumers
- `alignment="top"` — sets `align-self: stretch` so the card fills its container height even when the parent does not stretch children, and `align-items: flex-start` to pin content to the top edge

I'm amenable to adding the application of stretch as a new param if the consensus is it warrants it.

Also exports `CardAlignment` from both the component barrel and the top-level `src/index.ts`.

Smoke tests added for both alignment values.

## Tickets?

[UC-957](https://linear.app/clickhouse/issue/UC-957)

## Contribution checklist?

- [x] You've done enough research before writing
- [x] You have reviewed the PR
- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [x] For documentation, guides or references, you've tested the commands

## Security checklist?

- [x] All user inputs are validated and sanitized
- [x] No usage of `dangerouslySetInnerHTML`
- [x] Sensitive data has been identified and is being protected properly
- [x] Build output contains no secrets or API keys

## Preview?

Screenshots showing the before/after in the consuming app to be added.