### PR TITLE
feat(Flyout): Add hasShadow prop to toggle box shadow

### DIFF
--- a/.changeset/feat-flyout-has-shadow.md
+++ b/.changeset/feat-flyout-has-shadow.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': patch
+---
+
+Add hasShadow prop to Flyout.Content to toggle box shadow

--- a/src/components/Flyout/Flyout.stories.tsx
+++ b/src/components/Flyout/Flyout.stories.tsx
@@ -13,6 +13,7 @@ interface FlyoutExampleProps extends FlyoutProps {
   type: 'default' | 'inline';
   size: 'default' | 'narrow' | 'wide' | 'widest';
   width?: string;
+  hasShadow?: boolean;
 }
 
 const FlyoutExample = ({
@@ -23,6 +24,7 @@ const FlyoutExample = ({
   size,
   width,
   align,
+  hasShadow,
   ...props
 }: FlyoutExampleProps) => {
   return (
@@ -35,6 +37,7 @@ const FlyoutExample = ({
         align={align}
         size={size}
         width={width}
+        hasShadow={hasShadow}
       >
         <Flyout.Header
           type={type}
@@ -84,6 +87,7 @@ const meta: Meta<typeof FlyoutExample> = {
     size: { control: 'select', options: ['default', 'narrow', 'wide', 'widest'] },
     type: { control: 'select', options: ['default', 'inline'] },
     width: { control: 'text' },
+    hasShadow: { control: 'boolean' },
   },
 };
 
@@ -98,6 +102,7 @@ export const Playground: Story = {
     align: 'end',
     size: 'default',
     type: 'default',
+    hasShadow: true,
   },
   parameters: {
     docs: {

--- a/src/components/Flyout/Flyout.test.tsx
+++ b/src/components/Flyout/Flyout.test.tsx
@@ -7,16 +7,20 @@ import { DialogProps } from '@radix-ui/react-dialog';
 interface Props extends DialogProps {
   showClose?: boolean;
   showSeparator?: boolean;
+  hasShadow?: boolean;
 }
 
 describe('Flyout', () => {
-  const renderFlyout = ({ showClose, showSeparator, ...props }: Props) => {
+  const renderFlyout = ({ showClose, showSeparator, hasShadow, ...props }: Props) => {
     return renderCUI(
       <Flyout {...props}>
         <Flyout.Trigger>
           <Button iconLeft="user">Flyout Fixed</Button>
         </Flyout.Trigger>
-        <Flyout.Content strategy="fixed">
+        <Flyout.Content
+          strategy="fixed"
+          hasShadow={hasShadow}
+        >
           <Flyout.Header
             title="test1"
             description="test2"
@@ -105,5 +109,15 @@ describe('Flyout', () => {
     expect(queryByText('Flyout Text')).not.toBeNull();
     fireEvent.click(getByText('Cancel'));
     expect(queryByText('Flyout Text')).toBeNull();
+  });
+
+  it('should remove shadow when hasShadow is false', () => {
+    const { queryByText, getByRole } = renderFlyout({
+      open: true,
+      hasShadow: false,
+    });
+
+    expect(queryByText('Flyout Text')).not.toBeNull();
+    expect(getByRole('dialog')).toHaveStyle({ boxShadow: 'none' });
   });
 });

--- a/src/components/Flyout/Flyout.tsx
+++ b/src/components/Flyout/Flyout.tsx
@@ -63,6 +63,7 @@ const FlyoutContent = styled(DialogContent)<{
   $strategy: FlyoutStrategy;
   $width?: string;
   $align: FlyoutAlignmentType;
+  $hasShadow?: boolean;
 }>`
   display: flex;
   flex-direction: column;
@@ -74,7 +75,7 @@ const FlyoutContent = styled(DialogContent)<{
   --flyout-width: ${({ theme, $size = 'default', $width }) =>
     $width || theme.click.flyout.size[$size].width};
   animation: ${animationWidth} 500ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
-  ${({ theme, $strategy, $type = 'default', $align }) => `
+  ${({ theme, $strategy, $type = 'default', $align, $hasShadow = true }) => `
     ${$align === 'start' ? 'left' : 'right'}: 0;
     max-width: 100%;
     position: ${$strategy};
@@ -82,9 +83,11 @@ const FlyoutContent = styled(DialogContent)<{
     padding: 0 ${theme.click.flyout.space[$type].x}
     gap: ${theme.click.flyout.space[$type].gap};
     box-shadow: ${
-      $align === 'start'
-        ? theme.click.flyout.shadow.reverse
-        : theme.click.flyout.shadow.default
+      $hasShadow === false
+        ? 'none'
+        : $align === 'start'
+          ? theme.click.flyout.shadow.reverse
+          : theme.click.flyout.shadow.default
     };
     border-${$align === 'start' ? 'right' : 'left'}: 1px solid ${
       theme.click.flyout.color.stroke.default
@@ -133,6 +136,7 @@ const Content = ({
   closeOnInteractOutside = false,
   width,
   align = 'end',
+  hasShadow = true,
   onInteractOutside,
   ...props
 }: FlyoutContentProps) => {
@@ -153,6 +157,7 @@ const Content = ({
         }}
         $width={width}
         $align={align}
+        $hasShadow={hasShadow}
         {...props}
       >
         {children}

--- a/src/components/Flyout/Flyout.tsx
+++ b/src/components/Flyout/Flyout.tsx
@@ -80,7 +80,7 @@ const FlyoutContent = styled(DialogContent)<{
     max-width: 100%;
     position: ${$strategy};
     height: ${$strategy === 'relative' ? '100%' : 'auto'};
-    padding: 0 ${theme.click.flyout.space[$type].x}
+    padding: 0 ${theme.click.flyout.space[$type].x};
     gap: ${theme.click.flyout.space[$type].gap};
     box-shadow: ${
       $hasShadow === false
@@ -175,10 +175,12 @@ const FlyoutElement = styled(Container)<{
   max-width: -webkit-fill-available;
   max-width: fill-available;
   max-width: stretch;
-  ${({ theme, $type = 'default' }) => `
-    gap: ${theme.click.flyout.space[$type].gap};
-    padding: 0 ${theme.click.flyout.space[$type].content.x};
-  `}
+  && {
+    ${({ theme, $type = 'default' }) => `
+      gap: ${theme.click.flyout.space[$type].gap};
+      padding: 0 ${theme.click.flyout.space[$type].content.x};
+    `}
+  }
 `;
 
 interface ElementProps extends Omit<
@@ -204,11 +206,13 @@ Flyout.Element = Element;
 const FlyoutHeaderContainer = styled(Container)<{
   $type?: FlyoutType;
 }>`
-  ${({ theme, $type = 'default' }) => `
-    row-gap: ${theme.click.flyout.space[$type].content['row-gap']};
-    column-gap: ${theme.click.flyout.space[$type].content['column-gap']};
-    padding: ${theme.click.flyout.space[$type].y} ${theme.click.flyout.space[$type].y} 0 ${theme.click.flyout.space[$type].y} ;
-  `}
+  && {
+    ${({ theme, $type = 'default' }) => `
+      row-gap: ${theme.click.flyout.space[$type].content['row-gap']};
+      column-gap: ${theme.click.flyout.space[$type].content['column-gap']};
+      padding: ${theme.click.flyout.space[$type].y} ${theme.click.flyout.space[$type].y} 0 ${theme.click.flyout.space[$type].y};
+    `}
+  }
 `;
 
 const FlyoutTitle = styled(DialogTitle)<{
@@ -355,11 +359,13 @@ Flyout.Body = Body;
 const FlyoutFooter = styled(Container)<{
   type?: FlyoutType;
 }>`
-  ${({ theme, type = 'default' }) => `
-    row-gap: ${theme.click.flyout.space[type].content['row-gap']};
-    column-gap: ${theme.click.flyout.space[type].content['column-gap']};
-    padding: ${theme.click.flyout.space[type].y} ${theme.click.flyout.space[type].content.x};
-  `}
+  && {
+    ${({ theme, type = 'default' }) => `
+      row-gap: ${theme.click.flyout.space[type].content['row-gap']};
+      column-gap: ${theme.click.flyout.space[type].content['column-gap']};
+      padding: ${theme.click.flyout.space[type].y} ${theme.click.flyout.space[type].content.x};
+    `}
+  }
 `;
 
 interface FlyoutButtonProps extends Omit<ButtonProps, 'children'> {

--- a/src/components/Flyout/Flyout.tsx
+++ b/src/components/Flyout/Flyout.tsx
@@ -81,9 +81,11 @@ const FlyoutContent = styled(DialogContent)<{
     height: ${$strategy === 'relative' ? '100%' : 'auto'};
     padding: 0 ${theme.click.flyout.space[$type].x};
     gap: ${theme.click.flyout.space[$type].gap};
-    box-shadow: ${$hasShadow === false
-      ? 'none'
-      : theme.click.flyout.shadow[$align === 'start' ? 'reverse' : 'default']};
+    box-shadow: ${
+      $hasShadow === false
+        ? 'none'
+        : theme.click.flyout.shadow[$align === 'start' ? 'reverse' : 'default']
+    };
     border-${$align === 'start' ? 'right' : 'left'}: 1px solid ${
       theme.click.flyout.color.stroke.default
     };

--- a/src/components/Flyout/Flyout.tsx
+++ b/src/components/Flyout/Flyout.tsx
@@ -17,9 +17,8 @@ import type { ContainerProps } from '@/components/Container';
 import { Icon } from '@/components/Icon';
 import { Separator } from '@/components/Separator';
 import { Spacer } from '@/components/Spacer';
-import { styled } from 'styled-components';
+import { styled, keyframes } from 'styled-components';
 import { CrossButton } from '@/components/CrossButton';
-import { keyframes } from 'styled-components';
 import type {
   FlyoutProps,
   FlyoutTriggerProps,
@@ -82,13 +81,9 @@ const FlyoutContent = styled(DialogContent)<{
     height: ${$strategy === 'relative' ? '100%' : 'auto'};
     padding: 0 ${theme.click.flyout.space[$type].x};
     gap: ${theme.click.flyout.space[$type].gap};
-    box-shadow: ${
-      $hasShadow === false
-        ? 'none'
-        : $align === 'start'
-          ? theme.click.flyout.shadow.reverse
-          : theme.click.flyout.shadow.default
-    };
+    box-shadow: ${$hasShadow === false
+      ? 'none'
+      : theme.click.flyout.shadow[$align === 'start' ? 'reverse' : 'default']};
     border-${$align === 'start' ? 'right' : 'left'}: 1px solid ${
       theme.click.flyout.color.stroke.default
     };

--- a/src/components/Flyout/Flyout.types.ts
+++ b/src/components/Flyout/Flyout.types.ts
@@ -24,6 +24,8 @@ export interface FlyoutContentProps extends HTMLAttributes<HTMLDivElement> {
   closeOnInteractOutside?: boolean;
   width?: string;
   align?: FlyoutAlignmentType;
+  /** Whether to show a shadow on the flyout */
+  hasShadow?: boolean;
   onInteractOutside?: (event: CustomEvent) => void;
   onEscapeKeyDown?: (event: KeyboardEvent) => void;
   onPointerDownOutside?: (event: CustomEvent) => void;


### PR DESCRIPTION
## Why?

Adding a `hasShadow` prop to the flyouts to allow them to be turned off. Useful for inline flyouts but I figured we should err on flexibility and give to option to all flyouts. API consistent with `Panel` and `Card` components

## Tickets?

- https://github.com/ClickHouse/click-ui/issues/563
