### PR TITLE
fix(Select): don't wrap options content

### DIFF
--- a/.changeset/light-maps-rule.md
+++ b/.changeset/light-maps-rule.md
@@ -1,0 +1,5 @@
+---
+"@clickhouse/click-ui": patch
+---
+
+fix(Select): don't wrap options content

--- a/src/components/Select/common/InternalSelect.tsx
+++ b/src/components/Select/common/InternalSelect.tsx
@@ -776,6 +776,7 @@ export const MultiSelectCheckboxItem = forwardRef<
             orientation="horizontal"
             gap="xs"
             overflow="hidden"
+            isResponsive={false}
           >
             <Checkbox
               checked={isChecked}


### PR DESCRIPTION
## Why?

Select with `checkbox={true}` options are rendered with checkboxes, the row is wrapped in Container. isResponsive wasn't set, so layout was broken on narrow screens.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single layout prop on Select checkbox items; no API, auth, or data changes.
> 
> **Overview**
> Fixes broken layout for **multi-select checkbox** option rows on narrow viewports by setting **`isResponsive={false}`** on the horizontal `Container` that wraps the checkbox and label in `MultiSelectCheckboxItem`.
> 
> Without it, `Container`’s default responsive behavior stacks the row vertically below the breakpoint, which was causing option content to wrap incorrectly inside the select dropdown.
> 
> Includes a **patch** changeset for `@clickhouse/click-ui`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1477576921acc232c74ca89d0e107c6983d21807. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->