### PR TITLE
feat(DateTimeRangePicker): add predefinedDateLabel prop to onSelectDateRange

### DIFF
--- a/.changeset/puny-parts-cough.md
+++ b/.changeset/puny-parts-cough.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': minor
+---
+
+`DateTimeRangePicker` adds an optional prop `predefinedDateLabel` to `onSelectDateRange` which passes the label of the predefined date that was selected. This will allow the callback function to know if it was a custom range or a predefined one that was selected

--- a/src/components/DatePicker/DateTimeRangePicker.stories.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.stories.tsx
@@ -8,8 +8,14 @@ const meta: Meta<typeof DateTimeRangePicker> = {
   component: DateTimeRangePicker,
   args: {
     maxRangeLength: undefined,
-    onSelectDateRange: (startDate: Date, endDate: Date) => {
-      console.log('Date range selected: ', startDate, endDate);
+    onSelectDateRange: (startDate: Date, endDate: Date, predefinedDateLabel) => {
+      console.log(
+        'Date range selected: ',
+        startDate,
+        endDate,
+        'predefinedDateLabel: ',
+        predefinedDateLabel
+      );
     },
   },
   tags: ['autodocs'],

--- a/src/components/DatePicker/DateTimeRangePicker.test.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.test.tsx
@@ -97,6 +97,46 @@ describe('DateTimeRangePicker', () => {
       expect(endDate).toEqual(new Date('2020-07-10 12:00.00'));
     });
 
+    it('omits predefinedDateLabel when selecting an end date via the calendar', async () => {
+      const handleSelectDate = vi.fn();
+
+      const { getByTestId, getByText } = renderCUI(
+        <DateTimeRangePicker onSelectDateRange={handleSelectDate} />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+
+      await userEvent.click(getByText('Start date'));
+      await userEvent.click(getByText('4'));
+
+      await userEvent.click(getByText('End date'));
+      await userEvent.click(getByText('10'));
+
+      const [, , predefinedDateLabel] = handleSelectDate.mock.lastCall ?? [];
+
+      expect(predefinedDateLabel).toBeUndefined();
+    });
+
+    it('omits predefinedDateLabel when selecting a start date via the calendar after end date is set', async () => {
+      const handleSelectDate = vi.fn();
+
+      const { getByTestId, getByText } = renderCUI(
+        <DateTimeRangePicker onSelectDateRange={handleSelectDate} />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+
+      await userEvent.click(getByTestId('tabbed-calendar-trigger-end'));
+      await userEvent.click(getByText('10'));
+
+      await userEvent.click(getByTestId('tabbed-calendar-trigger-start'));
+      await userEvent.click(getByText('4'));
+
+      const [, , predefinedDateLabel] = handleSelectDate.mock.lastCall ?? [];
+
+      expect(predefinedDateLabel).toBeUndefined();
+    });
+
     it('allows setting a new start date by clicking any date', async () => {
       const handleSelectDate = vi.fn();
 
@@ -1076,6 +1116,47 @@ describe('DateTimeRangePicker', () => {
       expect(getByTestId('datetimepicker-input').textContent).toBe(
         'Jul 04, 11:15 am – Jul 04, 11:30 am'
       );
+    });
+
+    it('passes the predefined label as predefinedDateLabel when a predefined time is selected', async () => {
+      const handleSelectDate = vi.fn();
+
+      const predefinedTimesList = getPredefinedTimePeriodsForDateTimePicker();
+      const { getByTestId, getByText } = renderCUI(
+        <DateTimeRangePicker
+          onSelectDateRange={handleSelectDate}
+          predefinedTimesList={predefinedTimesList}
+        />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+      await userEvent.click(getByText('Past 15 minutes'));
+
+      const [startDate, endDate, predefinedDateLabel] =
+        handleSelectDate.mock.lastCall ?? [];
+
+      expect(startDate).toEqual(new Date('2020-07-04 11:15.00'));
+      expect(endDate).toEqual(new Date('2020-07-04 11:30.00'));
+      expect(predefinedDateLabel).toBe('Past 15 minutes');
+    });
+
+    it('passes the matching label as predefinedDateLabel for any predefined time selection', async () => {
+      const handleSelectDate = vi.fn();
+
+      const predefinedTimesList = getPredefinedTimePeriodsForDateTimePicker();
+      const { getByTestId, getByText } = renderCUI(
+        <DateTimeRangePicker
+          onSelectDateRange={handleSelectDate}
+          predefinedTimesList={predefinedTimesList}
+        />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+      await userEvent.click(getByText('Past hour'));
+
+      const [, , predefinedDateLabel] = handleSelectDate.mock.lastCall ?? [];
+
+      expect(predefinedDateLabel).toBe('Past hour');
     });
   });
 

--- a/src/components/DatePicker/DateTimeRangePicker.test.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.test.tsx
@@ -584,7 +584,7 @@ describe('DateTimeRangePicker', () => {
       );
 
       await userEvent.click(getByTestId('datetimepicker-input'));
-      await userEvent.click(getByText('Since a specific date and time'));
+      await userEvent.click(getByText('Custom time period'));
 
       expect(getByTestId('tabbed-calendar-trigger-end')).toHaveAttribute(
         'data-state',
@@ -1093,7 +1093,7 @@ describe('DateTimeRangePicker', () => {
       expect(queryByTestId('datepicker-calendar-container')).not.toBeInTheDocument();
 
       await userEvent.click(getByTestId('datetimepicker-input'));
-      await userEvent.click(getByText('Since a specific date and time'));
+      await userEvent.click(getByText('Custom time period'));
 
       expect(getByTestId('datepicker-calendar-container')).toBeInTheDocument();
     });

--- a/src/components/DatePicker/DateTimeRangePicker.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.tsx
@@ -288,7 +288,11 @@ const Calendar = ({
 };
 
 interface PredefinedTimesProps {
-  onSelectDateRange: (selectedStartDate: Date, selectedEndDate: Date) => void;
+  onSelectDateRange: (
+    startDate: Date,
+    endDate: Date,
+    predefinedDateLabel?: string
+  ) => void;
   predefinedTimesList: DateRangeListItem[];
   selectedEndDate: Date | undefined;
   selectedStartDate: Date | undefined;
@@ -324,7 +328,7 @@ const PredefinedTimes = ({
           const handleItemClick = () => {
             setStartDate(startDate);
             setEndDate(endDate);
-            onSelectDateRange(startDate, endDate);
+            onSelectDateRange(startDate, endDate, label);
           };
 
           const rangeIsSelected =
@@ -769,7 +773,11 @@ export interface DateTimeRangePickerProps {
   endDate?: Date;
   futureDatesDisabled?: boolean;
   futureStartDatesDisabled?: boolean;
-  onSelectDateRange: (selectedStartDate: Date, selectedEndDate: Date) => void;
+  onSelectDateRange: (
+    startDate: Date,
+    endDate: Date,
+    predefinedDateLabel?: string
+  ) => void;
   openDirection?: OpenDirection;
   placeholder?: string;
   predefinedTimesList?: DateRangeListItem[];

--- a/src/components/DatePicker/DateTimeRangePicker.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.tsx
@@ -361,7 +361,7 @@ const PredefinedTimes = ({
           justifyContent="space-between"
           orientation="horizontal"
         >
-          Since a specific date and time <Icon name="chevron-right" />
+          Custom time period <Icon name="chevron-right" />
         </Container>
       </StyledDropdownItem>
     </PredefinedTimesContainer>


### PR DESCRIPTION
## Why?

- For usability purposes, it's useful to know if the selected date is from a predefined list or not. This passes the label, if it exists, as the third argument to `onSelectDateRange`

Also updated the copy to say Custom time period:

<img width="709" height="485" alt="Screenshot 2026-05-13 at 12 44 23 PM" src="https://github.com/user-attachments/assets/6e9e4e35-fe75-4c81-9ced-c105b54dd054" />
