### PR TITLE
feat(datepickers): add optional hasClearButton prop to datepickers

### DIFF
--- a/.changeset/tall-schools-agree.md
+++ b/.changeset/tall-schools-agree.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': minor
+---
+
+Adds the property `hasCloseButton`, which shows a close button on the right side of the input to the date pickers.

--- a/src/components/DatePicker/Common.tsx
+++ b/src/components/DatePicker/Common.tsx
@@ -2,6 +2,7 @@ import { styled } from 'styled-components';
 import { InputElement, InputStartContent, InputWrapper } from '@/components/InputWrapper';
 import {
   KeyboardEvent,
+  MouseEvent,
   ReactNode,
   useCallback,
   useEffect,
@@ -45,9 +46,10 @@ const yearsOffset = Math.floor(totalYears / 2);
 const HighlightedInputWrapper = styled(InputWrapper)<{
   $isActive: boolean;
   $width?: string;
+  $minWidth?: string;
   error?: boolean;
 }>`
-  ${({ $isActive, $width, error, theme }) => {
+  ${({ $isActive, $width, $minWidth, error, theme }) => {
     let borderColor = $isActive
       ? theme.click.datePicker.dateOption.color.stroke.active
       : theme.click.field.color.stroke.default;
@@ -58,21 +60,37 @@ const HighlightedInputWrapper = styled(InputWrapper)<{
 
     return `border: ${theme.click.datePicker.dateOption.stroke} solid ${borderColor};
     width: ${$width ? $width : explicitWidth};
-    ${$width && `min-width: ${explicitWidth};`}
+    ${$minWidth ? `min-width: ${$minWidth};` : ''}
     `;
   }}
 }`;
 
-interface DatePickerInputProps {
-  isActive: boolean;
-  disabled: boolean;
-  id?: string;
-  partialMonth?: number;
-  partialYear?: number;
-  placeholder?: string;
-  selectedDate?: Date;
-  timezone?: Timezone;
-}
+// This span is rendered in the Date*PickerInputs, which are children of a Popover Trigger
+// which are buttons. So using an IconButton will cause React to throw an error since a button can't be inside a button
+const ClearButton = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  cursor: pointer;
+  ${({ theme }) => `
+    padding: ${theme.click.button.iconButton.default.space.y} ${theme.click.button.iconButton.default.space.x};
+    border: 1px solid ${theme.click.button.iconButton.color.primary.stroke.default};
+    border-radius: ${theme.click.button.iconButton.radii.all};
+    color: ${theme.click.button.iconButton.color.primary.text.default};
+    background-color: ${theme.click.button.iconButton.color.primary.background.default};
+
+    &:hover {
+      border-color: ${theme.click.button.iconButton.color.primary.stroke.hover};
+      background-color: ${theme.click.button.iconButton.color.primary.background.hover};
+    }
+
+    &:active {
+      border-color: ${theme.click.button.iconButton.color.primary.stroke.active};
+      background-color: ${theme.click.button.iconButton.color.primary.background.active};
+    }
+  `}
+`;
 
 const formatPartialDate = (
   timezone: Timezone,
@@ -99,10 +117,25 @@ const formatPartialDate = (
   return '';
 };
 
+interface DatePickerInputProps {
+  isActive: boolean;
+  disabled: boolean;
+  hasClearButton?: boolean;
+  id?: string;
+  onClear?: () => void;
+  partialMonth?: number;
+  partialYear?: number;
+  placeholder?: string;
+  selectedDate?: Date;
+  timezone?: Timezone;
+}
+
 export const DatePickerInput = ({
   isActive,
   disabled,
+  hasClearButton,
   id,
+  onClear,
   partialMonth,
   partialYear,
   placeholder,
@@ -115,6 +148,17 @@ export const DatePickerInput = ({
     selectedDate,
     partialYear,
     partialMonth
+  );
+
+  // Stop propagation to keep the event from bubbling up to the dropdown trigger and opening the dropdown
+  const handleClear = useCallback(
+    (event: MouseEvent<HTMLSpanElement>) => {
+      event.stopPropagation();
+      if (onClear) {
+        onClear();
+      }
+    },
+    [onClear]
   );
 
   return (
@@ -133,6 +177,19 @@ export const DatePickerInput = ({
         readOnly
         value={formattedSelectedDate}
       />
+      {hasClearButton && !disabled && (
+        <ClearButton
+          role="button"
+          aria-label="clear input"
+          data-testid="datepicker-input-clear"
+          onClick={handleClear}
+        >
+          <Icon
+            name="cross"
+            size="sm"
+          />
+        </ClearButton>
+      )}
     </HighlightedInputWrapper>
   );
 };
@@ -140,7 +197,9 @@ export const DatePickerInput = ({
 interface DateRangePickerInputProps {
   isActive: boolean;
   disabled: boolean;
+  hasClearButton?: boolean;
   id?: string;
+  onClear?: () => void;
   placeholder?: string;
   selectedEndDate?: Date;
   selectedStartDate?: Date;
@@ -150,13 +209,32 @@ interface DateRangePickerInputProps {
 export const DateRangePickerInput = ({
   isActive,
   disabled,
+  hasClearButton,
   id,
+  onClear,
   placeholder,
   selectedEndDate,
   selectedStartDate,
   timezone = 'system',
 }: DateRangePickerInputProps) => {
   const defaultId = useId();
+
+  // Stop propagation to keep the event from bubbling up to the dropdown trigger and opening the dropdown
+  const handleClear = useCallback(
+    (event: MouseEvent<HTMLSpanElement>) => {
+      event.stopPropagation();
+      if (onClear) {
+        onClear();
+      }
+    },
+    [onClear]
+  );
+
+  // The Dropdown.Trigger wrapping this input toggles on pointerdown, so stop
+  // pointerdown (and click) from bubbling up to it when clearing.
+  const handleClearPointerDown = useCallback((event: MouseEvent<HTMLSpanElement>) => {
+    event.stopPropagation();
+  }, []);
 
   let formattedValue = (
     <Text
@@ -192,6 +270,7 @@ export const DateRangePickerInput = ({
   return (
     <HighlightedInputWrapper
       $isActive={isActive}
+      $width={hasClearButton ? 'max-content' : undefined}
       disabled={disabled}
       id={id ?? defaultId}
     >
@@ -205,6 +284,20 @@ export const DateRangePickerInput = ({
       >
         {formattedValue}
       </InputElement>
+      {hasClearButton && !disabled && (
+        <ClearButton
+          role="button"
+          aria-label="clear input"
+          data-testid="daterangepicker-input-clear"
+          onPointerDown={handleClearPointerDown}
+          onClick={handleClear}
+        >
+          <Icon
+            name="cross"
+            size="sm"
+          />
+        </ClearButton>
+      )}
     </HighlightedInputWrapper>
   );
 };
@@ -212,7 +305,9 @@ export const DateRangePickerInput = ({
 interface DateTimeRangePickerInputProps {
   isActive: boolean;
   disabled: boolean;
+  hasClearButton?: boolean;
   id?: string;
+  onClear?: () => void;
   placeholder?: string;
   selectedEndDate?: Date;
   selectedStartDate?: Date;
@@ -223,7 +318,9 @@ interface DateTimeRangePickerInputProps {
 export const DateTimeRangePickerInput = ({
   isActive,
   disabled,
+  hasClearButton,
   id,
+  onClear,
   placeholder,
   selectedEndDate,
   selectedStartDate,
@@ -231,6 +328,23 @@ export const DateTimeRangePickerInput = ({
   timezone = 'system',
 }: DateTimeRangePickerInputProps) => {
   const defaultId = useId();
+
+  // Stop propagation to keep the event from bubbling up to the dropdown trigger and opening the dropdown
+  const handleClear = useCallback(
+    (event: MouseEvent<HTMLSpanElement>) => {
+      event.stopPropagation();
+      if (onClear) {
+        onClear();
+      }
+    },
+    [onClear]
+  );
+
+  // The Dropdown.Trigger wrapping this input toggles on pointerdown, so stop
+  // pointerdown (and click) from bubbling up to it when clearing.
+  const handleClearPointerDown = useCallback((event: MouseEvent<HTMLSpanElement>) => {
+    event.stopPropagation();
+  }, []);
 
   const formatDateTime = useCallback(
     (date: Date) => {
@@ -299,6 +413,7 @@ export const DateTimeRangePickerInput = ({
     <HighlightedInputWrapper
       $isActive={isActive}
       $width="max-content"
+      $minWidth={explicitWidth}
       disabled={disabled}
       error={startDateIsAfterEndDate}
       id={id ?? defaultId}
@@ -313,6 +428,20 @@ export const DateTimeRangePickerInput = ({
       >
         {formattedValue}
       </InputElement>
+      {hasClearButton && !disabled && (
+        <ClearButton
+          role="button"
+          aria-label="clear input"
+          data-testid="datetimepicker-input-clear"
+          onPointerDown={handleClearPointerDown}
+          onClick={handleClear}
+        >
+          <Icon
+            name="cross"
+            size="sm"
+          />
+        </ClearButton>
+      )}
     </HighlightedInputWrapper>
   );
 };

--- a/src/components/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DatePicker/DatePicker.stories.tsx
@@ -101,3 +101,19 @@ export const TimezoneLocalVsUTC = {
     );
   },
 };
+
+export const HasClearButton = {
+  ...defaultStory,
+  render: (args: Args) => {
+    const date = args.date ? new Date(args.date) : new Date('2026-04-15');
+    return (
+      <DatePicker
+        date={date}
+        hasClearButton
+        onSelectDate={args.onSelectDate}
+        placeholder={args.placeholder}
+        responsivePositioning={false}
+      />
+    );
+  },
+};

--- a/src/components/DatePicker/DatePicker.test.tsx
+++ b/src/components/DatePicker/DatePicker.test.tsx
@@ -623,4 +623,67 @@ describe('DatePicker', () => {
       });
     });
   });
+
+  describe('clearing the selected date', () => {
+    it('hides the clear control until it is explicitly enabled', () => {
+      const { queryByTestId } = renderCUI(<DatePicker onSelectDate={vi.fn()} />);
+
+      expect(queryByTestId('datepicker-input-clear')).not.toBeInTheDocument();
+    });
+
+    it('offers a clear control when enabled', () => {
+      const { getByTestId } = renderCUI(
+        <DatePicker
+          hasClearButton
+          onSelectDate={vi.fn()}
+        />
+      );
+
+      expect(getByTestId('datepicker-input-clear')).toBeInTheDocument();
+    });
+
+    it('withholds the clear control while the picker is disabled', () => {
+      const { queryByTestId } = renderCUI(
+        <DatePicker
+          disabled
+          hasClearButton
+          onSelectDate={vi.fn()}
+        />
+      );
+
+      expect(queryByTestId('datepicker-input-clear')).not.toBeInTheDocument();
+    });
+
+    describe('when the clear control is clicked', () => {
+      it('removes the currently selected date', async () => {
+        const { getByTestId } = renderCUI(
+          <DatePicker
+            hasClearButton
+            date={new Date('07-04-2020')}
+            onSelectDate={vi.fn()}
+          />
+        );
+
+        expect(getByTestId('datepicker-input')).toHaveValue('Jul 04, 2020');
+
+        await userEvent.click(getByTestId('datepicker-input-clear'));
+
+        expect(getByTestId('datepicker-input')).toHaveValue('');
+      });
+
+      it('leaves the calendar closed', async () => {
+        const { getByTestId, queryByTestId } = renderCUI(
+          <DatePicker
+            hasClearButton
+            date={new Date('07-04-2020')}
+            onSelectDate={vi.fn()}
+          />
+        );
+
+        await userEvent.click(getByTestId('datepicker-input-clear'));
+
+        expect(queryByTestId('datepicker-calendar-container')).not.toBeInTheDocument();
+      });
+    });
+  });
 });

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -202,6 +202,7 @@ export interface DatePickerProps {
   date?: Date;
   disabled?: boolean;
   futureDatesDisabled?: boolean;
+  hasClearButton?: boolean;
   onSelectDate: (selectedDate: Date) => void;
   placeholder?: string;
   responsivePositioning?: boolean;
@@ -213,6 +214,7 @@ export const DatePicker = ({
   date,
   disabled = false,
   futureDatesDisabled = false,
+  hasClearButton = false,
   onSelectDate,
   placeholder,
   responsivePositioning = true,
@@ -266,23 +268,28 @@ export const DatePicker = ({
     [onSelectDate, resetPartialState]
   );
 
-  const onYearSelect = useCallback((year: number) => {
+  const handleYearSelect = useCallback((year: number) => {
     setPartialYear(year);
     setPartialMonth(undefined);
   }, []);
 
-  const onMonthSelect = useCallback((year: number, month: number) => {
+  const handleMonthSelect = useCallback((year: number, month: number) => {
     setPartialYear(year);
     setPartialMonth(month);
   }, []);
 
-  const onTriggerKeyDown = useCallback((e: KeyboardEvent<HTMLButtonElement>) => {
+  const handleTriggerKeyDown = useCallback((e: KeyboardEvent<HTMLButtonElement>) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
       setIsOpen(true);
       setAutoFocusCalendar(true);
     }
   }, []);
+
+  const handleClear = useCallback(() => {
+    resetPartialState();
+    setSelectedDate(undefined);
+  }, [resetPartialState]);
 
   return (
     <Popover.Root
@@ -291,14 +298,16 @@ export const DatePicker = ({
     >
       <PopoverTrigger
         disabled={disabled}
-        onKeyDown={onTriggerKeyDown}
+        onKeyDown={handleTriggerKeyDown}
       >
         <DatePickerInput
           data-testid="datepicker-input-container"
           disabled={disabled}
           isActive={isOpen}
+          hasClearButton={hasClearButton}
           partialMonth={partialMonth}
           partialYear={partialYear}
+          onClear={handleClear}
           placeholder={placeholder}
           selectedDate={selectedDate}
           timezone={timezone}
@@ -312,8 +321,8 @@ export const DatePicker = ({
         >
           <CalendarRenderer
             calendarOptions={calendarOptions}
-            onYearSelect={onYearSelect}
-            onMonthSelect={onMonthSelect}
+            onYearSelect={handleYearSelect}
+            onMonthSelect={handleMonthSelect}
             selectedDate={selectedDate}
             timezone={timezone}
           >

--- a/src/components/DatePicker/DateRangePicker.stories.tsx
+++ b/src/components/DatePicker/DateRangePicker.stories.tsx
@@ -106,6 +106,31 @@ export const DateRangeFutureStartDatesDisabled: Story = {
   },
 };
 
+export const HasClearButton: Story = {
+  args: {
+    predefinedDatesList: [],
+  },
+  render: (args: Args) => {
+    const endDate = args.endDate ? new Date(args.endDate) : new Date('2026-04-30');
+    const startDate = args.startDate ? new Date(args.startDate) : new Date('2026-04-15');
+
+    return (
+      <DateRangePicker
+        key="default"
+        endDate={endDate}
+        disabled={args.disabled}
+        futureDatesDisabled={args.futureDatesDisabled}
+        futureStartDatesDisabled={args.futureStartDatesDisabled}
+        hasClearButton
+        maxRangeLength={args.maxRangeLength}
+        onSelectDateRange={args.onSelectDateRange}
+        placeholder={args.placeholder}
+        startDate={startDate}
+      />
+    );
+  },
+};
+
 export const PredefinedDatesLastSixMonths: Story = {
   render: (args: Args) => {
     const endDate = args.endDate ? new Date(args.endDate) : undefined;

--- a/src/components/DatePicker/DateRangePicker.test.tsx
+++ b/src/components/DatePicker/DateRangePicker.test.tsx
@@ -485,4 +485,73 @@ describe('DateRangePicker', () => {
       expect(emittedEnd.toISOString()).toBe('2026-04-22T00:00:00.000Z');
     });
   });
+
+  describe('clearing the selected date range', () => {
+    it('hides the clear control until it is explicitly enabled', () => {
+      const { queryByTestId } = renderCUI(
+        <DateRangePicker onSelectDateRange={vi.fn()} />
+      );
+
+      expect(queryByTestId('daterangepicker-input-clear')).not.toBeInTheDocument();
+    });
+
+    it('offers a clear control when enabled', () => {
+      const { getByTestId } = renderCUI(
+        <DateRangePicker
+          hasClearButton
+          onSelectDateRange={vi.fn()}
+        />
+      );
+
+      expect(getByTestId('daterangepicker-input-clear')).toBeInTheDocument();
+    });
+
+    it('withholds the clear control while the picker is disabled', () => {
+      const { queryByTestId } = renderCUI(
+        <DateRangePicker
+          disabled
+          hasClearButton
+          onSelectDateRange={vi.fn()}
+        />
+      );
+
+      expect(queryByTestId('daterangepicker-input-clear')).not.toBeInTheDocument();
+    });
+
+    describe('when the clear control is clicked', () => {
+      it('removes both the start and end dates', async () => {
+        const startDate = new Date('07-04-2020');
+        const endDate = new Date('07-05-2020');
+        const { getByTestId, getByText, queryByText } = renderCUI(
+          <DateRangePicker
+            hasClearButton
+            startDate={startDate}
+            endDate={endDate}
+            onSelectDateRange={vi.fn()}
+          />
+        );
+
+        expect(getByText('Jul 04, 2020 – Jul 05, 2020')).toBeInTheDocument();
+
+        await userEvent.click(getByTestId('daterangepicker-input-clear'));
+
+        expect(queryByText('Jul 04, 2020 – Jul 05, 2020')).not.toBeInTheDocument();
+        expect(getByText('start date – end date')).toBeInTheDocument();
+      });
+
+      it('leaves the calendar closed', async () => {
+        const { getByTestId, queryByTestId } = renderCUI(
+          <DateRangePicker
+            hasClearButton
+            startDate={new Date('07-04-2020')}
+            onSelectDateRange={vi.fn()}
+          />
+        );
+
+        await userEvent.click(getByTestId('daterangepicker-input-clear'));
+
+        expect(queryByTestId('datepicker-calendar-container')).not.toBeInTheDocument();
+      });
+    });
+  });
 });

--- a/src/components/DatePicker/DateRangePicker.tsx
+++ b/src/components/DatePicker/DateRangePicker.tsx
@@ -296,6 +296,7 @@ export interface DateRangePickerProps {
   disabled?: boolean;
   futureDatesDisabled?: boolean;
   futureStartDatesDisabled?: boolean;
+  hasClearButton?: boolean;
   onSelectDateRange: (selectedStartDate: Date, selectedEndDate: Date) => void;
   openDirection?: OpenDirection;
   placeholder?: string;
@@ -312,6 +313,7 @@ export const DateRangePicker = ({
   disabled = false,
   futureDatesDisabled = false,
   futureStartDatesDisabled = false,
+  hasClearButton = false,
   maxRangeLength = -1,
   onSelectDateRange,
   openDirection = 'right',
@@ -362,6 +364,11 @@ export const DateRangePicker = ({
     setShouldShowCustomRange(false);
     setCalendarOpenDirection(openDirection);
   }, [openDirection]);
+
+  const handleClear = useCallback((): void => {
+    setSelectedStartDate(undefined);
+    setSelectedEndDate(undefined);
+  }, []);
 
   const handleOpenChange = (isOpen: boolean): void => {
     setIsOpen(isOpen);
@@ -436,7 +443,9 @@ export const DateRangePicker = ({
         <DateRangePickerInput
           data-testid="datepicker-input-container"
           disabled={disabled}
+          hasClearButton={hasClearButton}
           isActive={isOpen}
+          onClear={handleClear}
           placeholder={placeholder}
           selectedEndDate={selectedEndDate}
           selectedStartDate={selectedStartDate}

--- a/src/components/DatePicker/DateTimeRangePicker.stories.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.stories.tsx
@@ -51,6 +51,32 @@ export const Default: Story = {
   },
 };
 
+export const HasClearButton: Story = {
+  args: {
+    predefinedTimesList: [],
+  },
+  render: (args: Args) => {
+    const endDate = args.endDate ? new Date(args.endDate) : new Date('2026-04-30');
+    const startDate = args.startDate ? new Date(args.startDate) : new Date('2026-04-15');
+
+    return (
+      <DateTimeRangePicker
+        key="default"
+        endDate={endDate}
+        disabled={args.disabled}
+        futureDatesDisabled={args.futureDatesDisabled}
+        futureStartDatesDisabled={args.futureStartDatesDisabled}
+        hasClearButton
+        maxRangeLength={args.maxRangeLength}
+        onSelectDateRange={args.onSelectDateRange}
+        placeholder={args.placeholder}
+        startDate={startDate}
+        shouldShowSeconds={args.shouldShowSeconds}
+      />
+    );
+  },
+};
+
 export const DateTimeRangePickerLeftSide: Story = {
   render: (args: Args) => {
     const endDate = args.endDate ? new Date(args.endDate) : undefined;

--- a/src/components/DatePicker/DateTimeRangePicker.test.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.test.tsx
@@ -1215,4 +1215,76 @@ describe('DateTimeRangePicker', () => {
       expect((timeInputs[0] as HTMLInputElement).value).toBe('08:00');
     });
   });
+
+  describe('clearing the selected date range', () => {
+    it('hides the clear control until it is explicitly enabled', () => {
+      const { queryByTestId } = renderCUI(
+        <DateTimeRangePicker onSelectDateRange={vi.fn()} />
+      );
+
+      expect(queryByTestId('datetimepicker-input-clear')).not.toBeInTheDocument();
+    });
+
+    it('offers a clear control when enabled', () => {
+      const { getByTestId } = renderCUI(
+        <DateTimeRangePicker
+          hasClearButton
+          onSelectDateRange={vi.fn()}
+        />
+      );
+
+      expect(getByTestId('datetimepicker-input-clear')).toBeInTheDocument();
+    });
+
+    it('withholds the clear control while the picker is disabled', () => {
+      const { queryByTestId } = renderCUI(
+        <DateTimeRangePicker
+          disabled
+          hasClearButton
+          onSelectDateRange={vi.fn()}
+        />
+      );
+
+      expect(queryByTestId('datetimepicker-input-clear')).not.toBeInTheDocument();
+    });
+
+    describe('when the clear control is clicked', () => {
+      it('removes both the start and end dates', async () => {
+        const startDate = new Date('07-04-2020');
+        const endDate = new Date('07-05-2020');
+        const { getByTestId } = renderCUI(
+          <DateTimeRangePicker
+            hasClearButton
+            startDate={startDate}
+            endDate={endDate}
+            onSelectDateRange={vi.fn()}
+          />
+        );
+
+        expect(getByTestId('datetimepicker-input').textContent).toBe(
+          'Jul 04, 12:00 pm – Jul 05, 12:00 pm'
+        );
+
+        await userEvent.click(getByTestId('datetimepicker-input-clear'));
+
+        expect(getByTestId('datetimepicker-input').textContent).toBe(
+          'start date – end date'
+        );
+      });
+
+      it('leaves the calendar closed', async () => {
+        const { getByTestId, queryByTestId } = renderCUI(
+          <DateTimeRangePicker
+            hasClearButton
+            startDate={new Date('07-04-2020')}
+            onSelectDateRange={vi.fn()}
+          />
+        );
+
+        await userEvent.click(getByTestId('datetimepicker-input-clear'));
+
+        expect(queryByTestId('datepicker-calendar-container')).not.toBeInTheDocument();
+      });
+    });
+  });
 });

--- a/src/components/DatePicker/DateTimeRangePicker.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.tsx
@@ -773,6 +773,7 @@ export interface DateTimeRangePickerProps {
   endDate?: Date;
   futureDatesDisabled?: boolean;
   futureStartDatesDisabled?: boolean;
+  hasClearButton?: boolean;
   onSelectDateRange: (
     startDate: Date,
     endDate: Date,
@@ -796,6 +797,7 @@ export const DateTimeRangePicker = ({
   endDate,
   futureDatesDisabled = false,
   futureStartDatesDisabled = false,
+  hasClearButton = false,
   maxRangeLength = -1,
   onSelectDateRange,
   openDirection = 'right',
@@ -869,6 +871,11 @@ export const DateTimeRangePicker = ({
     setIsOpen(false);
     setShouldShowCustomRange(false);
     setCalendarOpenDirection('right');
+  }, []);
+
+  const handleClear = useCallback((): void => {
+    setSelectedStartDate(undefined);
+    setSelectedEndDate(undefined);
   }, []);
 
   const handleOpenChange = useCallback((isOpen: boolean): void => {
@@ -972,7 +979,9 @@ export const DateTimeRangePicker = ({
         <DateTimeRangePickerInput
           data-testid="datepicker-input-container"
           disabled={disabled}
+          hasClearButton={hasClearButton}
           isActive={isOpen}
+          onClear={handleClear}
           placeholder={placeholder}
           selectedEndDate={selectedEndDate}
           selectedStartDate={selectedStartDate}


### PR DESCRIPTION
- Adds clear buttons to the three date pickers, which clears out the dates when clicked

<img width="284" height="76" alt="Screenshot 2026-06-18 at 4 21 15 PM" src="https://github.com/user-attachments/assets/0629e774-ead7-4f4c-b5bc-7b65e155cfdf" />
<br />
<img width="320" height="65" alt="Screenshot 2026-06-18 at 4 21 24 PM" src="https://github.com/user-attachments/assets/4f3b2892-4232-4c0c-a4d1-09b658f48976" />
<br />
<img width="364" height="59" alt="Screenshot 2026-06-18 at 4 21 33 PM" src="https://github.com/user-attachments/assets/55dcc8ce-1e3f-4e43-a694-620d5d2e6acf" />

https://github.com/user-attachments/assets/f7b39586-27ff-4ecb-a12c-7fe7daa02c20



Closes https://linear.app/clickhouse/issue/CUI-178/datepickers-add-a-prop-controlled-clear-button

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in UI with local state only; main integration caveat is that clear does not invoke `onSelectDate` / `onSelectDateRange`, so parents must handle empty state themselves if needed.
> 
> **Overview**
> Adds an opt-in **`hasClearButton`** prop on **DatePicker**, **DateRangePicker**, and **DateTimeRangePicker** that shows a cross control on the right of the trigger input. Clearing resets internal selection (and partial year/month on the single date picker) without opening the popover/dropdown; range pickers also stop **`pointerdown`** on the clear control so the dropdown trigger does not toggle.
> 
> Shared input UI in **`Common.tsx`** introduces a styled **`ClearButton`** (`span` with `role="button"`, not **`IconButton`**) to avoid invalid button-in-button nesting inside popover/dropdown triggers. Layout tweaks include optional **`$minWidth`** on the highlighted wrapper and **`max-content`** width when the clear control is shown on range inputs.
> 
> Stories, tests, and a minor changeset are included. Note: the changeset text refers to **`hasCloseButton`**, while the public API is **`hasClearButton`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 383bd875766c0778cda49427c046be5ab5a3e840. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->