### PR TITLE
fix(Button): accept htmlType to support native button types

### DIFF
--- a/.changeset/fix-button-html-type.md
+++ b/.changeset/fix-button-html-type.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': patch
+---
+
+ fix(Button): accept htmlType to support native button types

--- a/.changeset/fix-button-html-type.md
+++ b/.changeset/fix-button-html-type.md
@@ -2,4 +2,4 @@
 '@clickhouse/click-ui': patch
 ---
 
- fix(Button): accept htmlType to support native button types
+ `Button` now accepts `htmlType` prop to support native HTML `type` attribute.

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -119,4 +119,31 @@ describe('Button', () => {
       expect(button).toBeDisabled();
     });
   });
+
+  describe('Button HTML types', () => {
+    it('should not default to any type when consumer does not specify it, thus behaving as type=submit', () => {
+      const handleSubmit = vi.fn();
+
+      const { getByRole } = renderCUI(
+        <form onSubmit={handleSubmit}>
+          <Button />
+        </form>
+      );
+
+      const button = getByRole('button');
+
+      expect(handleSubmit).not.toHaveBeenCalled();
+      fireEvent.click(button);
+      expect(handleSubmit).toHaveBeenCalled();
+    });
+
+    it.each(['submit', 'button', 'reset'] as const)(
+      'should use htmlType to set type=%s',
+      type => {
+        const { getByRole } = renderButton({ htmlType: type });
+        const button = getByRole('button');
+        expect(button).toHaveAttribute('type', type);
+      }
+    );
+  });
 });

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,32 +1,8 @@
-import { Icon, IconName } from '@/components/Icon';
+import { Icon } from '@/components/Icon';
 import { cn, cva } from '@/lib/cva';
 import { forwardRef } from 'react';
 import styles from './Button.module.css';
