### PR TITLE
perf(Icon): memoize wrapper inline style object

### DIFF
--- a/.changeset/perf-icon-memoize-style.md
+++ b/.changeset/perf-icon-memoize-style.md
@@ -1,0 +1,5 @@
+---
+"@clickhouse/click-ui": patch
+---
+
+Memoize the Icon wrapper's inline style object so its reference stays stable when the underlying values haven't changed.

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties } from 'react';
+import { CSSProperties, useMemo } from 'react';
 import { cn, cva } from '@/lib/cva';
 import { IconName, IconProps, ImageType } from './Icon.types';
 import { ICONS_MAP } from '@/components/Icon/IconCommon';
@@ -49,15 +49,19 @@ const SVGIcon = ({
 }: IconProps) => {
   const Component = ICONS_MAP[name];
 
+  const wrapperStyle = useMemo(
+    () =>
+      ({
+        ...(color !== undefined ? { '--svg-icon-color': color } : {}),
+        ...(width !== undefined ? { '--svg-width': String(width) } : {}),
+        ...(height !== undefined ? { '--svg-height': String(height) } : {}),
+      }) as CSSProperties,
+    [color, width, height]
+  );
+
   if (!Component) {
     return null;
   }
-
-  const wrapperStyle = {
-    ...(color !== undefined ? { '--svg-icon-color': color } : {}),
-    ...(width !== undefined ? { '--svg-width': String(width) } : {}),
-    ...(height !== undefined ? { '--svg-height': String(height) } : {}),
-  } as CSSProperties;
 
   return (
     <div


### PR DESCRIPTION
## What

The `Icon` wrapper built a fresh inline `style` object of CSS custom properties (`--svg-icon-color`, `--svg-width`, `--svg-height`) on **every render**. This wraps it in `useMemo` keyed on `color`/`width`/`height` so the reference stays stable when those values haven't changed.

The `useMemo` is placed above the early `!Component` return to satisfy `react-hooks/rules-of-hooks`.

## Why

Follow-up to review feedback on the Container CSS Modules migration (#1059), where the same per-render inline-style allocation was flagged and fixed. `Icon` (migrated in #1050) had the identical pattern and is used ubiquitously, so it gets the same stable-reference treatment.

## Notes

- Behavior-equivalent — no visual or API change.
- Lint + Prettier pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, behavior-preserving React performance tweak in a widely used UI component with no auth, data, or API surface changes.
> 
> **Overview**
> The **`Icon`** wrapper no longer allocates a new inline **`style`** object on every render. CSS custom properties (`--svg-icon-color`, `--svg-width`, `--svg-height`) are built inside **`useMemo`** keyed on **`color`**, **`width`**, and **`height`**, so the **`style`** reference stays stable when those props are unchanged.
> 
> The memo runs **before** the missing-component early return so hook order stays valid under **`react-hooks/rules-of-hooks`**. A patch **changeset** documents the **`@clickhouse/click-ui`** release note. No API or visual behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44ba238dcd48e7abfd7da9e979a270e6041dd5be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->