### PR TITLE
fix: properly define types of polymorphic components

### DIFF
--- a/.changeset/fix-polymorphic-types.md
+++ b/.changeset/fix-polymorphic-types.md
@@ -1,0 +1,5 @@
+---
+"@clickhouse/click-ui": patch
+---
+
+fix: properly define types of polymorphic components

--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -23,7 +23,7 @@ type JustifyContentOptions =
 type WrapOptions = 'nowrap' | 'wrap' | 'wrap-reverse';
 
 type ContainerPolymorphicComponent = <T extends ElementType = 'div'>(
-  props: Omit<ComponentProps<T>, keyof T> & ContainerProps<T>
+  props: Omit<ComponentProps<T>, keyof ContainerProps<T>> & ContainerProps<T>
 ) => ReactNode;
 
 const _Container = <T extends ElementType = 'div'>(
@@ -48,7 +48,7 @@ const _Container = <T extends ElementType = 'div'>(
     overflow,
     display = 'flex',
     ...props
-  }: Omit<ComponentProps<T>, keyof T> & ContainerProps<T>,
+  }: Omit<ComponentProps<T>, keyof ContainerProps<T>> & ContainerProps<T>,
   ref: ComponentPropsWithRef<T>['ref']
 ) => {
   return (

--- a/src/components/EllipsisContent/EllipsisContent.tsx
+++ b/src/components/EllipsisContent/EllipsisContent.tsx
@@ -33,7 +33,10 @@ type EllipsisPolymorphicComponent = <T extends ElementType = 'div'>(
 ) => ReactNode;
 
 const _EllipsisContent = <T extends ElementType = 'div'>(
-  { component, ...props }: Omit<ComponentProps<T>, keyof EllipsisContentProps<T>> & EllipsisContentProps<T>,
+  {
+    component,
+    ...props
+  }: Omit<ComponentProps<T>, keyof EllipsisContentProps<T>> & EllipsisContentProps<T>,
   ref: ComponentPropsWithRef<T>['ref']
 ) => {
   return (

--- a/src/components/EllipsisContent/EllipsisContent.tsx
+++ b/src/components/EllipsisContent/EllipsisContent.tsx
@@ -29,11 +29,11 @@ export interface EllipsisContentProps<T extends ElementType = 'div'> {
 }
 
 type EllipsisPolymorphicComponent = <T extends ElementType = 'div'>(
-  props: Omit<ComponentProps<T>, keyof T> & EllipsisContentProps<T>
+  props: Omit<ComponentProps<T>, keyof EllipsisContentProps<T>> & EllipsisContentProps<T>
 ) => ReactNode;
 
 const _EllipsisContent = <T extends ElementType = 'div'>(
-  { component, ...props }: Omit<ComponentProps<T>, keyof T> & EllipsisContentProps<T>,
+  { component, ...props }: Omit<ComponentProps<T>, keyof EllipsisContentProps<T>> & EllipsisContentProps<T>,
   ref: ComponentPropsWithRef<T>['ref']
 ) => {
   return (

--- a/src/components/GridContainer/GridContainer.tsx
+++ b/src/components/GridContainer/GridContainer.tsx
@@ -75,7 +75,7 @@ export interface GridContainerProps<T extends ElementType = 'div'> {
 }
 
 type GridContainerPolymorphicComponent = <T extends ElementType = 'div'>(
-  props: Omit<ComponentProps<T>, keyof T> & GridContainerProps<T>
+  props: Omit<ComponentProps<T>, keyof GridContainerProps<T>> & GridContainerProps<T>
 ) => ReactNode;
 
 const _GridContainer = <T extends ElementType = 'div'>(
@@ -106,7 +106,7 @@ const _GridContainer = <T extends ElementType = 'div'>(
     overflow,
     component,
     ...props
-  }: Omit<ComponentProps<T>, keyof T> & GridContainerProps<T>,
+  }: Omit<ComponentProps<T>, keyof GridContainerProps<T>> & GridContainerProps<T>,
   ref: ComponentPropsWithRef<T>['ref']
 ) => {
   return (

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -64,7 +64,7 @@ const externalIconVariants = cva('', {
 });
 
 type LinkPolymorphicComponent = <T extends ElementType = 'a'>(
-  props: Omit<ComponentProps<T>, keyof T> & LinkProps<T>
+  props: Omit<ComponentProps<T>, keyof LinkProps<T>> & LinkProps<T>
 ) => ReactNode;
 
 /** Component for linking to other pages or sections from with body text */
@@ -78,7 +78,7 @@ const _Link = <T extends ElementType = 'a'>(
     component,
     className,
     ...props
-  }: Omit<ComponentProps<T>, keyof T> & LinkProps<T> & { className?: string },
+  }: Omit<ComponentProps<T>, keyof LinkProps<T>> & LinkProps<T> & { className?: string },
   ref: ComponentPropsWithRef<T>['ref']
 ) => {
   const Component = component ?? 'a';

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -32,7 +32,7 @@ export interface TextProps<T extends ElementType = 'p'> {
 }
 
 type TextPolymorphicComponent = <T extends ElementType = 'p'>(
-  props: Omit<ComponentProps<T>, keyof T> & TextProps<T>
+  props: Omit<ComponentProps<T>, keyof TextProps<T>> & TextProps<T>
 ) => ReactNode;
 
 const _Text = <T extends ElementType = 'p'>(
@@ -46,7 +46,7 @@ const _Text = <T extends ElementType = 'p'>(
     component,
     fillWidth,
     ...props
-  }: Omit<ComponentProps<T>, keyof T> & TextProps<T>,
+  }: Omit<ComponentProps<T>, keyof TextProps<T>> & TextProps<T>,
   ref: ComponentPropsWithRef<T>['ref']
 ) => (
   <CuiText


### PR DESCRIPTION
## Why?

Types for polymorphic components were broken since forever.

## How?

Define types properly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only fixes with no runtime logic changes; risk is limited to possible stricter or corrected compile-time errors for consumers.
> 
> **Overview**
> Fixes **polymorphic** public typings for `Container`, `EllipsisContent`, `GridContainer`, `Link`, and `Text` by omitting conflicts against each component’s own props interface (`ContainerProps`, `TextProps`, etc.) instead of `keyof T` on the element type.
> 
> Consumers get correct merging of the `component` prop with native/HTML props for a chosen `T`, without changing runtime behavior. A **patch** changeset is included for `@clickhouse/click-ui`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acb5c72b872fced66b290e367777bc98c7bd0194. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->