### PR TITLE
ci: scope visual-regression suite to specs affected by the diff

### DIFF
--- a/.claude/skills/component-css-modules-migration/SKILL.md
+++ b/.claude/skills/component-css-modules-migration/SKILL.md
@@ -54,6 +54,16 @@ If you need to fix repo tooling (broken script, version mismatch) to even run `y
   - For primitives that just display content (Spacer, Separator, Text, Title, Label, GenericLabel, Icon, etc.), use **`tests/display/`**.
   - Establish a new folder only when the component genuinely starts a new family. Name it for the family (e.g. `tests/forms/`, `tests/overlays/`), not the component.
 
+  **Required header — `@covers` directive.** Begin the spec file with a comment declaring which source directory it guards:
+
+  ```ts
+  // Affected-spec coverage for scoped visual-regression runs in CI.
+  // See .scripts/js/affected-visual-specs
+  // @covers src/components/<Name>
+  ```
+
+  CI reads these directives to run only the specs a PR's diff touches instead of the whole suite (`.github/workflows/visual-regression-tests.yml` → `.scripts/js/affected-visual-specs`). The resolver **throws if any spec lacks a `@covers` directive**, so the visual-regression job fails fast until you add one. Point it at the component's source directory — the resolver verifies the path exists. If the spec screenshots more than one component (e.g. an overview spec), add one `@covers` line per component directory. The visual specs navigate to Storybook stories by string id rather than importing the component, so this directive is the *only* link the resolver has between a `src/` change and its spec — there is no fallback.
+
   Mirror the structure from `tests/buttons/button.spec.ts` or `tests/buttons/buttongroup.spec.ts`. Cover:
   - Light + dark theme via `getStoryUrl(storyId, theme)` from `tests/utils/index.ts` (imported as `from '../utils'` from a sibling test folder)
   - Each variant story → snapshot
@@ -179,6 +189,7 @@ Before marking the PR ready:
 
 - [ ] Branch is rebased on the latest `main` (a fresh `forwardRef` or unrelated commit may have landed during the work).
 - [ ] Commit 1 contains only stories, spec, snapshots, and possibly a narrow TS widening — nothing else.
+- [ ] The new spec starts with a `@covers src/components/<Name>` directive (CI's visual-regression job throws without it).
 - [ ] Commit 2 changes only `<Name>.tsx`, `<Name>.module.css`, and the changeset.
 - [ ] Changeset is `patch` and reads exactly `Migrate <Name> from styled-components to css modules with no change in behavior`
 - [ ] `yarn test:visual tests/<area>/<name>.spec.ts` is green with zero snapshot regenerations between the two commits.

--- a/.github/workflows/visual-regression-tests.yml
+++ b/.github/workflows/visual-regression-tests.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Full history so the resolver can diff against the PR base branch.
+          fetch-depth: 0
 
       - uses: actions/setup-node@v6
         with:
@@ -20,16 +23,35 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
+      # Decide which specs the diff affects before doing any expensive setup.
+      # See .scripts/js/affected-visual-specs for the resolution rules.
+      - name: Resolve affected specs
+        id: affected
+        run: |
+          base="origin/${{ github.base_ref }}"
+          result="$(node .scripts/js/affected-visual-specs "$base")"
+          echo "result=$result" >> "$GITHUB_OUTPUT"
+
       - name: Install dependencies
+        if: steps.affected.outputs.result != 'NONE'
         run: yarn install --immutable
 
       - name: Install Playwright browsers
+        if: steps.affected.outputs.result != 'NONE'
         run: npx playwright install --with-deps chromium
 
       # NOTE: The tests path is located in playwright.config.ts
       # e.g. ./tests
       - name: Run visual regression tests
-        run: npx playwright test
+        if: steps.affected.outputs.result != 'NONE'
+        run: |
+          if [ "${{ steps.affected.outputs.result }}" = "ALL" ]; then
+            echo "Running the full visual-regression suite."
+            npx playwright test
+          else
+            echo "Running scoped specs: ${{ steps.affected.outputs.result }}"
+            npx playwright test ${{ steps.affected.outputs.result }}
+          fi
 
       - name: Upload test results
         if: failure()

--- a/.scripts/js/affected-visual-specs
+++ b/.scripts/js/affected-visual-specs
@@ -1,0 +1,275 @@
+#!/usr/bin/env node
+
+/**
+ * Resolves which Playwright visual-regression spec files are affected by the
+ * current diff, so CI can run a scoped subset instead of the whole suite.
+ *
+ * The visual specs navigate to Storybook story URLs by string id rather than
+ * importing the component under test, so Playwright's own `--only-changed`
+ * dependency tracing cannot connect a `src/` change to its spec. Instead, each
+ * spec declares the source it covers with one or more `@covers <path>`
+ * directives, and this script maps the diff onto those declarations.
+ *
+ * Resolution rules for each changed path:
+ *   - a spec file itself .............................. run that spec
+ *   - a snapshot under `<spec>.spec.ts-snapshots/` .... run the owning spec
+ *   - `src/components/<X>/**` with a mapped spec ....... run that spec,
+ *       UNLESS <X> is imported by other components (a shared dependency),
+ *       in which case fall back to the full suite
+ *   - `src/components/<X>/**` with no mapped spec ...... ignore (no visual test)
+ *   - docs / changesets ............................... ignore
+ *   - anything else (theme, lib, tests/utils, configs,
+ *       storybook setup, package.json, ...) ........... run the full suite
+ *
+ * Output (stdout, machine-readable):
+ *   ALL   -> run the entire suite
+ *   NONE  -> nothing visual-affecting changed, skip
+ *   <list of spec paths separated by spaces>
+ *
+ * Human-readable reasoning is written to stderr so it shows up in CI logs
+ * without polluting the captured result.
+ *
+ * Usage: affected-visual-specs [baseRef]   (baseRef defaults to origin/main)
+ */
+
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(__dirname, '../..');
+const testsDir = path.join(rootDir, 'tests');
+const componentsDir = path.join(rootDir, 'src/components');
+
+const baseRef = process.argv[2] || 'origin/main';
+
+const log = msg => process.stderr.write(`${msg}\n`);
+
+const git = args => {
+  try {
+    return execFileSync('git', args, { cwd: rootDir, encoding: 'utf-8' });
+  } catch {
+    return '';
+  }
+};
+
+const toPosix = p => p.split(path.sep).join('/');
+
+/** Every changed path relative to the repo root: PR diff + uncommitted work. */
+const getChangedFiles = () => {
+  const sets = [
+    git(['diff', '--name-only', `${baseRef}...HEAD`]), // committed since merge-base
+    git(['diff', '--name-only', 'HEAD']), // unstaged
+    git(['diff', '--name-only', '--cached']), // staged
+  ];
+  const files = new Set();
+  for (const out of sets) {
+    for (const line of out.split('\n')) {
+      const f = line.trim();
+      if (f) files.add(f);
+    }
+  }
+  return [...files];
+};
+
+/** Walk a directory returning absolute paths of files matching `filter`. */
+const walk = (dir, filter, acc = []) => {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, filter, acc);
+    else if (filter(entry.name)) acc.push(full);
+  }
+  return acc;
+};
+
+/**
+ * Build the coverage map from `@covers` directives.
+ * Returns Map<coveredDir (repo-relative posix), Set<spec (repo-relative posix)>>.
+ * Throws if a spec lacks a directive or points at a path that does not exist,
+ * so the map can never silently drift out of sync with the suite.
+ */
+const buildCoverageMap = () => {
+  const specFiles = walk(testsDir, name => name.endsWith('.spec.ts'));
+  const map = new Map();
+  const directiveRe = /@covers\s+(\S+)/g;
+
+  for (const specAbs of specFiles) {
+    const specRel = toPosix(path.relative(rootDir, specAbs));
+    const src = fs.readFileSync(specAbs, 'utf-8');
+    const covered = [...src.matchAll(directiveRe)].map(m => m[1]);
+
+    if (covered.length === 0) {
+      throw new Error(
+        `Spec "${specRel}" has no "@covers <path>" directive. Add one so the ` +
+          `affected-spec resolver knows which source it guards (see ` +
+          `.scripts/js/affected-visual-specs).`
+      );
+    }
+
+    for (const coveredPath of covered) {
+      if (!fs.existsSync(path.join(rootDir, coveredPath))) {
+        throw new Error(
+          `Spec "${specRel}" declares "@covers ${coveredPath}" but that path ` +
+            `does not exist.`
+        );
+      }
+      if (!map.has(coveredPath)) map.set(coveredPath, new Set());
+      map.get(coveredPath).add(specRel);
+    }
+  }
+  return map;
+};
+
+/**
+ * Set of component directory names (e.g. "Icon") that are imported by *another*
+ * component. A change to such a shared component can alter the rendering of its
+ * consumers' snapshots, so we escalate to the full suite rather than trusting a
+ * scoped run.
+ *
+ * What counts as a shared dependency: an import of the component from another
+ * component's *runtime* source (i.e. it is a building block other components
+ * render). What does NOT count:
+ *   - barrel re-exports (src/components/index.ts), theme, lib, demo code —
+ *     otherwise the barrel that re-exports every component would mark the whole
+ *     catalogue shared and defeat scoping;
+ *   - `.stories.tsx` / test files — a story importing a layout primitive for
+ *     demo purposes is not a runtime rendering dependency. (Trade-off: a
+ *     primitive used *only* inside another component's stories is not treated
+ *     as shared; migrations are visual-parity by design, so this is accepted
+ *     and surfaced in the logs.)
+ */
+const getSharedComponents = () => {
+  const componentNames = fs
+    .readdirSync(componentsDir, { withFileTypes: true })
+    .filter(e => e.isDirectory())
+    .map(e => e.name);
+
+  // `components/Icon` must not match `components/IconButton`, so require the
+  // name to be followed by a non-identifier character (path separator, quote…).
+  const matchers = componentNames.map(name => ({
+    name,
+    re: new RegExp(`components/${name}(?![A-Za-z0-9])`),
+  }));
+
+  const shared = new Set();
+  const srcFiles = walk(
+    path.join(rootDir, 'src'),
+    name =>
+      /\.(ts|tsx)$/.test(name) &&
+      !/\.stories\.tsx?$/.test(name) &&
+      !/\.(test|spec)\.tsx?$/.test(name)
+  );
+
+  for (const fileAbs of srcFiles) {
+    const fileRel = toPosix(path.relative(rootDir, fileAbs));
+    const importerComponent = fileRel.match(/^src\/components\/([^/]+)\//)?.[1];
+    if (!importerComponent) continue; // not inside a component dir
+
+    const content = fs.readFileSync(fileAbs, 'utf-8');
+    for (const { name, re } of matchers) {
+      if (name === importerComponent || shared.has(name)) continue;
+      if (re.test(content)) shared.add(name);
+    }
+  }
+  return shared;
+};
+
+const isSnapshot = p => /\.spec\.ts-snapshots\//.test(p);
+const isIgnorable = p =>
+  p.startsWith('.changeset/') ||
+  /\.(md|mdx)$/.test(p) ||
+  p === 'LICENSE' ||
+  p.startsWith('.github/ISSUE_TEMPLATE/');
+
+const main = () => {
+  const changed = getChangedFiles();
+  if (changed.length === 0) {
+    log(`No changes detected against ${baseRef}.`);
+    process.stdout.write('NONE');
+    return;
+  }
+
+  log(`Changed files vs ${baseRef}:`);
+  changed.forEach(f => log(`  ${f}`));
+
+  const coverage = buildCoverageMap();
+  const shared = getSharedComponents();
+  const selected = new Set();
+  const reasons = [];
+
+  for (const file of changed) {
+    // 1. A spec file itself always runs.
+    if (file.startsWith('tests/') && file.endsWith('.spec.ts')) {
+      selected.add(file);
+      reasons.push(`${file} -> itself (spec changed)`);
+      continue;
+    }
+
+    // 2. A snapshot runs its owning spec.
+    if (isSnapshot(file)) {
+      const owning = file.replace(/\.spec\.ts-snapshots\/.*$/, '.spec.ts');
+      selected.add(owning);
+      reasons.push(`${file} -> ${owning} (snapshot baseline)`);
+      continue;
+    }
+
+    // 3. Other test infrastructure (utils, fixtures) -> full suite.
+    if (file.startsWith('tests/')) {
+      log(`\nFull suite: shared test infra changed (${file}).`);
+      return finish('ALL');
+    }
+
+    // 4. Component source.
+    const componentMatch = file.match(/^src\/components\/([^/]+)\//);
+    if (componentMatch) {
+      const name = componentMatch[1];
+      if (shared.has(name)) {
+        log(
+          `\nFull suite: shared component changed (${name} is imported by other components).`
+        );
+        return finish('ALL');
+      }
+      const dir = `src/components/${name}`;
+      const specs = coverage.get(dir);
+      if (specs) {
+        specs.forEach(s => {
+          selected.add(s);
+          reasons.push(`${file} -> ${s} (@covers ${dir})`);
+        });
+      } else {
+        reasons.push(`${file} -> ignored (${dir} has no visual spec)`);
+      }
+      continue;
+    }
+
+    // 5. Docs / changesets -> no visual impact.
+    if (isIgnorable(file)) {
+      reasons.push(`${file} -> ignored (docs/changeset)`);
+      continue;
+    }
+
+    // 6. Anything else (theme, lib, hooks, configs, storybook, deps) is
+    //    potentially global -> run the full suite to stay safe.
+    log(`\nFull suite: non-component change that may affect any story (${file}).`);
+    return finish('ALL');
+  }
+
+  log('\nResolution:');
+  reasons.forEach(r => log(`  ${r}`));
+
+  if (selected.size === 0) {
+    log('\nNo visual-affecting changes -> skipping the visual suite.');
+    return finish('NONE');
+  }
+
+  const list = [...selected].sort();
+  log(`\nScoped to ${list.length} spec file(s).`);
+  return finish(list.join(' '));
+};
+
+const finish = result => {
+  process.stdout.write(result);
+};
+
+main();

--- a/tests/buttons/button.spec.ts
+++ b/tests/buttons/button.spec.ts
@@ -1,3 +1,6 @@
+// Affected-spec coverage for scoped visual-regression runs in CI.
+// See .scripts/js/affected-visual-specs
+// @covers src/components/Button
 import { test as it, expect } from '@playwright/test';
 import { getStoryUrl } from '../utils';
 

--- a/tests/buttons/buttongroup.spec.ts
+++ b/tests/buttons/buttongroup.spec.ts
@@ -1,3 +1,6 @@
+// Affected-spec coverage for scoped visual-regression runs in CI.
+// See .scripts/js/affected-visual-specs
+// @covers src/components/ButtonGroup
 import { test as it, expect } from '@playwright/test';
 import { getStoryUrl } from '../utils';
 

--- a/tests/buttons/iconbutton.spec.ts
+++ b/tests/buttons/iconbutton.spec.ts
@@ -1,3 +1,6 @@
+// Affected-spec coverage for scoped visual-regression runs in CI.
+// See .scripts/js/affected-visual-specs
+// @covers src/components/IconButton
 import { test as it, expect } from '@playwright/test';
 import { getStoryUrl } from '../utils';
 

--- a/tests/buttons/overview.spec.ts
+++ b/tests/buttons/overview.spec.ts
@@ -1,3 +1,7 @@
+// Affected-spec coverage for scoped visual-regression runs in CI.
+// See .scripts/js/affected-visual-specs
+// @covers src/components/Button
+// @covers src/components/ButtonGroup
 import { test as it, expect } from '@playwright/test';
 
 const { describe, beforeEach, afterEach } = it;

--- a/tests/cards/cardhorizontal.spec.ts
+++ b/tests/cards/cardhorizontal.spec.ts
@@ -1,3 +1,6 @@
+// Affected-spec coverage for scoped visual-regression runs in CI.
+// See .scripts/js/affected-visual-specs
+// @covers src/components/CardHorizontal
 import { test as it, expect } from '@playwright/test';
 import { getStoryUrl } from '../utils';
 

--- a/tests/cards/cardprimary.spec.ts
+++ b/tests/cards/cardprimary.spec.ts
@@ -1,3 +1,6 @@
+// Affected-spec coverage for scoped visual-regression runs in CI.
+// See .scripts/js/affected-visual-specs
+// @covers src/components/CardPrimary
 import { test as it, expect } from '@playwright/test';
 import { getStoryUrl } from '../utils';
 

--- a/tests/display/avatar.spec.ts
+++ b/tests/display/avatar.spec.ts
@@ -1,3 +1,6 @@
+// Affected-spec coverage for scoped visual-regression runs in CI.
+// See .scripts/js/affected-visual-specs
+// @covers src/components/Avatar
 import { test as it, expect } from '@playwright/test';
 import { getStoryUrl } from '../utils';
 

--- a/tests/display/badge.spec.ts
+++ b/tests/display/badge.spec.ts
@@ -1,3 +1,6 @@
+// Affected-spec coverage for scoped visual-regression runs in CI.
+// See .scripts/js/affected-visual-specs
+// @covers src/components/Badge
 import { test as it, expect } from '@playwright/test';
 import { getStoryUrl } from '../utils';
 

--- a/tests/display/container.spec.ts
+++ b/tests/display/container.spec.ts
@@ -1,3 +1,6 @@
+// Affected-spec coverage for scoped visual-regression runs in CI.
+// See .scripts/js/affected-visual-specs
+// @covers src/components/Container
 import { test as it, expect } from '@playwright/test';
 import { getStoryUrl } from '../utils';
 

--- a/tests/display/generic-label.spec.ts
+++ b/tests/display/generic-label.spec.ts
@@ -1,3 +1,6 @@
+// Affected-spec coverage for scoped visual-regression runs in CI.
+// See .scripts/js/affected-visual-specs
+// @covers src/components/GenericLabel
 import { test as it, expect } from '@playwright/test';
 import { getStoryUrl } from '../utils';
 

--- a/tests/display/icon.spec.ts
+++ b/tests/display/icon.spec.ts
@@ -1,3 +1,6 @@
+// Affected-spec coverage for scoped visual-regression runs in CI.
+// See .scripts/js/affected-visual-specs
+// @covers src/components/Icon
 import { test as it, expect } from '@playwright/test';
 import { getStoryUrl } from '../utils';
 

--- a/tests/display/label.spec.ts
+++ b/tests/display/label.spec.ts
@@ -1,3 +1,6 @@
+// Affected-spec coverage for scoped visual-regression runs in CI.
+// See .scripts/js/affected-visual-specs
+// @covers src/components/Label
 import { test as it, expect } from '@playwright/test';
 import { getStoryUrl } from '../utils';
 

--- a/tests/display/link.spec.ts
+++ b/tests/display/link.spec.ts
@@ -1,3 +1,6 @@
+// Affected-spec coverage for scoped visual-regression runs in CI.
+// See .scripts/js/affected-visual-specs
+// @covers src/components/Link
 import { test as it, expect } from '@playwright/test';
 import { getStoryUrl } from '../utils';
 

--- a/tests/display/progress-bar.spec.ts
+++ b/tests/display/progress-bar.spec.ts
@@ -1,3 +1,6 @@
+// Affected-spec coverage for scoped visual-regression runs in CI.
+// See .scripts/js/affected-visual-specs
+// @covers src/components/ProgressBar
 import { test as it, expect } from '@playwright/test';
 import { getStoryUrl } from '../utils';
 

--- a/tests/display/separator.spec.ts
+++ b/tests/display/separator.spec.ts
@@ -1,3 +1,6 @@
+// Affected-spec coverage for scoped visual-regression runs in CI.
+// See .scripts/js/affected-visual-specs
+// @covers src/components/Separator
 import { test as it, expect } from '@playwright/test';
 import { getStoryUrl } from '../utils';
 

--- a/tests/display/spacer.spec.ts
+++ b/tests/display/spacer.spec.ts
@@ -1,3 +1,6 @@
+// Affected-spec coverage for scoped visual-regression runs in CI.
+// See .scripts/js/affected-visual-specs
+// @covers src/components/Spacer
 import { test as it, expect } from '@playwright/test';
 import { getStoryUrl } from '../utils';
 

--- a/tests/display/text.spec.ts
+++ b/tests/display/text.spec.ts
@@ -1,3 +1,6 @@
+// Affected-spec coverage for scoped visual-regression runs in CI.
+// See .scripts/js/affected-visual-specs
+// @covers src/components/Text
 import { test as it, expect } from '@playwright/test';
 import { getStoryUrl } from '../utils';
 

--- a/tests/display/title.spec.ts
+++ b/tests/display/title.spec.ts
@@ -1,3 +1,6 @@
+// Affected-spec coverage for scoped visual-regression runs in CI.
+// See .scripts/js/affected-visual-specs
+// @covers src/components/Title
 import { test as it, expect } from '@playwright/test';
 import { getStoryUrl } from '../utils';
 

--- a/tests/forms/checkbox.spec.ts
+++ b/tests/forms/checkbox.spec.ts
@@ -1,3 +1,6 @@
+// Affected-spec coverage for scoped visual-regression runs in CI.
+// See .scripts/js/affected-visual-specs
+// @covers src/components/Checkbox
 import { test as it, expect } from '@playwright/test';
 import { getStoryUrl } from '../utils';
 

--- a/tests/forms/switch.spec.ts
+++ b/tests/forms/switch.spec.ts
@@ -1,3 +1,6 @@
+// Affected-spec coverage for scoped visual-regression runs in CI.
+// See .scripts/js/affected-visual-specs
+// @covers src/components/Switch
 import { test as it, expect } from '@playwright/test';
 import { getStoryUrl } from '../utils';
 


### PR DESCRIPTION
## Problem

The visual-regression job runs the **full Playwright suite on every PR** — 469 screenshots, ~7.7 min — and it grows with each new component. A recent run breaks down as:

| Phase | Time |
|---|---|
| Install deps + Chromium | ~50s |
| Storybook boot | ~9s |
| **Running 469 tests** | **7.7 min** |

So ~90% of the time is test execution, and it scales linearly with test count (median 3.8s/test).

## Why not Playwright `--only-changed`

Each spec navigates to a Storybook story **by string id** rather than importing its component, so there's no import-graph edge from a `src/` change to its spec. I confirmed empirically that adding a real import breaks collection — Playwright executes top-level imports and chokes on the component's `.module.css` import (`SyntaxError: Unexpected token` at `.spacer {`). So `--only-changed` can't see `src/` changes here without hacky CSS-stubbing in Playwright's loader.

## Approach

Each spec declares the source it guards with `@covers <path>` directives, and a new resolver (`.scripts/js/affected-visual-specs`) maps the PR diff onto them:

| Changed | Runs |
|---|---|
| leaf component | that component's spec only |
| snapshot baseline | its owning spec |
| spec file | itself |
| **shared** building block (rendered by other components) | full suite |
| theme / lib / config / test utils | full suite |
| changeset / docs only | skips the suite entirely |

A component is "shared" if another component's **runtime** source imports it (story-only/demo usage doesn't count). The resolver **throws if any spec lacks a `@covers` directive**, so coverage can't silently drift out of sync.

## Impact

Of the 14 spec-backed components today, **5 are leaves** (scoped to ~1–2 min): `ButtonGroup`, `CardHorizontal`, `CardPrimary`, `Avatar`, `Link`. The other 9 are genuinely shared building blocks and still run the full suite — correctly, since changing them can shift other snapshots. Every future leaf spec added gets the fast path too.

## Verified

- Leaf migration PR (e.g. Avatar: component + snapshot + changeset) → scopes to `avatar.spec.ts` only
- Shared component (Icon/Spacer/etc.) → full suite
- theme/lib/config change → full suite
- changeset-only → skips entirely (no install, no browser download)

## Follow-up (not in this PR)

A dependency-graph version could turn many of the 9 shared components into scoped runs (e.g. a `Badge` change → only specs of components that actually render Badge). I left it out deliberately: it trades the current "never under-runs" safety for under-run risk if the import graph misses an edge, which is a false-green in visual regression. Can add it if the extra speed is worth that trade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI test selection logic; conservative fallbacks to full suite limit false greens, but mis-tagged `@covers` or shared-component edge cases could under-run tests until caught.
> 
> **Overview**
> Adds **diff-based scoping** for the visual-regression CI job so PRs no longer always run the full Playwright suite (~469 tests).
> 
> A new resolver (`.scripts/js/affected-visual-specs`) maps changed files to specs via **`@covers src/components/<Name>`** comments in each visual spec. It outputs `ALL`, `NONE`, or a space-separated list of spec paths. Rules: run the mapped spec for leaf component changes; escalate to **full suite** for shared components (imported by other components’ runtime code), global areas (theme, lib, configs, `tests/utils`), or other test infra; **skip** install/browsers/tests when only docs/changesets change. Specs without `@covers` **fail the resolver** so coverage cannot drift.
> 
> The **visual-regression workflow** now uses `fetch-depth: 0`, resolves affected specs before install, gates yarn/Playwright on `result != NONE`, and runs either the full suite or scoped `npx playwright test <paths>`.
> 
> Existing visual specs and the **CSS Modules migration skill** are updated to require the `@covers` header on new specs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf253de706331ef8dfcba13ff272d3a69bce9c09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->