### PR TITLE
fix(build): load CSS module rules for non-index components

### DIFF
--- a/.changeset/fix-iconwrapper-css-module-not-loaded.md
+++ b/.changeset/fix-iconwrapper-css-module-not-loaded.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': patch
+---
+
+Fix CSS module rules not loading for non-index components. The css-colocate build plugin only injected a component's compiled CSS into its matching `<Dir>/index.js`, so files like `Collapsible/IconWrapper.js` applied class names without ever loading their styles. Components that render `IconWrapper` but not `Collapsible` (e.g. `SidebarNavigationItem`) lost the `display: flex` layout, stacking the icon above the label. The plugin now injects the compiled CSS into every module that imports a `.module.css`.

--- a/plugins/css-colocate/import-inject.ts
+++ b/plugins/css-colocate/import-inject.ts
@@ -124,6 +124,71 @@ export const injectComponentCss = async (
 };
 
 /**
+ * Inject the compiled CSS for every `.module.css` a source file imports.
+ *
+ * CSS module imports are served as virtual modules that expose only the
+ * class-name map — they carry no styles. `injectComponentCss` loads the rules
+ * for `<Dir>/index.js`, but any other module that uses a CSS module (e.g.
+ * Collapsible/IconWrapper.js, which other components render) would otherwise
+ * render with class names but no styles. This injects `<name>.css` into each
+ * such file so the rules travel with every consumer.
+ */
+export const injectModuleCssImports = async (
+  trackedModuleImports: TrackedImport[],
+  rootDir: string,
+  distDir: string,
+  format: 'esm' | 'cjs',
+  ext: string
+): Promise<void> => {
+  if (trackedModuleImports.length === 0) return;
+
+  const srcDir = path.join(rootDir, 'src');
+
+  for (const { sourceFile, cssPaths } of trackedModuleImports) {
+    const relativeToSrc = path.relative(srcDir, sourceFile);
+    const jsOutputFile = path.join(distDir, relativeToSrc.replace(/\.tsx?$/, `.${ext}`));
+
+    if (!(await fileExists(jsOutputFile))) continue;
+
+    let content = await fs.readFile(jsOutputFile, 'utf-8');
+    const importStatements: string[] = [];
+
+    for (const cssPath of cssPaths) {
+      const moduleSourcePath = resolveCssPath(cssPath, sourceFile, srcDir);
+      if (!moduleSourcePath) continue;
+
+      // The pre-processor emits `<name>.css` next to the `<name>.module.css`.
+      const compiledSourcePath = moduleSourcePath.replace(/\.module\.css$/, '.css');
+      const compiledDistPath = path.join(
+        distDir,
+        path.relative(srcDir, compiledSourcePath)
+      );
+
+      if (!(await fileExists(compiledDistPath))) continue;
+
+      const importPath = calculateImportPath(
+        jsOutputFile,
+        compiledSourcePath,
+        srcDir,
+        distDir
+      );
+      if (!importPath) continue;
+
+      // Skip when this file already imports the CSS (e.g. via injectComponentCss).
+      if (content.includes(`"${importPath}"`)) continue;
+
+      importStatements.push(createImportStatement(importPath, format));
+    }
+
+    if (importStatements.length > 0) {
+      content = removeEmptyCssComments(content);
+      content = insertAtTop(content, importStatements.join('\n') + '\n');
+      await fs.writeFile(jsOutputFile, content);
+    }
+  }
+};
+
+/**
  * Inject CSS imports into files that had CSS imports in source
  * (e.g., ThemeProvider.tsx imports theme CSS files)
  */

--- a/plugins/css-colocate/index.ts
+++ b/plugins/css-colocate/index.ts
@@ -1,7 +1,11 @@
 import type { Plugin, ResolvedConfig } from 'vite';
 import { preprocessCssModules } from './css-preprocess';
 import { resolveCssModule, loadCssModule } from './virtual-modules';
-import { injectComponentCss, injectRegularCssImports } from './import-inject';
+import {
+  injectComponentCss,
+  injectRegularCssImports,
+  injectModuleCssImports,
+} from './import-inject';
 import { copyCssFiles } from './utils';
 import path from 'path';
 
@@ -11,6 +15,11 @@ interface TrackedCssImport {
 }
 
 const REGULAR_CSS_IMPORT_REGEX = /import\s+['"]([^'"]+\.css)['"];?/g;
