### PR TITLE
chore(skill): direct primitives to tests/display/ and reserve tests/utils/ for helpers

### DIFF
--- a/.claude/skills/component-css-modules-migration/SKILL.md
+++ b/.claude/skills/component-css-modules-migration/SKILL.md
@@ -48,8 +48,14 @@ If you need to fix repo tooling (broken script, version mismatch) to even run `y
 ### Files
 
 - `src/components/<Name>/<Name>.stories.tsx` — Extend the existing stories. There must be exactly one named story per visual variant the spec wants to screenshot. Reuse the structure from `src/components/ButtonGroup/ButtonGroup.stories.tsx`. Required scenarios: each `type` variant, selected/active state, disabled state (including disabled+active if applicable), fill-width / size variants, multi-select if applicable.
-- `tests/<area>/<name>.spec.ts` — New Playwright spec. Mirror the structure from `tests/buttons/button.spec.ts` or `tests/buttons/buttongroup.spec.ts`. Cover:
-  - Light + dark theme via `getStoryUrl(storyId, theme)` from `tests/utils/index.ts`
+- `tests/<area>/<name>.spec.ts` — New Playwright spec. Pick `<area>` carefully:
+  - **Never put component specs under `tests/utils/`.** That folder is reserved for shared test helpers like `getStoryUrl` (`tests/utils/index.ts`). Mixing specs and helpers there confuses both human readers and Copilot reviewers.
+  - Use an existing component-family folder if the component fits one (e.g. `tests/buttons/`, `tests/cards/`).
+  - For primitives that just display content (Spacer, Separator, Text, Title, Label, GenericLabel, Icon, etc.), use **`tests/display/`**.
+  - Establish a new folder only when the component genuinely starts a new family. Name it for the family (e.g. `tests/forms/`, `tests/overlays/`), not the component.
+
+  Mirror the structure from `tests/buttons/button.spec.ts` or `tests/buttons/buttongroup.spec.ts`. Cover:
+  - Light + dark theme via `getStoryUrl(storyId, theme)` from `tests/utils/index.ts` (imported as `from '../utils'` from a sibling test folder)
   - Each variant story → snapshot
   - Interactive states (hover, focus) — call `page.locator('body').click()` before `Tab` to anchor focus into page content (not browser chrome — known flakiness fix)
   - Keyboard activation if relevant (Space, Enter) — works on native `<button>` regardless of styling


### PR DESCRIPTION
## Summary

Codify in the CSS Modules migration skill where component specs belong, so future migration PRs land in the right test folder on the first try.

Copilot raised the same observation on the Spacer ([#1045](https://github.com/ClickHouse/click-ui/pull/1045)) and Separator ([#1046](https://github.com/ClickHouse/click-ui/pull/1046)) review: those specs were placed under `tests/utils/`, which is reserved for shared helpers like `getStoryUrl` (`tests/utils/index.ts`). Component specs belong in component-family folders.

## Changes

- Add a "Pick `<area>` carefully" subsection in the skill explaining:
  - `tests/utils/` is reserved for shared helpers — never put component specs there.
  - Existing component-family folders (`tests/buttons/`, `tests/cards/`) take precedence.
  - Primitives (Spacer, Separator, Text, Title, Label, GenericLabel, Icon, etc.) go in `tests/display/`.
  - New folders are named for the family (`tests/forms/`, `tests/overlays/`), not the individual component.
- Note that sibling specs import the helper as `from '../utils'`.

## Follow-ups (separate PRs)

- Fix the placement on existing migration PRs (#1045, #1046, #1047, #1048) — already in flight or queued.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an internal migration skill; no runtime or test code modified.
> 
> **Overview**
> Updates the **component CSS Modules migration** skill so commit 1’s Playwright spec path is chosen deliberately instead of defaulting to `tests/utils/`.
> 
> The skill now spells out that **`tests/utils/` is helpers-only** (e.g. `getStoryUrl`), that existing families like `tests/buttons/` and `tests/cards/` should be reused when they fit, that **display primitives** (Spacer, Separator, Text, Icon, etc.) belong in **`tests/display/`**, and that new folders should be named for a **component family** rather than a single component. It also documents importing shared helpers as **`from '../utils'`** from a sibling test folder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e946756da779ec113e61ea71039266defaff610d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->