### PR TITLE
feat: Adds responsivePositioning to the DatePickers, forcing the dropdown to align with the input

### DIFF
--- a/.changeset/fiery-sails-post.md
+++ b/.changeset/fiery-sails-post.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': minor
+---
+
+Adds a `responsivePositioning` prop to the DatePickers, which allows the dropdown to be forced to be aligned with the input in cases where radix determines it shouldn't be

--- a/src/components/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DatePicker/DatePicker.stories.tsx
@@ -57,6 +57,23 @@ export const DatePickerAllowOnlyNext30Days = {
   },
 };
 
+export const ResponsivePositioningDisabled = {
+  ...defaultStory,
+  render: (args: Args) => {
+    const date = args.date ? new Date(args.date) : undefined;
+    return (
+      <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <DatePicker
+          date={date}
+          onSelectDate={args.onSelectDate}
+          placeholder={args.placeholder}
+          responsivePositioning={false}
+        />
+      </div>
+    );
+  },
+};
+
 export const TimezoneLocalVsUTC = {
   ...defaultStory,
   render: (args: Args) => {

--- a/src/components/DatePicker/DatePicker.test.tsx
+++ b/src/components/DatePicker/DatePicker.test.tsx
@@ -92,6 +92,23 @@ describe('DatePicker', () => {
     expect(selectedDate).toEqual(new Date('2020-07-22 00:00.00'));
   });
 
+  it('opens the calendar when responsivePositioning is disabled', async () => {
+    const handleSelectDate = vi.fn();
+
+    const { getByTestId, queryByTestId } = renderCUI(
+      <DatePicker
+        onSelectDate={handleSelectDate}
+        responsivePositioning={false}
+      />
+    );
+
+    expect(queryByTestId('datepicker-calendar-container')).not.toBeInTheDocument();
+
+    await userEvent.click(getByTestId('datepicker-input'));
+
+    expect(queryByTestId('datepicker-calendar-container')).toBeVisible();
+  });
+
   describe('disabling dates', () => {
     // this test was throwing an error if `vi.useFakeTimers` was called outside
     // of beforeAll, so it needed to be put in here

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -204,6 +204,7 @@ export interface DatePickerProps {
   futureDatesDisabled?: boolean;
   onSelectDate: (selectedDate: Date) => void;
   placeholder?: string;
+  responsivePositioning?: boolean;
   timezone?: Timezone;
 }
 
@@ -214,6 +215,7 @@ export const DatePicker = ({
   futureDatesDisabled = false,
   onSelectDate,
   placeholder,
+  responsivePositioning = true,
   timezone = 'system',
 }: DatePickerProps) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -305,6 +307,7 @@ export const DatePicker = ({
       <Popover.Portal>
         <PopoverContent
           align="start"
+          avoidCollisions={responsivePositioning}
           sideOffset={4}
         >
           <CalendarRenderer

--- a/src/components/DatePicker/DateRangePicker.stories.tsx
+++ b/src/components/DatePicker/DateRangePicker.stories.tsx
@@ -179,6 +179,30 @@ export const PredefinedDatesArbitraryDates: Story = {
   },
 };
 
+export const ResponsivePositioningDisabled: Story = {
+  args: {
+    predefinedDatesList: [],
+  },
+  render: (args: Args) => {
+    const endDate = args.endDate ? new Date(args.endDate) : undefined;
+    const startDate = args.startDate ? new Date(args.startDate) : undefined;
+    const predefinedDatesList = getPredefinedMonthsForDateRangePicker(-6);
+
+    return (
+      <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <DateRangePicker
+          key="default"
+          endDate={endDate}
+          onSelectDateRange={args.onSelectDateRange}
+          predefinedDatesList={predefinedDatesList}
+          responsivePositioning={false}
+          startDate={startDate}
+        />
+      </div>
+    );
+  },
+};
+
 export const TimezoneLocalVsUTC: Story = {
   render: (args: Args) => {
     const startDate = args.startDate

--- a/src/components/DatePicker/DateRangePicker.test.tsx
+++ b/src/components/DatePicker/DateRangePicker.test.tsx
@@ -61,6 +61,23 @@ describe('DateRangePicker', () => {
     expect(getByText('start date – end date')).toBeInTheDocument();
   });
 
+  it('opens the calendar when responsivePositioning is disabled', async () => {
+    const handleSelectDate = vi.fn();
+
+    const { getByTestId, queryByTestId } = renderCUI(
+      <DateRangePicker
+        onSelectDateRange={handleSelectDate}
+        responsivePositioning={false}
+      />
+    );
+
+    expect(queryByTestId('datepicker-calendar-container')).not.toBeInTheDocument();
+
+    await userEvent.click(getByTestId('daterangepicker-input'));
+
+    expect(queryByTestId('datepicker-calendar-container')).toBeVisible();
+  });
+
   describe('selecting dates', () => {
     beforeAll(() => {
       vi.setSystemTime(new Date('07-04-2020'));

--- a/src/components/DatePicker/DateTimeRangePicker.stories.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.stories.tsx
@@ -388,3 +388,24 @@ export const DefaultActiveTabEndDate: Story = {
     );
   },
 };
+
+export const ResponsivePositioningDisabled: Story = {
+  render: (args: Args) => {
+    const endDate = args.endDate ? new Date(args.endDate) : undefined;
+    const startDate = args.startDate ? new Date(args.startDate) : undefined;
+    const predefinedTimesList = getPredefinedTimePeriodsForDateTimePicker();
+
+    return (
+      <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <DateTimeRangePicker
+          key="default"
+          endDate={endDate}
+          onSelectDateRange={args.onSelectDateRange}
+          predefinedTimesList={predefinedTimesList}
+          responsivePositioning={false}
+          startDate={startDate}
+        />
+      </div>
+    );
+  },
+};

--- a/src/components/DatePicker/DateTimeRangePicker.test.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.test.tsx
@@ -50,6 +50,23 @@ describe('DateTimeRangePicker', () => {
     );
   });
 
+  it('opens the calendar when responsivePositioning is disabled', async () => {
+    const handleSelectDate = vi.fn();
+
+    const { getByTestId, queryByTestId } = renderCUI(
+      <DateTimeRangePicker
+        onSelectDateRange={handleSelectDate}
+        responsivePositioning={false}
+      />
+    );
+
+    expect(queryByTestId('datepicker-calendar-container')).not.toBeInTheDocument();
+
+    await userEvent.click(getByTestId('datetimepicker-input'));
+
+    expect(queryByTestId('datepicker-calendar-container')).toBeVisible();
+  });
+
   it('handles only passing in end date, but not start date', () => {
     const handleSelectDate = vi.fn();
     const endDate = new Date('07-05-2020');

--- a/src/components/DatePicker/DateTimeRangePicker.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.tsx
@@ -782,6 +782,7 @@ export interface DateTimeRangePickerProps {
   placeholder?: string;
   predefinedTimesList?: DateRangeListItem[];
   maxRangeLength?: number;
+  responsivePositioning?: boolean;
   shouldFireIfInvalid?: boolean;
   shouldShowSeconds?: boolean;
   startDate?: Date;
@@ -800,6 +801,7 @@ export const DateTimeRangePicker = ({
   openDirection = 'right',
   placeholder = 'start date – end date',
   predefinedTimesList,
+  responsivePositioning = true,
   shouldFireIfInvalid = true,
   shouldShowSeconds,
   startDate,
@@ -978,7 +980,10 @@ export const DateTimeRangePicker = ({
           timezone={timezone}
         />
       </Dropdown.Trigger>
-      <NoOverflowDropdownContent align="start">
+      <NoOverflowDropdownContent
+        align="start"
+        responsivePositioning={responsivePositioning}
+      >
         <Container orientation="horizontal">
           {shouldShowPredefinedTimes ? (
             <PredefinedCalendarContainer


### PR DESCRIPTION
## Why?

When the inputs for the datepickers are near the right edge of the screen, Radix will automatically positioning them away from the side to avoid clipping.

#### The issue in action:
<img width="637" height="301" alt="Screenshot 2026-05-14 at 2 56 54 PM" src="https://github.com/user-attachments/assets/7c6eec5c-425c-46ce-b295-8cf8538c24a4" />

#### After resolving:
<img width="335" height="324" alt="Screenshot 2026-05-14 at 3 39 18 PM" src="https://github.com/user-attachments/assets/a1105593-e0c5-478c-b1b0-ff01ee00034d" />

## How?

- Adds `responsivePositioning` boolean value (defaults to true) to all the DatePickers to override this behavior

