### PR TITLE
fix(build): replace directory-based colocation of css.module files with actual usage

### DIFF
--- a/.scripts/bash/build_pkg_dist
+++ b/.scripts/bash/build_pkg_dist
@@ -2,24 +2,24 @@
 
 if [[ -d ./dist ]]; then
   if ! rm -rf ./dist; then
-    echo "⚠️Failed to delete dist directory"
+    echo "Failed to delete dist directory"
   fi
 fi
 
 if ! yarn typecheck; then
-  echo "👹 Oops! Found typescript issues..."
+  echo "Error: found typescript issues"
 
   exit 1
 fi
 
 if ! vite build; then
-  echo "👹 Oops! Failed to build the package..."
+  echo "Error: failed to build the package"
 
   exit 1
 fi
 
 if ! .scripts/js/generate-exports; then
-  echo "👹 Oops! Failed to generate exports..."
+  echo "Error: failed to generate exports"
 
   exit 1
 fi

--- a/plugins/css-colocate/import-inject.ts
+++ b/plugins/css-colocate/import-inject.ts
@@ -1,6 +1,5 @@
 import fs from 'fs-extra';
 import path from 'path';
-import { glob } from 'glob';
 import { fileExists, createImportStatement } from './utils';
 
 interface TrackedImport {
@@ -23,6 +22,26 @@ const resolveCssPath = (
     return path.resolve(path.dirname(sourceFile), cssImportPath);
   }
   return null;
+};
+
+/**
+ * Map a source file to its emitted JS output path, mirroring the
+ * `createEntryFileNames` rule in vite.config.ts: when a module's filename equals
+ * its parent directory (e.g. Button/Button.tsx), the output is renamed to
+ * `index` (Button/index.js). Siblings like Collapsible/IconWrapper.tsx are not
+ * renamed.
+ */
+const resolveJsOutputFile = (
+  sourceFile: string,
+  srcDir: string,
+  distDir: string,
+  ext: string
+): string => {
+  const relative = path.relative(srcDir, sourceFile).replace(/\.tsx?$/, '');
+  const dir = path.dirname(relative);
+  const name = path.basename(relative);
+  const outName = path.basename(dir) === name ? 'index' : name;
+  return path.join(distDir, dir, `${outName}.${ext}`);
 };
 
 /**
@@ -52,7 +71,9 @@ const copyAndResolveCss = async (
   jsOutputFile: string
 ): Promise<string | null> => {
   const cssSourcePath = resolveCssPath(cssImportPath, sourceFile, srcDir);
-  if (!cssSourcePath || !(await fileExists(cssSourcePath))) return null;
+  if (!cssSourcePath || !(await fileExists(cssSourcePath))) {
+    return null;
+  }
 
   const cssRelativeToSrc = path.relative(srcDir, cssSourcePath);
   const cssOutputPath = path.join(distDir, cssRelativeToSrc);
@@ -93,33 +114,71 @@ const insertAtTop = (content: string, codeToInsert: string): string => {
 };
 
 /**
- * Inject CSS imports into component files (e.g., Button/index.js gets import "./Button.css")
+ * Inject the colocated rules stylesheet for every module that imported a `.module.css`.
  *
- * NOTE: This function assumes the CSS filename matches the parent directory name.
- * For example, components/Button/index.js expects components/Button/Button.css to exist.
- * Components that don't follow this naming convention will be silently skipped.
+ * Driven by the actual source imports tracked during `transform` (any file, not just
+ * `index.*`), so non-index consumers are covered too — e.g. Collapsible/IconWrapper.tsx
+ * imports Collapsible.module.css but is reached by SidebarNavigationItem without ever
+ * pulling in Collapsible/index.js. Keying off the directory name (the old approach) left
+ * such siblings without their stylesheet, which then got tree-shaken out of consumer builds.
+ *
+ * The rules file (`<Name>.css`) for a `<Name>.module.css` is produced by
+ * preprocessCssModules and copied into dist by copyCssFiles before this runs.
  */
