### PR TITLE
fix(Toast): clear auto-close timer on unmount (jsdom teardown crash)

### DIFF
--- a/src/components/Toast/Toast.test.tsx
+++ b/src/components/Toast/Toast.test.tsx
@@ -66,6 +66,49 @@ describe('Toast', () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
+  it('does not reset the auto-close timer when the parent re-renders with a new onClose identity', () => {
+    // Regression for: in ToastProvider, `onClose={onClose(id)}` produces a
+    // fresh function on every provider render. Without a stable callback ref
+    // inside Toast, every provider update (e.g. another toast appearing)
+    // would restart the countdown from the full duration, so a toast could
+    // be kept alive indefinitely by a frequently-rerendering parent.
+    const onClose1 = vi.fn();
+    const onClose2 = vi.fn();
+    const { rerender } = renderCUI(
+      <Toast
+        title="hello"
+        duration={1000}
+        onClose={onClose1}
+      />
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(onClose1).not.toHaveBeenCalled();
+
+    rerender(
+      <Toast
+        title="hello"
+        duration={1000}
+        onClose={onClose2}
+      />
+    );
+
+    // Total elapsed since mount = 1100ms > original duration of 1000ms.
+    // If the timer was reset on re-render, no onClose would have fired yet
+    // (only 500ms of a fresh 1000ms countdown would have elapsed).
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    // The latest onClose must have been invoked exactly once.
+    expect(onClose2).toHaveBeenCalledTimes(1);
+    expect(onClose2).toHaveBeenCalledWith(false);
+    // And the original onClose -- which is no longer the prop -- must not
+    // have been invoked.
+    expect(onClose1).not.toHaveBeenCalled();
+  });
+
   it('does not auto-close when duration is Infinity', () => {
     const onClose = vi.fn();
     renderCUI(

--- a/src/components/Toast/Toast.test.tsx
+++ b/src/components/Toast/Toast.test.tsx
@@ -1,6 +1,28 @@
-import { act } from '@testing-library/react';
+import { useEffect } from 'react';
+import { act, render } from '@testing-library/react';
+import { useToast } from '@/hooks/useToast';
+import { ClickUIProvider } from '@/providers';
 import { renderCUI } from '@/utils/test-utils';
 import { Toast } from '@/components/Toast';
+import type { ToastProviderProps } from '@/components/Toast';
+
+// `ClickUIProvider` already nests `ToastProvider` and forwards `config.toast`,
+// so we render directly into that to exercise the full
+// `ToastProvider` -> `Toast` integration path (including provider-level
+// defaults like `duration`).
+const renderInToastProvider = (
+  ui: React.ReactNode,
+  providerProps: Omit<ToastProviderProps, 'children'> = {}
+) =>
+  render(
+    <ClickUIProvider
+      theme="dark"
+      config={{ toast: providerProps, tooltip: { delayDuration: 0 } }}
+      persistTheme={false}
+    >
+      {ui}
+    </ClickUIProvider>
+  );
 
 describe('Toast', () => {
   beforeEach(() => {
@@ -32,7 +54,7 @@ describe('Toast', () => {
     expect(onClose).toHaveBeenCalledWith(false);
   });
 
-  it('clears the auto-close timer when the toast unmounts (regression for radix-ui/primitives#3703)', () => {
+  it('does not leak the auto-close timer past unmount (regression for radix-ui/primitives#3703)', () => {
     const onClose = vi.fn();
     const { unmount } = renderCUI(
       <Toast
@@ -49,20 +71,38 @@ describe('Toast', () => {
 
     unmount();
 
-    // No pending timers must remain after unmount. Radix v1.2.2 leaks its
-    // internal `closeTimerRef` (the auto-close `setTimeout`) here because it
-    // never `clearTimeout`s it on unmount. The leftover timer later fires
-    // after vitest tears down jsdom and calls `handleClose`, which accesses
-    // `document.activeElement` -- producing
-    // `ReferenceError: document is not defined` and aborting the whole test
-    // file. We side-step this by passing `duration={Infinity}` to Radix and
-    // owning the timer in click-ui itself with a cleanup effect.
-    expect(vi.getTimerCount()).toBe(0);
-
-    // And nothing left behind should be able to invoke our `onClose` later.
-    act(() => {
-      vi.advanceTimersByTime(60_000);
+    // Simulate the post-unmount + post-jsdom-teardown environment: any
+    // subsequent access to `document.activeElement` would normally throw
+    // `ReferenceError: document is not defined`. Here we stub the getter so
+    // that an access flips a boolean we can assert against. If Radix's
+    // internal close timer leaks past unmount (radix-ui/primitives#3703,
+    // still present in 1.2.17), `handleClose` will fire after unmount and
+    // dereference `document.activeElement`, tripping the stub. With this
+    // PR's fix, we own the timer ourselves and clear it from the unmount
+    // cleanup, so no Radix `handleClose` ever runs post-unmount.
+    const originalDescriptor = Object.getOwnPropertyDescriptor(
+      Document.prototype,
+      'activeElement'
+    );
+    if (!originalDescriptor) {
+      throw new Error('Expected Document.prototype.activeElement descriptor');
+    }
+    let leakedDocumentAccess = false;
+    Object.defineProperty(Document.prototype, 'activeElement', {
+      configurable: true,
+      get: () => {
+        leakedDocumentAccess = true;
+        return null;
+      },
     });
+    try {
+      act(() => {
+        vi.advanceTimersByTime(60_000);
+      });
+    } finally {
+      Object.defineProperty(Document.prototype, 'activeElement', originalDescriptor);
+    }
+    expect(leakedDocumentAccess).toBe(false);
     expect(onClose).not.toHaveBeenCalled();
   });
 
@@ -123,5 +163,88 @@ describe('Toast', () => {
       vi.advanceTimersByTime(60_000);
     });
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the provider-level duration when a toast does not set its own', () => {
+    // Regression: before this PR, an unset `ToastProps.duration` let Radix's
+    // `ToastProvider duration` (the default for every toast) take effect.
+    // After moving the timer into click-ui's wrapper, we must keep the same
+    // resolution order: prop > provider > built-in default.
+    const onCreated = vi.fn();
+    const TriggerWithSpy = () => {
+      const { createToast } = useToast();
+      useEffect(() => {
+        createToast({ title: 'hello' });
+        onCreated();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+      }, []);
+      return null;
+    };
+
+    renderInToastProvider(<TriggerWithSpy />, { duration: 2000 });
+    expect(onCreated).toHaveBeenCalledTimes(1);
+
+    // The toast was created with no explicit `duration`, so it should pick
+    // up the provider's 2000 ms and not the built-in 5000 ms default.
+    act(() => {
+      vi.advanceTimersByTime(1999);
+    });
+    // The DOM should still have the toast.
+    expect(document.querySelector('[role="status"]')).not.toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(2);
+    });
+    // After 2001 ms total the provider-level deadline has elapsed and the
+    // toast should have been removed from the provider's state, which
+    // unmounts it from the DOM.
+    expect(document.querySelector('[role="status"]')).toBeNull();
+  });
+
+  it('closes immediately on resume when the auto-close deadline elapsed during a pause', () => {
+    // Regression for: if `handlePause` runs after the auto-close deadline
+    // has already passed (event-loop delay / throttling beat Radix's
+    // close-timer to the punch), remaining time clamps to 0 and a naive
+    // `handleResume` -> `startCloseTimer(0)` would short-circuit, leaving
+    // the toast open forever.
+    const onClose = vi.fn();
+    // Use renderCUI so we get a real `Viewport` (which is what Radix's
+    // window-blur listener dispatches `toast.viewportPause` against).
+    renderCUI(
+      <Toast
+        title="hello"
+        duration={100}
+        onClose={onClose}
+      />
+    );
+
+    // Advance the wall clock past the deadline WITHOUT draining the fake
+    // timer queue, so the close-timer hasn't run yet but `Date.now()`
+    // reports an elapsed time greater than `duration`.
+    act(() => {
+      vi.setSystemTime(Date.now() + 500);
+    });
+    expect(onClose).not.toHaveBeenCalled();
+
+    // Simulate Radix's viewport-level pause/resume. Radix's outer
+    // `<div role="region">` wraps the actual viewport `<ol>`; the
+    // `VIEWPORT_PAUSE`/`VIEWPORT_RESUME` custom events are dispatched on the
+    // inner `<ol>` (that's what `ToastImpl` listens on), not the wrapper.
+    const viewport = document.querySelector('[role="region"] > ol');
+    if (!viewport) {
+      throw new Error('Expected Radix Toast viewport <ol> to be in the DOM');
+    }
+    act(() => {
+      viewport.dispatchEvent(new CustomEvent('toast.viewportPause'));
+    });
+    // Pause cleared the timer, but the deadline already elapsed -> remaining = 0.
+    act(() => {
+      viewport.dispatchEvent(new CustomEvent('toast.viewportResume'));
+    });
+
+    // Without the fix, onClose would never be invoked. With the fix, resume
+    // detects `remaining <= 0` after a real pause and closes immediately.
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledWith(false);
   });
 });

--- a/src/components/Toast/Toast.test.tsx
+++ b/src/components/Toast/Toast.test.tsx
@@ -1,0 +1,84 @@
+import { act } from '@testing-library/react';
+import { renderCUI } from '@/utils/test-utils';
+import { Toast } from '@/components/Toast';
+
+describe('Toast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({
+      // Don't fake `setImmediate` / `queueMicrotask`, otherwise React's
+      // scheduler / styled-components batching can hang.
+      toFake: ['setTimeout', 'clearTimeout', 'Date'],
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('auto-closes after the configured duration', () => {
+    const onClose = vi.fn();
+    renderCUI(
+      <Toast
+        title="hello"
+        duration={3000}
+        onClose={onClose}
+      />
+    );
+
+    expect(onClose).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(onClose).toHaveBeenCalledWith(false);
+  });
+
+  it('clears the auto-close timer when the toast unmounts (regression for radix-ui/primitives#3703)', () => {
+    const onClose = vi.fn();
+    const { unmount } = renderCUI(
+      <Toast
+        title="hello"
+        duration={5000}
+        onClose={onClose}
+      />
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(onClose).not.toHaveBeenCalled();
+
+    unmount();
+
+    // No pending timers must remain after unmount. Radix v1.2.2 leaks its
+    // internal `closeTimerRef` (the auto-close `setTimeout`) here because it
+    // never `clearTimeout`s it on unmount. The leftover timer later fires
+    // after vitest tears down jsdom and calls `handleClose`, which accesses
+    // `document.activeElement` -- producing
+    // `ReferenceError: document is not defined` and aborting the whole test
+    // file. We side-step this by passing `duration={Infinity}` to Radix and
+    // owning the timer in click-ui itself with a cleanup effect.
+    expect(vi.getTimerCount()).toBe(0);
+
+    // And nothing left behind should be able to invoke our `onClose` later.
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-close when duration is Infinity', () => {
+    const onClose = vi.fn();
+    renderCUI(
+      <Toast
+        title="hello"
+        duration={Infinity}
+        onClose={onClose}
+      />
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -144,14 +144,27 @@ export const Toast = ({
 
   // We manage the auto-close timer ourselves (and pass `duration={Infinity}` to
   // Radix below) so that the timer is always cleared on unmount. The Radix
-  // implementation (v1.2.2) never clears its internal `closeTimerRef`, which
-  // causes the timer to fire after the host (e.g. jsdom in tests) has been
-  // torn down, surfacing as `ReferenceError: document is not defined`. See
+  // implementation (v1.2.2, still the case on 1.2.17) never clears its
+  // internal `closeTimerRef`, which causes the timer to fire after the host
+  // (e.g. jsdom in tests) has been torn down, surfacing as
+  // `ReferenceError: document is not defined`. See
   // https://github.com/radix-ui/primitives/pull/3794. Once that upstream fix
   // ships and we adopt it we can revert this in favour of Radix's own timer.
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const closeTimerStartTimeRef = useRef<number>(0);
   const closeTimerRemainingTimeRef = useRef<number>(duration);
+
+  // Stable ref to the latest `onClose` so that `startCloseTimer` does not
+  // depend on `onClose`'s identity. Without this, the auto-close `useEffect`
+  // below would re-run (and the countdown would restart from the full
+  // duration) every time the parent passes a fresh function -- which
+  // `ToastProvider` does on every render because it uses `onClose={onClose(id)}`
+  // (a new closure per render). That would let a frequently-rerendering parent
+  // keep a toast alive indefinitely and would also discard pause progress.
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  });
 
   const clearCloseTimer = useCallback(() => {
     if (closeTimerRef.current !== undefined) {
@@ -169,10 +182,10 @@ export const Toast = ({
       closeTimerStartTimeRef.current = Date.now();
       closeTimerRef.current = setTimeout(() => {
         closeTimerRef.current = undefined;
-        onClose(false);
+        onCloseRef.current(false);
       }, remaining);
     },
-    [clearCloseTimer, onClose]
+    [clearCloseTimer]
   );
 
   useEffect(() => {

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,4 +1,11 @@
-import { createContext, useCallback, useEffect, useRef, useState } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import * as RadixUIToast from '@radix-ui/react-toast';
 import { keyframes, styled } from 'styled-components';
 import { toastsEventEmitter } from './toastEmitter';
@@ -14,6 +21,13 @@ const DEFAULT_TOAST_DURATION = 5000;
 export const ToastContext = createContext<ToastContextProps>({
   createToast: () => null,
 });
+
+// Provider-level default duration. Mirrors Radix's `ToastProvider duration`
+// prop semantics so that consumers can do `<ToastProvider duration={...}>`
+// (or `<ClickUIProvider config={{ toast: { duration } }}>`) to set the
+// fallback for every toast that doesn't explicitly set its own `duration`.
+// Defaults to `DEFAULT_TOAST_DURATION`.
+const ToastDurationContext = createContext<number>(DEFAULT_TOAST_DURATION);
 
 // Lazy wrapper to avoid circular dependency issues at module load time
 const ToastIconWrapper = (props: IconProps & { $type?: ToastType }) => (
@@ -128,11 +142,18 @@ export const Toast = ({
   title,
   description,
   actions = [],
-  duration = DEFAULT_TOAST_DURATION,
+  duration: durationProp,
   onClose,
 
   ...props
 }: ToastProps & { onClose: (open: boolean) => void }) => {
+  // Resolve the effective duration: explicit prop wins, then the provider-level
+  // duration from `ToastDurationContext` (`<ToastProvider duration={...}>` /
+  // `<ClickUIProvider config={{ toast: { duration } }}>`), then Radix's
+  // historical default of 5000 ms.
+  const providerDuration = useContext(ToastDurationContext);
+  const duration = durationProp ?? providerDuration;
+
   let iconName = '';
   if (type === 'default') {
     iconName = 'info-in-circle';
@@ -153,6 +174,11 @@ export const Toast = ({
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const closeTimerStartTimeRef = useRef<number>(0);
   const closeTimerRemainingTimeRef = useRef<number>(duration);
+  // Tracks whether `handlePause` actually paused a running timer. Without
+  // this, `handleResume` could not tell apart "duration was 0/unset, never
+  // had a timer" from "timer was running and got paused with no time left",
+  // and the latter case must close the toast immediately on resume.
+  const wasPausedRef = useRef(false);
 
   // Stable ref to the latest `onClose` so that `startCloseTimer` does not
   // depend on `onClose`'s identity. Without this, the auto-close `useEffect`
@@ -190,6 +216,7 @@ export const Toast = ({
 
   useEffect(() => {
     closeTimerRemainingTimeRef.current = duration;
+    wasPausedRef.current = false;
     startCloseTimer(duration);
     return clearCloseTimer;
   }, [duration, startCloseTimer, clearCloseTimer]);
@@ -204,9 +231,23 @@ export const Toast = ({
       closeTimerRemainingTimeRef.current - elapsed
     );
     clearCloseTimer();
+    wasPausedRef.current = true;
   }, [clearCloseTimer]);
 
   const handleResume = useCallback(() => {
+    if (!wasPausedRef.current) {
+      return;
+    }
+    wasPausedRef.current = false;
+    // If the deadline elapsed during the pause window (e.g. event-loop delay
+    // or timer throttling pushed the pause past the auto-close deadline
+    // before the timer callback ran), close immediately on resume instead of
+    // letting `startCloseTimer(0)` short-circuit and leave the toast open
+    // forever.
+    if (closeTimerRemainingTimeRef.current <= 0) {
+      onCloseRef.current(false);
+      return;
+    }
     startCloseTimer(closeTimerRemainingTimeRef.current);
   }, [startCloseTimer]);
 
@@ -291,6 +332,7 @@ export interface ToastProviderProps extends RadixUIToast.ToastProviderProps {
 export const ToastProvider = ({
   children,
   align = 'end',
+  duration: providerDuration = DEFAULT_TOAST_DURATION,
   ...props
 }: ToastProviderProps) => {
   const [toasts, setToasts] = useState<Record<ToastAlignment, Map<string, ToastProps>>>({
@@ -343,18 +385,21 @@ export const ToastProvider = ({
     <RadixUIToast.Provider
       swipeDirection={align === 'start' ? 'left' : 'right'}
       key={`toast-provider-${align}`}
+      duration={providerDuration}
       {...props}
     >
-      <ToastContext.Provider value={value}>
-        {children}
-        {Array.from(toasts[align]).map(([id, toast]) => (
-          <Toast
-            key={id}
-            {...toast}
-            onClose={onClose(id)}
-          />
-        ))}
-      </ToastContext.Provider>
+      <ToastDurationContext.Provider value={providerDuration}>
+        <ToastContext.Provider value={value}>
+          {children}
+          {Array.from(toasts[align]).map(([id, toast]) => (
+            <Toast
+              key={id}
+              {...toast}
+              onClose={onClose(id)}
+            />
+          ))}
+        </ToastContext.Provider>
+      </ToastDurationContext.Provider>
       <Viewport $align={align} />
     </RadixUIToast.Provider>
   );

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,4 +1,4 @@
-import { createContext, useEffect, useState } from 'react';
+import { createContext, useCallback, useEffect, useRef, useState } from 'react';
 import * as RadixUIToast from '@radix-ui/react-toast';
 import { keyframes, styled } from 'styled-components';
 import { toastsEventEmitter } from './toastEmitter';
@@ -6,6 +6,10 @@ import { Icon, type IconName, type IconProps } from '@/components/Icon';
 import { IconButton } from '@/components/IconButton';
 import { Button } from '@/components/Button';
 import { ToastContextProps, ToastProps, ToastAlignment, ToastType } from './Toast.types';
+
+// Radix's default auto-close duration, mirrored here so our internally managed
+// timer matches Radix's behaviour when no `duration` is provided.
+const DEFAULT_TOAST_DURATION = 5000;
 
 export const ToastContext = createContext<ToastContextProps>({
   createToast: () => null,
@@ -124,7 +128,7 @@ export const Toast = ({
   title,
   description,
   actions = [],
-  duration,
+  duration = DEFAULT_TOAST_DURATION,
   onClose,
 
   ...props
@@ -137,10 +141,68 @@ export const Toast = ({
   } else if (type && ['danger', 'warning'].includes(type)) {
     iconName = 'warning';
   }
+
+  // We manage the auto-close timer ourselves (and pass `duration={Infinity}` to
+  // Radix below) so that the timer is always cleared on unmount. The Radix
+  // implementation (v1.2.2) never clears its internal `closeTimerRef`, which
+  // causes the timer to fire after the host (e.g. jsdom in tests) has been
+  // torn down, surfacing as `ReferenceError: document is not defined`. See
+  // https://github.com/radix-ui/primitives/pull/3794. Once that upstream fix
+  // ships and we adopt it we can revert this in favour of Radix's own timer.
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const closeTimerStartTimeRef = useRef<number>(0);
+  const closeTimerRemainingTimeRef = useRef<number>(duration);
+
+  const clearCloseTimer = useCallback(() => {
+    if (closeTimerRef.current !== undefined) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = undefined;
+    }
+  }, []);
+
+  const startCloseTimer = useCallback(
+    (remaining: number) => {
+      clearCloseTimer();
+      if (!remaining || remaining === Infinity) {
+        return;
+      }
+      closeTimerStartTimeRef.current = Date.now();
+      closeTimerRef.current = setTimeout(() => {
+        closeTimerRef.current = undefined;
+        onClose(false);
+      }, remaining);
+    },
+    [clearCloseTimer, onClose]
+  );
+
+  useEffect(() => {
+    closeTimerRemainingTimeRef.current = duration;
+    startCloseTimer(duration);
+    return clearCloseTimer;
+  }, [duration, startCloseTimer, clearCloseTimer]);
+
+  const handlePause = useCallback(() => {
+    if (closeTimerRef.current === undefined) {
+      return;
+    }
+    const elapsed = Date.now() - closeTimerStartTimeRef.current;
+    closeTimerRemainingTimeRef.current = Math.max(
+      0,
+      closeTimerRemainingTimeRef.current - elapsed
+    );
+    clearCloseTimer();
+  }, [clearCloseTimer]);
+
+  const handleResume = useCallback(() => {
+    startCloseTimer(closeTimerRemainingTimeRef.current);
+  }, [startCloseTimer]);
+
   return (
     <ToastRoot
       onOpenChange={onClose}
-      duration={duration}
+      duration={Infinity}
+      onPause={handlePause}
+      onResume={handleResume}
       type={toastType}
       {...props}
     >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why?

Radix `@radix-ui/react-toast@1.2.2` (and the latest published `1.2.17`, verified by diffing `ToastImpl`) never clears its internal `closeTimerRef` when it unmounts. The leftover `setTimeout` fires after the host has gone away — in jsdom-based test runs, vitest tears down the file's DOM before the timer fires, then Radix's `handleClose` does `node?.contains(document.activeElement)` and crashes with `ReferenceError: document is not defined`, aborting the entire test suite for that file.

Upstream fix is open but unmerged: [radix-ui/primitives#3794](https://github.com/radix-ui/primitives/pull/3794) (tracking issue: radix-ui/primitives#3703). When that ships and we bump our `@radix-ui/react-toast` dep, this wrapper-side workaround can be reverted.

## How?

Take ownership of the auto-close timer inside click-ui's `Toast` wrapper instead of relying on Radix's internal one:

- Always pass `duration={Infinity}` to the underlying `RadixUIToast.Root`. Radix's `startTimer` short-circuits on `Infinity` (`if (!duration2 || duration2 === Infinity) return;`), so no real `setTimeout` is ever scheduled inside Radix — no leak possible.
- Manage `closeTimerRef` ourselves with `useRef` + `setTimeout`, and clear it from the `useEffect` cleanup, so the timer is guaranteed to be cancelled on unmount.
- Wire `onPause` / `onResume` (public Radix props) to pause/resume our own timer. This preserves the existing viewport-level pause-on-blur / pause-on-hover behaviour for production consumers.
- Resolve the effective `duration` as `toast.duration ?? providerDuration ?? DEFAULT_TOAST_DURATION` via a new internal `ToastDurationContext` populated by `ToastProvider`. This preserves the previous prop > provider > default precedence so `<ToastProvider duration={...}>` / `<ClickUIProvider config={{ toast: { duration } }}>` still works.
- Keep `onClose` behind a stable callback ref (the same `useCallbackRef` pattern Radix uses internally), so the auto-close `useEffect` does **not** re-run when the parent passes a new `onClose` identity. This matters because `ToastProvider` produces a new `onClose={onClose(id)}` closure on every render — without the ref, every provider update (e.g. another toast appearing) would restart the countdown from the full duration and discard pause progress, letting a frequently-rerendering parent keep a toast alive indefinitely.
- Track `wasPausedRef` so that `handleResume` can distinguish "never paused" from "paused with deadline already elapsed". In the latter case (event-loop delay / timer throttling beat the close timer to the punch), `handleResume` now closes immediately instead of calling `startCloseTimer(0)` and short-circuiting forever.

Added `src/components/Toast/Toast.test.tsx` with six cases, four of them targeted regression tests:

1. `does not leak the auto-close timer past unmount (regression for radix-ui/primitives#3703)` — stubs `Document.prototype.activeElement` and advances time past the leaked deadline. If Radix's auto-close handler ever fires post-unmount it dereferences `document.activeElement`, tripping the stub. Asserts the stub was never tripped, which is insensitive to unrelated Radix / styled-components internal timer counts.
2. `does not reset the auto-close timer when the parent re-renders with a new onClose identity` — re-renders with a fresh `onClose` mid-countdown and asserts the original deadline still fires.
3. `falls back to the provider-level duration when a toast does not set its own` — creates a toast via `useToast().createToast` under a `<ClickUIProvider config={{ toast: { duration: 2000 } }}>` and asserts the toast disappears just past 2000 ms (not the 5000 ms hard default).
4. `closes immediately on resume when the auto-close deadline elapsed during a pause` — advances the wall clock past `duration` without draining the fake-timer queue, then dispatches Radix's `toast.viewportPause` / `toast.viewportResume` events on the viewport `<ol>`. Asserts `onClose(false)` fires immediately on resume.

Verified: each new test fails on the corresponding pre-fix code path (parent-re-render, provider-duration, resume-after-deadline) and passes with the fix applied.

## Verification

- `yarn test` — **480 passed (59 files)**, including the new 6-test `Toast` suite.
- `yarn typecheck` — clean.
- `yarn lint` — clean (no new warnings/errors; same 13 pre-existing warnings in unrelated files).
- `yarn build` — clean; `Toast` chunk built successfully.
- Counter-tests: with the fix file stashed, the parent-rerender, provider-duration, and resume-after-deadline tests fail individually, confirming each assertion exercises its target bug.
- Confirmed upgrading the dep would not fix this natively: latest published `@radix-ui/react-toast@1.2.17` (2026-06-15) still has the same `closeTimerRef`-without-unmount-cleanup code path as `1.2.2`; only whitespace differs in `ToastImpl`.

## Tickets?

- Upstream fix (pending): radix-ui/primitives#3794

## Contribution checklist?

- [x] You've done enough research before writing
- [x] You have reviewed the PR
- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project — n/a
- [ ] For documentation, guides or references, you've tested the commands — n/a

## Security checklist?

- [x] All user inputs are validated and sanitized — n/a
- [x] No usage of `dangerouslySetInnerHTML`
- [x] Sensitive data has been identified and is being protected properly — n/a
- [x] Build output contains no secrets or API keys

## Preview?

n/a — internal timer / lifecycle change with no visible UI/UX delta.

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://clickhouse-inc.slack.com/archives/C0AQ3EVGALX/p1782125105186279?thread_ts=1782125105.186279&cid=C0AQ3EVGALX)

<div><a href="https://cursor.com/agents/bc-479999a2-550a-57ab-a714-0b7841bdb3a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-479999a2-550a-57ab-a714-0b7841bdb3a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

