### PR TITLE
fix(test): let vitest resolve deps from nested git worktrees

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -142,6 +142,15 @@ const viteConfig = defineConfig({
 });
 
 const vitestConfig = defineVitestConfig({
+  // Allow Vitest to read files outside the package root. When tests run from a
+  // git worktree created under the repo (e.g. `.claude/worktrees/<id>/`), Vite
+  // resolves setup files like `@testing-library/jest-dom` up-tree into the
+  // parent checkout's `node_modules`; the default `fs.allow` (scoped to the
+  // worktree) then denies the read, surfacing as a misleading
+  // "Failed to load url …/jest-dom/dist/index.mjs … Does the file exist?".
+  // This only affects the local Vitest transform server — the library build and
+  // Storybook use their own configs — so relaxing strictness here is safe.
+  server: { fs: { strict: false } },
   test: {
     environment: 'jsdom',
     // TODO: Note that currently, the pw visual regression tests

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -142,14 +142,8 @@ const viteConfig = defineConfig({
 });
 
 const vitestConfig = defineVitestConfig({
-  // Allow Vitest to read files outside the package root. When tests run from a
-  // git worktree created under the repo (e.g. `.claude/worktrees/<id>/`), Vite
-  // resolves setup files like `@testing-library/jest-dom` up-tree into the
-  // parent checkout's `node_modules`; the default `fs.allow` (scoped to the
-  // worktree) then denies the read, surfacing as a misleading
-  // "Failed to load url …/jest-dom/dist/index.mjs … Does the file exist?".
-  // This only affects the local Vitest transform server — the library build and
-  // Storybook use their own configs — so relaxing strictness here is safe.
+  // Let Vitest read setup files from a parent checkout's node_modules when run
+  // from a git worktree. See https://github.com/ClickHouse/click-ui/pull/1071
   server: { fs: { strict: false } },
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Problem

Running `yarn test` from a **git worktree created under the repo** (e.g. `.claude/worktrees/<id>/`) fails to load the Vitest setup files:

```
Error: Failed to load url /…/click-ui/node_modules/@testing-library/jest-dom/dist/index.mjs
(resolved id: /…/click-ui/node_modules/@testing-library/jest-dom/dist/index.mjs). Does the file exist?
```

The file *does* exist. Vitest's transform server inherits Vite's default `server.fs.allow`, which is scoped to the package root. Because the worktree lives **inside** the parent checkout, Vite resolves bare setup specifiers like `@testing-library/jest-dom` up-tree into the parent's `node_modules`, and `fs.allow` (rooted at the worktree) then denies the read — surfacing as the misleading "Does the file exist?" load error.

This blocks anyone running the test suite from a worktree, not just one workflow.

## Fix

Relax `fs.strict` for the **Vitest config only**. This affects just the local Vitest transform server; the library `vite build` and Storybook use their own configs, so there is no dev-server file-exposure tradeoff.

## Verification

- Nested worktree: `vitest run` now passes (was failing to load every suite).
- Main checkout: unchanged — full suite still green.
- `yarn lint`, `yarn typecheck`, `yarn format` (prettier) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Vite server setting with no change to production build or app runtime behavior.
> 
> **Overview**
> Fixes Vitest failing in **nested git worktrees** when setup files resolve to the parent checkout’s `node_modules` and Vite’s default `server.fs` rules block those reads.
> 
> The Vitest-only config now sets **`server.fs.strict: false`**, so the local test transform server can load paths like `@testing-library/jest-dom` from an ancestor install. **Library `vite build` and Storybook are unchanged**—this relaxation applies only to the merged Vitest config, not the main dev/build server exposure surface described in the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65a9a0fdc73030694326ef52757e3ed4f0b8e8e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->