### PR TITLE
ci: declare workflow-level `contents: read` on 4 check workflows

### DIFF
--- a/.github/workflows/build-health-checkup.yml
+++ b/.github/workflows/build-health-checkup.yml
@@ -10,6 +10,9 @@ on:
 env:
   HUSKY: 0
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -7,6 +7,9 @@ on:
 env:
   HUSKY: 0
 
+permissions:
+  contents: read
+
 jobs:
   code-quality-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,6 +7,9 @@ on:
 env:
   HUSKY: 0
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/visual-regression-tests.yml
+++ b/.github/workflows/visual-regression-tests.yml
@@ -7,6 +7,9 @@ on:
 env:
   HUSKY: 0
 
+permissions:
+  contents: read
+
 jobs:
   visual-regression:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds workflow-level `permissions: contents: read` to four check workflows: `code-quality`, `unit-tests`, `visual-regression-tests`, `build-health-checkup`. None make GitHub API writes.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML-only CI permission tightening with no application or secret-handling changes; checkout and existing steps remain sufficient with read access.
> 
> **Overview**
> Four CI workflows (`build-health-checkup`, `code-quality`, `unit-tests`, `visual-regression-tests`) now declare workflow-level **`permissions: contents: read`**, limiting the default `GITHUB_TOKEN` to repository read access (checkout and build/test steps only).
> 
> This matches the existing hardening on workflows like `storybook-vercel` and aligns with least-privilege guidance after supply-chain incidents affecting Actions permissions. **No job steps or triggers are changed**—only the explicit permission block is added under each workflow’s `env` section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e758811840f0903131ff98f0b64115443aebc4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->