### PR TITLE
feat(portal-provider): Add portal layer provider

### DIFF
--- a/.changeset/portal-layer-provider.md
+++ b/.changeset/portal-layer-provider.md
@@ -1,0 +1,5 @@
+---
+"@clickhouse/click-ui": minor
+---
+
+Add a portal provider API so overlay components can render into an explicit container.

--- a/src/components/AutoComplete/AutoComplete.tsx
+++ b/src/components/AutoComplete/AutoComplete.tsx
@@ -25,6 +25,7 @@ import { GenericMenuItem } from '@/components/GenericMenu';
 import { IconWrapper } from '@/components/IconWrapper';
 import { getTextFromNodes } from '@/lib/getTextFromNodes';
 import { mergeRefs } from '@/utils/mergeRefs';
+import { useResolvedPortalContainer } from '@/providers/PortalContext';
 
 import { useOption, useSearch } from './useOption';
 import { OptionContext } from './OptionContext';
@@ -94,6 +95,7 @@ interface Props
   placeholder?: string;
   onOpenChange?: (open: boolean) => void;
   label?: ReactNode;
+  container?: HTMLElement | null;
   error?: ReactNode;
   disabled?: boolean;
   dir?: 'start' | 'end';
@@ -264,6 +266,7 @@ export const AutoComplete = ({
   disabled,
   value = '',
   placeholder = 'Search',
+  container,
   ...props
 }: AutoCompleteProps) => {
   const defaultId = useId();
@@ -271,6 +274,7 @@ export const AutoComplete = ({
   const [open, setOpen] = useState(false);
 
   const inputRef = useRef<HTMLInputElement>(null);
+  const portalContainer = useResolvedPortalContainer(container);
   const [highlighted, setHighlighted] = useState<string | undefined>();
   const visibleList = useRef<string[]>([]);
   const navigatable = useRef<string[]>([]);
@@ -505,7 +509,7 @@ export const AutoComplete = ({
           />
         </div>
       </Trigger>
-      <Portal>
+      <Portal container={portalContainer}>
         <PopoverContent
           sideOffset={5}
           onFocus={onFocus}

--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -9,6 +9,7 @@ import Popover_Arrow from '@/components/Assets/Icons/Popover-Arrow';
 import { IconWrapper } from '@/components/IconWrapper/IconWrapper';
 import { useInputModality } from '@/hooks/internal';
 import type { ArrowProps, ContextMenuItemProps } from './ContextMenu.types';
+import { useResolvedPortalContainer } from '@/providers/PortalContext';
 
 export const ContextMenu = (props: RightMenu.ContextMenuProps) => (
   <RightMenu.Root {...props} />
@@ -80,11 +81,13 @@ type DeprecatedFields = {
 
 type ContextMenuContentProps = RightMenu.ContextMenuContentProps & {
   sub?: true;
+  container?: HTMLElement | null;
 } & ArrowProps &
   DeprecatedFields;
 
 type ContextMenuSubContentProps = RightMenu.ContextMenuSubContentProps & {
   sub?: never;
+  container?: HTMLElement | null;
 } & ArrowProps &
   DeprecatedFields;
 
@@ -120,6 +123,7 @@ const RightMenuContent = styled(GenericMenuPanel)<{ $showArrow?: boolean }>`
 const ContextMenuContent = ({
   sub,
   children,
+  container,
   showArrow,
   // TODO: remove deprecated side and align
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -130,8 +134,10 @@ const ContextMenuContent = ({
 }: ContextMenuContentProps | ContextMenuSubContentProps) => {
   const ContentElement = sub ? RightMenu.SubContent : RightMenu.Content;
   const inputModalityProps = useInputModality();
+  const portalContainer = useResolvedPortalContainer(container);
+
   return (
-    <RightMenu.Portal>
+    <RightMenu.Portal container={portalContainer}>
       <RightMenuContent
         {...props}
         $type="context-menu"

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -4,6 +4,7 @@ import * as Popover from '@radix-ui/react-popover';
 import { styled } from 'styled-components';
 import { Body, CalendarRenderer, DatePickerInput, DateTableCell } from './Common';
 import { shiftFromTimezone, shiftToTimezone, Timezone } from './utils';
+import { useResolvedPortalContainer } from '@/providers/PortalContext';
 
 const DAYS_IN_WEEK = 7;
 
@@ -199,6 +200,7 @@ const Calendar = ({
 
 export interface DatePickerProps {
   allowOnlyDatesList?: Array<Date>;
+  container?: HTMLElement | null;
   date?: Date;
   disabled?: boolean;
   futureDatesDisabled?: boolean;
@@ -210,6 +212,7 @@ export interface DatePickerProps {
 
 export const DatePicker = ({
   allowOnlyDatesList,
+  container,
   date,
   disabled = false,
   futureDatesDisabled = false,
@@ -225,6 +228,7 @@ export const DatePicker = ({
   const [autoFocusCalendar, setAutoFocusCalendar] = useState<boolean>(false);
 
   const calendarOptions: UseCalendarOptions = {};
+  const portalContainer = useResolvedPortalContainer(container);
 
   if (selectedDate) {
     calendarOptions.defaultDate = selectedDate;
@@ -304,7 +308,7 @@ export const DatePicker = ({
           timezone={timezone}
         />
       </PopoverTrigger>
-      <Popover.Portal>
+      <Popover.Portal container={portalContainer}>
         <PopoverContent
           align="start"
           avoidCollisions={responsivePositioning}

--- a/src/components/Dialog/Dialog.tsx
+++ b/src/components/Dialog/Dialog.tsx
@@ -5,6 +5,7 @@ import { Icon } from '@/components/Icon';
 import { Spacer } from '@/components/Spacer';
 import { CrossButton } from '@/components/CrossButton';
 import { DialogContentProps, DialogProps, DialogTriggerProps } from './Dialog.types';
+import { useResolvedPortalContainer } from '@/providers/PortalContext';
 
 export const Dialog = ({ children, ...props }: DialogProps) => {
   return <RadixDialog.Root {...props}>{children}</RadixDialog.Root>;
@@ -138,10 +139,12 @@ const DialogContent = ({
   reducePadding = false,
   ...props
 }: DialogContentProps) => {
+  const portalContainer = useResolvedPortalContainer(container);
+
   return (
     <RadixDialog.Portal
       forceMount={forceMount}
-      container={container}
+      container={portalContainer}
     >
       {showOverlay && <DialogOverlay />}
       <ContentArea

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -8,6 +8,7 @@ import { IconWrapper } from '@/components/IconWrapper';
 import { Icon } from '@/components/Icon';
 import type { IconName } from '@/components/Icon';
 import type { HorizontalDirection } from '@/types';
+import { useResolvedPortalContainer } from '@/providers/PortalContext';
 
 export const Dropdown = (props: DropdownMenu.DropdownMenuProps) => (
   <DropdownMenu.Root {...props} />
@@ -87,11 +88,13 @@ export type ArrowProps = {
 
 interface StyledDropdownContentProps extends DropdownMenu.DropdownMenuContentProps {
   children?: ReactNode;
+  container?: HTMLElement | null;
   responsivePositioning?: boolean;
 }
 
 interface StyledDropdownSubContentProps extends DropdownMenu.DropdownMenuSubContentProps {
   children?: ReactNode;
+  container?: HTMLElement | null;
   responsivePositioning?: boolean;
 }
 
@@ -110,14 +113,17 @@ const DropdownMenuContent = styled(GenericMenuPanel)`
 const DropdownContent = ({
   sub,
   children,
+  container,
   showArrow,
   responsivePositioning = true,
   ...props
 }: DropdownContentProps | DropdownSubContentProps) => {
   const ContentElement = sub ? DropdownMenu.SubContent : DropdownMenu.Content;
   const inputModalityProps = useInputModality();
+  const portalContainer = useResolvedPortalContainer(container);
+
   return (
-    <DropdownMenu.Portal>
+    <DropdownMenu.Portal container={portalContainer}>
       <DropdownMenuContent
         {...props}
         $type="dropdown-menu"

--- a/src/components/Flyout/Flyout.tsx
+++ b/src/components/Flyout/Flyout.tsx
@@ -19,6 +19,7 @@ import { Separator } from '@/components/Separator';
 import { Spacer } from '@/components/Spacer';
 import { styled, keyframes } from 'styled-components';
 import { CrossButton } from '@/components/CrossButton';
+import { useResolvedPortalContainer } from '@/providers/PortalContext';
 import type {
   FlyoutProps,
   FlyoutTriggerProps,
@@ -137,8 +138,10 @@ const Content = ({
   onInteractOutside,
   ...props
 }: FlyoutContentProps) => {
+  const portalContainer = useResolvedPortalContainer(container);
+
   return (
-    <DialogPortal container={container}>
+    <DialogPortal container={portalContainer}>
       {showOverlay && <DialogOverlay className="DialogOverlay" />}
       <FlyoutContent
         $size={size}

--- a/src/components/HoverCard/HoverCard.tsx
+++ b/src/components/HoverCard/HoverCard.tsx
@@ -3,6 +3,7 @@ import { ReactNode } from 'react';
 import { Arrow, GenericPopoverMenuPanel } from '@/components/GenericMenu';
 import { cn } from '@/lib/cva';
 import Popover_Arrow from '@/components/Assets/Icons/Popover-Arrow';
+import { useResolvedPortalContainer } from '@/providers/PortalContext';
 import styles from './HoverCard.module.css';
 
 export interface HoverCardContentProps extends RadixHoverCard.HoverCardContentProps {
@@ -40,10 +41,12 @@ const HoverCardContent = ({
   container,
   ...props
 }: HoverCardContentProps) => {
+  const portalContainer = useResolvedPortalContainer(container);
+
   return (
     <RadixHoverCard.Portal
       forceMount={forceMount}
-      container={container}
+      container={portalContainer}
     >
       <GenericPopoverMenuPanel
         as={RadixHoverCard.Content}

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -5,6 +5,7 @@ import { ReactNode } from 'react';
 import { Icon } from '@/components/Icon';
 import { EmptyButton } from '@/components/EmptyButton';
 import Popover_Arrow from '@/components/Assets/Icons/Popover-Arrow';
+import { useResolvedPortalContainer } from '@/providers/PortalContext';
 
 export const Popover = ({ children, ...props }: RadixPopover.PopoverProps) => {
   return <RadixPopover.Root {...props}>{children}</RadixPopover.Root>;
@@ -77,10 +78,12 @@ const PopoverContent = ({
   container,
   ...props
 }: PopoverContentProps) => {
+  const portalContainer = useResolvedPortalContainer(container);
+
   return (
     <RadixPopover.Portal
       forceMount={forceMount}
-      container={container}
+      container={portalContainer}
     >
       <MenuPanel
         as={RadixPopover.Content}

--- a/src/components/Select/common/InternalSelect.tsx
+++ b/src/components/Select/common/InternalSelect.tsx
@@ -61,6 +61,7 @@ import { IconWrapper } from '@/components/IconWrapper';
 import { useInputModality } from '@/hooks/internal';
 import { styled } from 'styled-components';
 import { getTextFromNodes } from '@/lib/getTextFromNodes';
+import { useResolvedPortalContainer } from '@/providers/PortalContext';
 
 type CallbackProps = SelectItemObject & {
   nodeProps: SelectItemProps;
@@ -331,6 +332,7 @@ export const InternalSelect = ({
 
   const inputRef = useRef<HTMLInputElement>(null);
   const inputModalityProps = useInputModality();
+  const portalContainer = useResolvedPortalContainer(container);
 
   const onFocus = () => {
     inputRef.current?.focus();
@@ -474,7 +476,7 @@ export const InternalSelect = ({
               ))}
             </HiddenSelectElement>
           )}
-          <Portal container={container}>
+          <Portal container={portalContainer}>
             <SelectPopoverContent
               {...inputModalityProps}
               sideOffset={5}

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,7 +1,8 @@
 import * as RadixTooltip from '@radix-ui/react-tooltip';
 import { HTMLAttributes } from 'react';
 import { styled } from 'styled-components';
-import { TooltipProps } from './Tooltip.types';
+import { useResolvedPortalContainer } from '@/providers/PortalContext';
+import { TooltipContentProps, TooltipProps } from './Tooltip.types';
 
 export const Tooltip = ({ children, open, disabled, ...props }: TooltipProps) => {
   return (
@@ -23,13 +24,6 @@ const TooltipTrigger = (props: HTMLAttributes<HTMLDivElement>) => {
 };
 TooltipTrigger.displayName = 'TooltipTrigger';
 Tooltip.Trigger = TooltipTrigger;
-interface TooltipContentProps extends RadixTooltip.TooltipContentProps {
-  /** Whether to show an arrow pointing to the trigger element */
-  showArrow?: boolean;
-  /** Maximum width of the tooltip content */
-  maxWidth?: string;
-}
-
 const RadixTooltipContent = styled(RadixTooltip.Content)<{ $maxWidth?: string }>`
   display: flex;
   align-items: flex-start;
@@ -55,10 +49,13 @@ const TooltipContent = ({
   children,
   sideOffset = 6,
   maxWidth,
+  container,
   ...props
 }: TooltipContentProps) => {
+  const portalContainer = useResolvedPortalContainer(container);
+
   return (
-    <RadixTooltip.Portal>
+    <RadixTooltip.Portal container={portalContainer}>
       <RadixTooltipContent
         sideOffset={sideOffset}
         $maxWidth={maxWidth}

--- a/src/components/Tooltip/Tooltip.types.ts
+++ b/src/components/Tooltip/Tooltip.types.ts
@@ -7,4 +7,5 @@ export interface TooltipProps extends RadixTooltip.TooltipProps {
 export interface TooltipContentProps extends RadixTooltip.TooltipContentProps {
   showArrow?: boolean;
   maxWidth?: string;
+  container?: HTMLElement | null;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -292,7 +292,14 @@ export type {
 
 // TODO: Having both ClickUIProvider and ThemeProvider exported is confusing.
 // Consider consolidating to a single public provider API. For example, have ThemeProvider only!
-export { ClickUIProvider, ThemeProvider } from './providers';
+export {
+  ClickUIProvider,
+  PortalProvider,
+  ThemeProvider,
+  usePortalContainer,
+  useResolvedPortalContainer,
+} from './providers';
+export type { PortalContainer, PortalProviderProps } from './providers';
 
 // ================================================
 // Theme

--- a/src/providers/PortalContext.ts
+++ b/src/providers/PortalContext.ts
@@ -1,0 +1,17 @@
+import { createContext, useContext } from 'react';
+
+export type PortalContainer = HTMLElement | null;
+
+export const PortalContainerContext = createContext<PortalContainer>(null);
+
+export const usePortalContainer = (): PortalContainer => {
+  return useContext(PortalContainerContext);
+};
+
+export const useResolvedPortalContainer = (
+  container?: PortalContainer
+): PortalContainer => {
+  const contextContainer = usePortalContainer();
+
+  return container === undefined ? contextContainer : container;
+};

--- a/src/providers/PortalProvider.test.tsx
+++ b/src/providers/PortalProvider.test.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Dropdown } from '@/components/Dropdown';
+import { Popover } from '@/components/Popover';
+import { Select } from '@/components/Select';
+import { Tooltip } from '@/components/Tooltip';
+import { PortalProvider } from '@/providers';
+import { renderCUI } from '@/utils/test-utils';
+
+describe('PortalProvider', () => {
+  let portalRoot: HTMLDivElement;
+
+  beforeAll(() => {
+    window.HTMLElement.prototype.scrollIntoView = vi.fn();
+    global.ResizeObserver = vi.fn().mockImplementation(() => ({
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+      disconnect: vi.fn(),
+    }));
+  });
+
+  beforeEach(() => {
+    portalRoot = document.createElement('div');
+    document.body.appendChild(portalRoot);
+  });
+
+  afterEach(() => {
+    portalRoot.remove();
+  });
+
+  it('renders select content into the configured portal container', () => {
+    const { getByTestId } = renderCUI(
+      <PortalProvider container={portalRoot}>
+        <Select
+          options={[{ value: 'content0', label: 'Content0' }]}
+          value={undefined}
+        />
+      </PortalProvider>
+    );
+
+    fireEvent.click(getByTestId('select-trigger'));
+
+    expect(within(portalRoot).getByText('Content0')).not.toBeNull();
+  });
+
+  it('renders popover content into the configured portal container', () => {
+    const { getByText } = renderCUI(
+      <PortalProvider container={portalRoot}>
+        <Popover>
+          <Popover.Trigger>Open popover</Popover.Trigger>
+          <Popover.Content>Portal popover</Popover.Content>
+        </Popover>
+      </PortalProvider>
+    );
+
+    fireEvent.click(getByText('Open popover'));
+
+    expect(within(portalRoot).getByText('Portal popover')).not.toBeNull();
+  });
+
+  it('renders tooltip content into the configured portal container', () => {
+    renderCUI(
+      <PortalProvider container={portalRoot}>
+        <Tooltip open>
+          <Tooltip.Trigger>Tooltip trigger</Tooltip.Trigger>
+          <Tooltip.Content>Portal tooltip</Tooltip.Content>
+        </Tooltip>
+      </PortalProvider>
+    );
+
+    expect(portalRoot).toHaveTextContent('Portal tooltip');
+  });
+
+  it('renders dropdown content into the configured portal container', async () => {
+    const { getByText } = renderCUI(
+      <PortalProvider container={portalRoot}>
+        <Dropdown>
+          <Dropdown.Trigger>Open dropdown</Dropdown.Trigger>
+          <Dropdown.Content>
+            <Dropdown.Item>Portal dropdown</Dropdown.Item>
+          </Dropdown.Content>
+        </Dropdown>
+      </PortalProvider>
+    );
+
+    await userEvent.click(getByText('Open dropdown'));
+
+    expect(within(portalRoot).getByText('Portal dropdown')).not.toBeNull();
+  });
+
+  it('lets an explicit component container override the provider container', () => {
+    const explicitRoot = document.createElement('div');
+    document.body.appendChild(explicitRoot);
+
+    const { getByText } = renderCUI(
+      <PortalProvider container={portalRoot}>
+        <Popover>
+          <Popover.Trigger>Open explicit popover</Popover.Trigger>
+          <Popover.Content container={explicitRoot}>Explicit popover</Popover.Content>
+        </Popover>
+      </PortalProvider>
+    );
+
+    fireEvent.click(getByText('Open explicit popover'));
+
+    expect(within(explicitRoot).getByText('Explicit popover')).not.toBeNull();
+    expect(portalRoot).not.toHaveTextContent('Explicit popover');
+
+    explicitRoot.remove();
+  });
+});

--- a/src/providers/PortalProvider.tsx
+++ b/src/providers/PortalProvider.tsx
@@ -1,0 +1,18 @@
+import { ReactElement, ReactNode } from 'react';
+import { PortalContainerContext, type PortalContainer } from './PortalContext';
+
+export interface PortalProviderProps {
+  children: ReactNode;
+  container?: PortalContainer;
+}
+
+export const PortalProvider = ({
+  children,
+  container = null,
+}: PortalProviderProps): ReactElement => {
+  return (
+    <PortalContainerContext.Provider value={container}>
+      {children}
+    </PortalContainerContext.Provider>
+  );
+};

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -4,4 +4,8 @@
 // theme provider. Consider deprecating one or making ThemeProvider internal only.
 
 export { ClickUIProvider } from './ClickUIProvider';
+export { PortalProvider } from './PortalProvider';
+export { usePortalContainer, useResolvedPortalContainer } from './PortalContext';
+export type { PortalContainer } from './PortalContext';
+export type { PortalProviderProps } from './PortalProvider';
 export { ThemeProvider } from './ThemeProvider';


### PR DESCRIPTION
## Summary

Adds a ClickUI portal provider API for detached panels and other layered surfaces.

- Adds `PortalProvider`, `usePortalContainer`, and `useResolvedPortalContainer`
- Lets overlay components use an explicit provider container while preserving existing per-component `container` overrides
- Wires provider fallback through portal-based components including Select, Popover, Tooltip, Dropdown, AutoComplete, DatePicker, ContextMenu, HoverCard, Dialog, and Flyout
- Adds focused tests for provider placement and explicit container override
- Adds a minor changeset for the new public API

## Context

This supports CUI-179 and avoids product code needing to target Radix internals or inject global z-index CSS for detached panels.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches portal mounting across many overlay components; wrong container choice could affect stacking, focus, or clipping in embedded panels, though behavior is backward-compatible when no provider is used.
> 
> **Overview**
> Introduces **`PortalProvider`** and **`useResolvedPortalContainer`** so layered UI can default to a shared DOM mount point instead of only per-component Radix portals.
> 
> Wrap overlay **Select**, **Popover**, **Tooltip**, **Dropdown**, **AutoComplete**, **DatePicker**, **ContextMenu**, **HoverCard**, **Dialog**, and **Flyout** so their portal `container` comes from the provider when a content prop does not pass `container` explicitly; passing `container` on a component still wins. **Tooltip** gains a `container` prop on content (types moved to `Tooltip.types.ts`). The public package exports **`PortalProvider`**, **`usePortalContainer`**, **`useResolvedPortalContainer`**, and related types, with a minor changeset and integration tests for provider placement and override behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0902a00bfd9201880619d60b344933bd83d9b44e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->