### PR TITLE
chore(ci): set top-level permissions on workflows

### DIFF
--- a/.github/workflows/build-health-checkup.yml
+++ b/.github/workflows/build-health-checkup.yml
@@ -10,6 +10,9 @@ on:
 env:
   HUSKY: 0
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -7,6 +7,9 @@ on:
 env:
   HUSKY: 0
 
+permissions:
+  contents: read
+
 jobs:
   code-quality-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,6 +7,9 @@ on:
 env:
   HUSKY: 0
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/visual-regression-tests.yml
+++ b/.github/workflows/visual-regression-tests.yml
@@ -7,6 +7,9 @@ on:
 env:
   HUSKY: 0
 
+permissions:
+  contents: read
+
 jobs:
   visual-regression:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Small hardening change: set `permissions: contents: read` at the top of `.github/workflows/build-health-checkup.yml`, `.github/workflows/code-quality.yml`, `.github/workflows/unit-tests.yml`, `.github/workflows/visual-regression-tests.yml` so the workflow token is read-only instead of inheriting the repository default. The job only does checkout and build/test, so nothing else is required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only least-privilege hardening with no application or runtime behavior changes.
> 
> **Overview**
> Adds **top-level `permissions: contents: read`** to four GitHub Actions workflows (`build-health-checkup`, `code-quality`, `unit-tests`, and `visual-regression-tests`) so the default `GITHUB_TOKEN` is **read-only** instead of inheriting the repo’s broader default permissions.
> 
> These jobs only check out code and run install/build/test (and upload artifacts on failure in visual regression), so no write scopes are required for normal operation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0206dda49a2c513fe9a446d09c38b7e308118736. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->