### PR TITLE
feat(new-icon): add new pop-in icon

### DIFF
--- a/.changeset/add-pop-in-icon.md
+++ b/.changeset/add-pop-in-icon.md
@@ -1,0 +1,5 @@
+---
+"@clickhouse/click-ui": minor
+---
+
+Add the `popin` icon to the icon library.

--- a/src/components/Assets/Icons/Popin.tsx
+++ b/src/components/Assets/Icons/Popin.tsx
@@ -1,0 +1,22 @@
+import type { SVGAssetProps } from '@/types';
+
+const Popin = (props: SVGAssetProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={24}
+    height={24}
+    viewBox="0 0 24 24"
+    fill="none"
+    {...props}
+  >
+    <path
+      stroke="#161517"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={1.5}
+      d="M19 10h-5V5M21 3l-7 7M19 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h5"
+    />
+  </svg>
+);
+
+export default Popin;

--- a/src/components/Assets/Icons/system/IconsDark.ts
+++ b/src/components/Assets/Icons/system/IconsDark.ts
@@ -130,6 +130,7 @@ import Play from '../Play';
 import Play_In_Circle from '../Play-In-Circle';
 import Plug from '../Plug';
 import Plus from '../Plus';
+import Popin from '../Popin';
 import Popout from '../Popout';
 import Popover_Arrow from '../Popover-Arrow';
 import Puzzle_Piece from '../Puzzle-Piece';
@@ -305,6 +306,7 @@ const IconsDark: Record<IconName, ComponentType<SVGAssetProps>> = {
   'play-in-circle': Play_In_Circle,
   plug: Plug,
   plus: Plus,
+  popin: Popin,
   popout: Popout,
   'popover-arrow': Popover_Arrow,
   'puzzle-piece': Puzzle_Piece,

--- a/src/components/Assets/Icons/system/IconsLight.ts
+++ b/src/components/Assets/Icons/system/IconsLight.ts
@@ -130,6 +130,7 @@ import Play from '../Play';
 import Play_In_Circle from '../Play-In-Circle';
 import Plug from '../Plug';
 import Plus from '../Plus';
+import Popin from '../Popin';
 import Popout from '../Popout';
 import Popover_Arrow from '../Popover-Arrow';
 import Puzzle_Piece from '../Puzzle-Piece';
@@ -305,6 +306,7 @@ const IconsLight: Record<IconName, ComponentType<SVGAssetProps>> = {
   'play-in-circle': Play_In_Circle,
   plug: Plug,
   plus: Plus,
+  popin: Popin,
   popout: Popout,
   'popover-arrow': Popover_Arrow,
   'puzzle-piece': Puzzle_Piece,

--- a/src/components/Assets/Icons/system/types.ts
+++ b/src/components/Assets/Icons/system/types.ts
@@ -128,6 +128,7 @@ export type IconName =
   | 'play-in-circle'
   | 'plug'
   | 'plus'
+  | 'popin'
   | 'popout'
   | 'popover-arrow'
   | 'puzzle-piece'

--- a/src/components/Assets/config.ts
+++ b/src/components/Assets/config.ts
@@ -135,6 +135,7 @@ export const ASSET_NAME_MAPPINGS = {
     PlayInCircle: 'play-in-circle',
     Plug: 'plug',
     Plus: 'plus',
+    Popin: 'popin',
     Popout: 'popout',
     PopoverArrow: 'popover-arrow',
     PuzzlePiece: 'puzzle-piece',


### PR DESCRIPTION
## Summary

- Add the `pop-in` icon asset using the supplied SVG.
- Regenerate the icon registry/type files so `pop-in` is available through the icon library.
- Add a minor changeset for the new public icon asset.

Fixes #1005.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive icon asset and registry entries only; no runtime or security-sensitive logic changes.
> 
> **Overview**
> Adds a new **`popin`** icon to the Click UI icon library, paired with the existing **`popout`** asset.
> 
> A new `Popin` SVG component is registered under the kebab-case name `popin` in the light/dark icon maps, `IconName` typing, and deprecated PascalCase alias (`Popin`). A **minor** changeset records the public API addition for `@clickhouse/click-ui`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b99b696e8071ba5bfeb63dd17f751d2040b8373d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->