### PR TITLE
chore: add changeset for Malaysia/Taiwan flags and rounded corners

### DIFF
--- a/.changeset/dani-changeset-flags.md
+++ b/.changeset/dani-changeset-flags.md
@@ -1,0 +1,5 @@
+---
+"@clickhouse/click-ui": minor
+---
+
+Add Malaysia and Taiwan flags, and standardize rounded corners across all flag SVGs for a consistent look.


### PR DESCRIPTION
## Summary

- Adds a `minor` changeset documenting the Malaysia + Taiwan flag additions and the rounded-corner standardization from #1030.

## Test plan

- [ ] Changeset is picked up in the next release's CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)