-
-export type ButtonType = 'primary' | 'secondary' | 'empty' | 'danger';
-type Alignment = 'center' | 'left';
-
-export interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
-  // TODO: The type prop ('primary' | 'secondary' | 'empty' | 'danger') shadows the native <button type="submit|reset|button"> attribute. Since type is destructured before ...delegated, consumers can never pass type="submit" for form submission. Consider renaming the visual variant prop to variant (consistent with the CSS class names button_primary etc.). This is a public API problem!
-  /** The visual style variant of the button */
-  type?: ButtonType;
-  /** Whether the button is disabled */
-  disabled?: boolean;
-  /** The text label to display in the button */
-  label?: string;
-  /** Icon to display on the left side of the label */
-  iconLeft?: IconName;
-  /** Icon to display on the right side of the label */
-  iconRight?: IconName;
-  /** Alignment of the button content */
-  align?: Alignment;
-  /** Whether the button should fill the full width of its container */
-  fillWidth?: boolean;
-  /** Whether to show a loading state */
-  loading?: boolean;
-  /** Whether the button should be focused on mount */
-  autoFocus?: boolean;
-}
+import { ButtonProps } from './Button.types';
 
 const buttonVariants = cva(styles.button, {
   variants: {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -33,6 +33,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
       type = 'primary',
+      htmlType,
       iconLeft,
       iconRight,
       align = 'center',
@@ -47,6 +48,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     ref
   ) => (
     <button
+      type={htmlType}
       ref={ref}
       className={cn(buttonVariants({ type, align, fillWidth, loading }), className)}
       disabled={disabled || loading}

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -4,13 +4,23 @@ export type ButtonType = 'primary' | 'secondary' | 'empty' | 'danger';
 export type Alignment = 'center' | 'left';
 
 export interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
+  // TODO: The type prop ('primary' | 'secondary' | 'empty' | 'danger') shadows the native <button type="submit|reset|button"> attribute. Since type is destructured before ...delegated, consumers can never pass type="submit" for form submission. Consider renaming the visual variant prop to variant (consistent with the CSS class names button_primary etc.). This is a public API problem!
+  /** The visual style variant of the button */
   type?: ButtonType;
+  /** Whether the button is disabled */
   disabled?: boolean;
+  /** The text label to display in the button */
   label?: string;
+  /** Icon to display on the left side of the label */
   iconLeft?: IconName;
+  /** Icon to display on the right side of the label */
   iconRight?: IconName;
+  /** Alignment of the button content */
   align?: Alignment;
+  /** Whether the button should fill the full width of its container */
   fillWidth?: boolean;
+  /** Whether to show a loading state */
   loading?: boolean;
+  /** Whether the button should be focused on mount */
   autoFocus?: boolean;
 }

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -10,20 +10,12 @@ export interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
   // TODO: A workaround to fix native prop shadowing by the `type` prop. Refactor in the next major update.
   /** Used for native button type attribute  */
   htmlType?: React.ButtonHTMLAttributes<HTMLButtonElement>['type'];
-  /** Whether the button is disabled */
   disabled?: boolean;
-  /** The text label to display in the button */
   label?: string;
-  /** Icon to display on the left side of the label */
   iconLeft?: IconName;
-  /** Icon to display on the right side of the label */
   iconRight?: IconName;
-  /** Alignment of the button content */
   align?: Alignment;
-  /** Whether the button should fill the full width of its container */
   fillWidth?: boolean;
-  /** Whether to show a loading state */
   loading?: boolean;
-  /** Whether the button should be focused on mount */
   autoFocus?: boolean;
 }

--- a/src/components/Button/Button.types.ts
+++ b/src/components/Button/Button.types.ts
@@ -7,6 +7,9 @@ export interface ButtonProps extends React.HTMLAttributes<HTMLButtonElement> {
   // TODO: The type prop ('primary' | 'secondary' | 'empty' | 'danger') shadows the native <button type="submit|reset|button"> attribute. Since type is destructured before ...delegated, consumers can never pass type="submit" for form submission. Consider renaming the visual variant prop to variant (consistent with the CSS class names button_primary etc.). This is a public API problem!
   /** The visual style variant of the button */
   type?: ButtonType;
+  // TODO: A workaround to fix native prop shadowing by the `type` prop. Refactor in the next major update.
+  /** Used for native button type attribute  */
+  htmlType?: React.ButtonHTMLAttributes<HTMLButtonElement>['type'];
   /** Whether the button is disabled */
   disabled?: boolean;
   /** The text label to display in the button */


### PR DESCRIPTION
## Why?

Buttons need their types.

## How?

- keep `type` as is to define button variant
- add `htmlType` to pass html button type
- add tests

When we are doing major updates, this needs to be refactored and done properly.

## Contribution checklist?

- [x] You've done enough research before writing
- [x] You have reviewed the PR
- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [x] Assets or static content are linked and stored in the project
- [x] For documentation, guides or references, you've tested the commands

## Security checklist?

- [x] All user inputs are validated and sanitized
- [x] No usage of `dangerouslySetInnerHTML`
- [x] Sensitive data has been identified and is being protected properly
- [x] Build output contains no secrets or API keys

## Preview?

Optionally, provide a demo or a preview url here

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive public API on a UI component with tests; no auth, data, or security-sensitive logic.
> 
> **Overview**
> **`Button`** gains an **`htmlType`** prop so consumers can set the native DOM **`type`** (`submit`, `button`, `reset`) without conflicting with the existing **`type`** visual variant (`primary`, `secondary`, etc.). The root **`<button>`** now renders **`type={htmlType}`**; when **`htmlType`** is omitted, default browser behavior applies (e.g. implicit submit inside forms).
> 
> **`ButtonProps`** and related types are moved into **`Button.types.ts`** with JSDoc and TODOs noting **`type`** should become **`variant`** in a future major release. Tests cover form submission and each **`htmlType`** value; a patch changeset documents the API addition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 274809851de1608e64ecfc94c26c28fbf60cd1b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->