-export const injectComponentCss = async (
+export const injectModuleCssImports = async (
+  trackedModuleImports: TrackedImport[],
+  rootDir: string,
   distDir: string,
-  format: 'esm' | 'cjs',
-  ext: string
+  format: 'esm' | 'cjs'
 ): Promise<void> => {
-  const files = await glob(`**/index.${ext}`, { cwd: distDir, absolute: true });
+  if (trackedModuleImports.length === 0) {
+    return;
+  }
 
-  for (const jsFile of files) {
-    const dir = path.dirname(jsFile);
-    const component = path.basename(dir);
-    const cssFile = path.join(dir, `${component}.css`);
+  const srcDir = path.join(rootDir, 'src');
+  const ext = format === 'esm' ? 'js' : 'cjs';
 
-    if (!(await fileExists(cssFile))) continue;
+  for (const { sourceFile, cssPaths } of trackedModuleImports) {
+    const jsOutputFile = resolveJsOutputFile(sourceFile, srcDir, distDir, ext);
 
-    const content = await fs.readFile(jsFile, 'utf-8');
-    if (content.includes(`${component}.css`)) continue;
+    if (!(await fileExists(jsOutputFile))) {
+      continue;
+    }
 
-    const importStmt = createImportStatement(`./${component}.css`, format) + '\n';
-    const updated = insertAtTop(content, importStmt);
+    let content = await fs.readFile(jsOutputFile, 'utf-8');
+    const importStatements: string[] = [];
 
-    await fs.writeFile(jsFile, updated);
+    for (const moduleCssPath of cssPaths) {
+      const moduleCssAbs = resolveCssPath(moduleCssPath, sourceFile, srcDir);
+      if (!moduleCssAbs) {
+        continue;
+      }
+
+      // `<Name>.module.css` -> `<Name>.css` (the emitted rules file, same relative dir)
+      const cssRulesSourcePath = moduleCssAbs.replace(/\.module\.css$/, '.css');
+      const cssOutputPath = path.join(distDir, path.relative(srcDir, cssRulesSourcePath));
+      if (!(await fileExists(cssOutputPath))) {
+        continue;
+      }
+
+      const importPath = calculateImportPath(jsOutputFile, cssRulesSourcePath, srcDir, distDir);
+      if (!importPath) {
+        continue;
+      }
+
+      const importStatement = createImportStatement(importPath, format);
+      if (!content.includes(importPath) && !importStatements.includes(importStatement)) {
+        importStatements.push(importStatement);
+      }
+    }
+
+    content = removeEmptyCssComments(content);
+
+    if (importStatements.length > 0) {
+      content = insertAtTop(content, importStatements.join('\n') + '\n');
+    }
+
+    await fs.writeFile(jsOutputFile, content);
   }
 };
 
@@ -133,7 +192,9 @@ export const injectRegularCssImports = async (
   distDir: string,
   format: 'esm' | 'cjs'
 ): Promise<void> => {
-  if (trackedImports.length === 0) return;
+  if (trackedImports.length === 0) {
+    return;
+  }
 
   const srcDir = path.join(rootDir, 'src');
 
@@ -144,7 +205,9 @@ export const injectRegularCssImports = async (
       relativeToSrc.replace(/\.tsx?$/, `.${format === 'esm' ? 'js' : 'cjs'}`)
     );
 
-    if (!(await fileExists(jsOutputFile))) continue;
+    if (!(await fileExists(jsOutputFile))) {
+      continue;
+    }
 
     let content = await fs.readFile(jsOutputFile, 'utf-8');
 

--- a/plugins/css-colocate/index.ts
+++ b/plugins/css-colocate/index.ts
@@ -1,7 +1,7 @@
 import type { Plugin, ResolvedConfig } from 'vite';
 import { preprocessCssModules } from './css-preprocess';
 import { resolveCssModule, loadCssModule } from './virtual-modules';
-import { injectComponentCss, injectRegularCssImports } from './import-inject';
+import { injectModuleCssImports, injectRegularCssImports } from './import-inject';
 import { copyCssFiles } from './utils';
 import path from 'path';
 
@@ -11,6 +11,10 @@ interface TrackedCssImport {
 }
 
 const REGULAR_CSS_IMPORT_REGEX = /import\s+['"]([^'"]+\.css)['"];?/g;
+// Matches `import styles from './x.module.css'`, `import * as s from …`,
+// `import { a } from …`, and bare `import './x.module.css'`.
+const MODULE_CSS_IMPORT_REGEX =
+  /import\s+(?:(?:[\w$]+|\*\s+as\s+[\w$]+|\{[^}]*\})\s+from\s+)?['"]([^'"]+\.module\.css)['"]/g;
 
 /**
  * Vite plugin that:
@@ -22,6 +26,7 @@ const REGULAR_CSS_IMPORT_REGEX = /import\s+['"]([^'"]+\.css)['"];?/g;
 export const cssColocatePlugin = (): Plugin => {
   let config: ResolvedConfig;
   const trackedImports: TrackedCssImport[] = [];
+  const trackedModuleImports: TrackedCssImport[] = [];
 
   return {
     name: 'vite-plugin-css-colocate',
@@ -33,6 +38,7 @@ export const cssColocatePlugin = (): Plugin => {
       // appending, causing duplicate CSS imports
       // on each rebuild
       trackedImports.length = 0;
+      trackedModuleImports.length = 0;
       await preprocessCssModules(config.root);
     },
 
@@ -49,7 +55,9 @@ export const cssColocatePlugin = (): Plugin => {
     },
 
     transform(code, id) {
-      if (id.includes('node_modules') || !/\.[jt]sx?$/.test(id)) return null;
+      if (id.includes('node_modules') || !/\.[jt]sx?$/.test(id)) {
+        return null;
+      }
 
       // Track regular CSS imports (not .module.css)
       const cssImports: string[] = [];
@@ -66,23 +74,32 @@ export const cssColocatePlugin = (): Plugin => {
         trackedImports.push({ sourceFile: id, cssPaths: cssImports });
       }
 
+      // Track .module.css imports so the colocated rules file is injected into
+      // every importer, not just the directory's index file.
+      const moduleCssImports: string[] = [];
+      MODULE_CSS_IMPORT_REGEX.lastIndex = 0;
+      while ((match = MODULE_CSS_IMPORT_REGEX.exec(code)) !== null) {
+        moduleCssImports.push(match[1]);
+      }
+
+      if (moduleCssImports.length) {
+        trackedModuleImports.push({ sourceFile: id, cssPaths: moduleCssImports });
+      }
+
       return null;
     },
 
     async closeBundle() {
-      const formats = [
-        { format: 'esm' as const, ext: 'js' as const },
-        { format: 'cjs' as const, ext: 'cjs' as const },
-      ];
+      const formats = ['esm', 'cjs'] as const;
 
-      for (const { format, ext } of formats) {
+      for (const format of formats) {
         const distDir = path.join(config.root, 'dist', format);
 
         // Copy all CSS files (from temp and src)
         await copyCssFiles(config.root, distDir);
 
-        // Inject CSS imports into component files
-        await injectComponentCss(distDir, format, ext);
+        // Inject colocated .module.css rules into every importer
+        await injectModuleCssImports(trackedModuleImports, config.root, distDir, format);
 
         // Inject CSS imports into files with tracked imports
         await injectRegularCssImports(trackedImports, config.root, distDir, format);


### PR DESCRIPTION
### Bug summary

**Symptom:** The sysadmin sidebar rendered with nav icons stacked above their labels (narrower) in production builds, while local dev and apps/web looked correct (icons beside labels).

**Root cause:** A packaging bug in @clickhouse/click-ui's custom cssColocatePlugin. For CSS-Module components, the build splits each X.module.css into a JS class-name map (X.module.css.js) plus the actual rules (X.css), and a post-build pass re-attaches the X.css side-effect import to consuming modules. That pass (injectComponentCss) only injected into **/index.* files keyed by directory name — so Collapsible/IconWrapper.js (a non-index sibling that imports Collapsible.module.css) never got import "./Collapsible.css".

SidebarNavigationItem renders through IconWrapper, so any app importing it without also importing the full Collapsible component (only sysadmin does this) had .collapsible__label { display:flex } tree-shaken out of its production bundle. Without flex, the icon (itself display:flex/block) dropped onto its own line above the label. It only broke in production, not dev, because Vite's dev dep pre-bundle pulls in the whole barrel.

**Fix:** Replaced the convention-based injection with injectModuleCssImports, which tracks the actual .module.css imports during transform and injects the colocated .css into every importing module — not just index.*. Included a resolveJsOutputFile helper to mirror the Button/Button.tsx → Button/index.js output rename (a same-name-as-dir case that would otherwise have regressed).
