### PR TITLE
fix(publish): unblock npm publish from changeset:verify

### DIFF
--- a/.changeset/fix-publish-changeset-verify.md
+++ b/.changeset/fix-publish-changeset-verify.md
@@ -1,0 +1,5 @@
+---
+"@clickhouse/click-ui": patch
+---
+
+Fix `Publish to npm with OIDC` failing because the `prepare` lifecycle script ran `yarn changeset:verify`. Removed `yarn changeset:verify` from the `prepare` script so `npm publish` no longer aborts with "Couldn't locate any changeset."

--- a/package.json
+++ b/package.json
@@ -383,7 +383,7 @@
     "lint:code:fix": "eslint src --report-unused-disable-directives --fix",
     "lint:css": "stylelint \"src/**/*.css\"",
     "lint:css:fix": "stylelint \"src/**/*.css\" --fix",
-    "prepare": "yarn test && yarn format && yarn lint && yarn changeset:verify && yarn circular-dependency:check",
+    "prepare": "yarn test && yarn format && yarn lint && yarn circular-dependency:check",
     "prettify": "yarn format:fix",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
## Summary

- Removes `yarn changeset:verify` from the `prepare` script so `npm publish` doesn't abort with "Couldn't locate any changeset." after the release workflow has consumed all changesets ([failing run](https://github.com/ClickHouse/click-ui/actions/runs/25925281295/job/76204775461)).
- Adds a `patch` changeset for this fix.

## Test plan

- [ ] Trigger the publish workflow (or wait for next release) and confirm `Publish to npm with OIDC` no longer fails on the changeset check.
- [ ] Verify other `prepare` checks (`yarn test`, `yarn format`, `yarn lint`, `yarn circular-dependency:check`) still run locally on `yarn install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)