### PR TITLE
test(Container): name the nested-inheritance spec in BDD style

### DIFF
--- a/tests/display/container.spec.ts
+++ b/tests/display/container.spec.ts
@@ -65,8 +65,8 @@ describe('Container Visual Regression', () => {
   // stretches every descendant Container to full height (regression observed in
   // the control-plane alert banner). Assert computed styles directly so the
   // guard does not depend on a pixel baseline.
-  describe('Nested custom-property inheritance', () => {
-    it('child Container does not inherit parent fillHeight/grow/overflow', async ({
+  describe('isolating layout custom properties from nested Containers', () => {
+    it('does not let a nested Container inherit its ancestor’s fillHeight, grow, or overflow', async ({
       page,
     }) => {
       await page.goto(getStoryUrl('layout-container--nested-inheritance', 'light'), {


### PR DESCRIPTION
Addresses @hoorayimhelping's review nit on #1067: the nested-inheritance guard's `describe`/`it` read as implementation labels rather than a sentence.

**Before**
```
Nested custom-property inheritance
  › child Container does not inherit parent fillHeight/grow/overflow
```

**After** (reads as natural-language BDD, per control-plane's `bdd-tests` convention)
```
isolating layout custom properties from nested Containers
  › does not let a nested Container inherit its ancestor's fillHeight, grow, or overflow
```

No behavior change — only the `describe`/`it` strings. The test still passes:

```
✓ … does not let a nested Container inherit its ancestor's fillHeight, grow, or overflow (1 passed)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only rename of describe/it strings; no production or assertion changes.
> 
> **Overview**
> Renames the nested Container layout test’s **`describe`** and **`it`** titles so they read as natural-language BDD (aligned with control-plane’s `bdd-tests` convention) instead of implementation-style labels.
> 
> **No test logic or assertions change** — only the strings shown in test output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee21a47e5f41eea7cc262fdd93d64956569dca72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->