### PR TITLE
chore(skill): use imperative mood for CSS Modules changeset phrasing

### DIFF
--- a/.claude/skills/component-css-modules-migration/SKILL.md
+++ b/.claude/skills/component-css-modules-migration/SKILL.md
@@ -120,7 +120,7 @@ After generating, run `yarn test:visual tests/<area>/<name>.spec.ts` to confirm 
   '@clickhouse/click-ui': patch
   ---
 
-  migration of <Name> from styled-components to css modules. no behavior change.
+  Migrate <Name> from styled-components to css modules with no change in behavior
   ````
 
   `patch` bump (no behavior change → not even minor). Do not pad the body with extra prose, lists of preserved attributes, or migration notes — the terse phrasing is intentional and scales across dozens of migration PRs.
@@ -171,7 +171,7 @@ Before marking the PR ready:
 - [ ] Branch is rebased on the latest `main` (a fresh `forwardRef` or unrelated commit may have landed during the work).
 - [ ] Commit 1 contains only stories, spec, snapshots, and possibly a narrow TS widening — nothing else.
 - [ ] Commit 2 changes only `<Name>.tsx`, `<Name>.module.css`, and the changeset.
-- [ ] Changeset is `patch` and reads exactly `migration of <Name> from styled-components to css modules. no behavior change.`
+- [ ] Changeset is `patch` and reads exactly `Migrate <Name> from styled-components to css modules with no change in behavior`
 - [ ] `yarn test:visual tests/<area>/<name>.spec.ts` is green with zero snapshot regenerations between the two commits.
 - [ ] No `styled-components` imports remain in `src/components/<Name>/`.
 - [ ] No internal links (Linear, Notion, internal Slack/Grafana) anywhere in PR text, commit messages, the changeset, or this skill's adjacent files — click-ui is a public repo.


### PR DESCRIPTION
## Summary
- Update the CSS Modules migration skill so the templated changeset reads in imperative mood: `Migrate <Name> from styled-components to css modules with no change in behavior`.
- Replaces the previous descriptive form (`migration of <Name> from styled-components to css modules. no behavior change.`) after reviewer feedback that changeset bodies should read like git commit messages (as if preceded by an implicit "this change will:").
- Two spots updated: the template snippet and the checklist line that pins the exact wording.

## Test plan
- [ ] Future migration PRs (CardHorizontal, CardPrimary, IconButton, SplitButton) use the new phrasing.
- [ ] No other behavior in the skill changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to an internal migration skill; no product code or release behavior changes.
> 
> **Overview**
> Updates the **component-css-modules-migration** skill so the required **Changesets** body uses **imperative** wording: `Migrate <Name> from styled-components to css modules with no change in behavior`, instead of the old descriptive line (`migration of <Name>... no behavior change.`).
> 
> The same sentence is applied in the **changeset template** and in the **pre-merge checklist** that pins exact wording. No migration tooling, components, or runtime behavior change—only documentation for future CSS Modules migration PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd5c42ed7eb6e5c1f5831f8004cc3f8c6200671e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->