+// Matches `import styles from './x.module.css'` / `import * as s from '...'`.
+// The class-name map is delivered via a virtual module that carries no CSS, so
+// every module importing one must also load the co-located compiled rules.
+const MODULE_CSS_IMPORT_REGEX =
+  /import\s+(?:\*\s+as\s+\w+|\w+)\s+from\s+['"]([^'"]+\.module\.css)['"];?/g;
 
 /**
  * Vite plugin that:
@@ -22,6 +31,7 @@ const REGULAR_CSS_IMPORT_REGEX = /import\s+['"]([^'"]+\.css)['"];?/g;
 export const cssColocatePlugin = (): Plugin => {
   let config: ResolvedConfig;
   const trackedImports: TrackedCssImport[] = [];
+  const trackedModuleImports: TrackedCssImport[] = [];
 
   return {
     name: 'vite-plugin-css-colocate',
@@ -33,6 +43,7 @@ export const cssColocatePlugin = (): Plugin => {
       // appending, causing duplicate CSS imports
       // on each rebuild
       trackedImports.length = 0;
+      trackedModuleImports.length = 0;
       await preprocessCssModules(config.root);
     },
 
@@ -66,6 +77,18 @@ export const cssColocatePlugin = (): Plugin => {
         trackedImports.push({ sourceFile: id, cssPaths: cssImports });
       }
 
+      // Track CSS module imports so the compiled rules are loaded into every
+      // consumer, not just the component whose name matches the directory.
+      const moduleCssImports: string[] = [];
+      MODULE_CSS_IMPORT_REGEX.lastIndex = 0;
+      while ((match = MODULE_CSS_IMPORT_REGEX.exec(code)) !== null) {
+        moduleCssImports.push(match[1]);
+      }
+
+      if (moduleCssImports.length) {
+        trackedModuleImports.push({ sourceFile: id, cssPaths: moduleCssImports });
+      }
+
       return null;
     },
 
@@ -86,6 +109,15 @@ export const cssColocatePlugin = (): Plugin => {
 
         // Inject CSS imports into files with tracked imports
         await injectRegularCssImports(trackedImports, config.root, distDir, format);
+
+        // Inject compiled CSS module rules into every file that imports one
+        await injectModuleCssImports(
+          trackedModuleImports,
+          config.root,
+          distDir,
+          format,
+          ext
+        );
       }
     },
   };


### PR DESCRIPTION
## Problem

Sidebar nav items in `SidebarNavigationItem` render with the **icon stacked above the label** instead of inline. Reproduces in any app that imports `SidebarNavigationItem` (or the other migrated `Collapsible`-family components) without also importing `Collapsible`/`Accordion` on the same route — e.g. the internal sysadmin app's sidebar.

| Expected (inline) | Broken (stacked) |
|---|---|
| icon + label on one row | icon on top, label below |

## Root cause

Introduced by `migrate-collapsible-family-to-css-modules` (Collapsible/SidebarNavigationItem/… moved from styled-components to CSS modules).

The `css-colocate` build plugin serves every `.module.css` import as a **virtual module that exposes only the class-name map — it carries no styles**. The compiled rules are loaded by a *separate* pass, `injectComponentCss`, which only injects `<Dir>.css` into the matching `<Dir>/index.js`.

So `Collapsible.module.css`'s rules are only loaded by `Collapsible/index.js`. But `Collapsible/IconWrapper.tsx` (a **non-index** file in the same dir) also uses `collapsible__label` / `collapsible__ellipsis` — it compiles to `Collapsible/IconWrapper.js` and never gets the rules. `SidebarNavigationItem` renders `IconWrapper` but only injects its *own* `SidebarNavigationItem.css`, so the `.collapsible__label { display: flex }` rule is absent → icon and label stack.

The styled-components version was self-contained, which is why this was "no change in behavior" everywhere a `Collapsible`/`Accordion` happened to also be bundled, but a regression elsewhere.

## Fix

Track `.module.css` imports the same way regular CSS imports are already tracked, and inject the compiled `<name>.css` side-effect into **every** module that imports a CSS module — not just the matching index barrel. This mirrors how a normal bundler treats CSS modules (the class-map import is also a style side-effect).

After the fix, `Collapsible/IconWrapper.js` (esm + cjs) now starts with `import "./Collapsible.css";`, and `Collapsible/index.js` still imports it exactly once (dedup preserved). Components that render `IconWrapper` pick up the rules transitively.

## Verification

- `yarn build` succeeds; inspected dist:
  - `dist/esm/components/Collapsible/IconWrapper.js` → `import "./Collapsible.css";`
  - `dist/cjs/components/Collapsible/IconWrapper.cjs` → `require("./Collapsible.css");`
  - `Collapsible/index.js` imports `Collapsible.css` exactly once (no duplicate)
- `yarn typecheck`, `yarn lint` pass
- `SidebarNavigationItem` + `Collapsible` unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)