### PR TITLE
fix(Container): keep base styles overridable by styled-components

### DIFF
--- a/.changeset/fix-container-padding-overridable.md
+++ b/.changeset/fix-container-padding-overridable.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': patch
+---
+
+Fix Container base styles overriding equal-specificity styled-components. Since Container migrated to CSS Modules, its base rule beat any `styled(Container)` override of layout properties like `padding` and `gap` (e.g. a downstream `styled(Flyout.Header)` padding override was silently dropped). The base rule is now scoped with `:where()` so modifier classes and consumer overrides win without a specificity hack, and the temporary `&&` workaround in Flyout has been removed.

--- a/src/components/Container/Container.module.css
+++ b/src/components/Container/Container.module.css
@@ -1,4 +1,8 @@
-.container {
+/* Kept at zero specificity via :where() so that modifier classes (e.g.
+   .container_padding_md) and downstream styled-components overrides on a
+   styled(Container) both win without needing a specificity hack — Container is
+   a CSS Module, whose rules otherwise beat equal-specificity styled-components. */
+:where(.container) {
   /* These props are only emitted as inline custom properties when the
      matching Container prop is set (grow, shrink, fillHeight, minHeight,
      maxHeight, overflow). Custom properties inherit by default, so without

--- a/src/components/Flyout/Flyout.tsx
+++ b/src/components/Flyout/Flyout.tsx
@@ -175,12 +175,10 @@ const FlyoutElement = styled(Container)<{
   max-width: -webkit-fill-available;
   max-width: fill-available;
   max-width: stretch;
-  && {
-    ${({ theme, $type = 'default' }) => `
-      gap: ${theme.click.flyout.space[$type].gap};
-      padding: 0 ${theme.click.flyout.space[$type].content.x};
-    `}
-  }
+  ${({ theme, $type = 'default' }) => `
+    gap: ${theme.click.flyout.space[$type].gap};
+    padding: 0 ${theme.click.flyout.space[$type].content.x};
+  `}
 `;
 
 interface ElementProps extends Omit<
@@ -206,13 +204,11 @@ Flyout.Element = Element;
 const FlyoutHeaderContainer = styled(Container)<{
   $type?: FlyoutType;
 }>`
-  && {
-    ${({ theme, $type = 'default' }) => `
-      row-gap: ${theme.click.flyout.space[$type].content['row-gap']};
-      column-gap: ${theme.click.flyout.space[$type].content['column-gap']};
-      padding: ${theme.click.flyout.space[$type].y} ${theme.click.flyout.space[$type].y} 0 ${theme.click.flyout.space[$type].y};
-    `}
-  }
+  ${({ theme, $type = 'default' }) => `
+    row-gap: ${theme.click.flyout.space[$type].content['row-gap']};
+    column-gap: ${theme.click.flyout.space[$type].content['column-gap']};
+    padding: ${theme.click.flyout.space[$type].y} ${theme.click.flyout.space[$type].y} 0 ${theme.click.flyout.space[$type].y};
+  `}
 `;
 
 const FlyoutTitle = styled(DialogTitle)<{
@@ -359,13 +355,11 @@ Flyout.Body = Body;
 const FlyoutFooter = styled(Container)<{
   type?: FlyoutType;
 }>`
-  && {
-    ${({ theme, type = 'default' }) => `
-      row-gap: ${theme.click.flyout.space[type].content['row-gap']};
-      column-gap: ${theme.click.flyout.space[type].content['column-gap']};
-      padding: ${theme.click.flyout.space[type].y} ${theme.click.flyout.space[type].content.x};
-    `}
-  }
+  ${({ theme, type = 'default' }) => `
+    row-gap: ${theme.click.flyout.space[type].content['row-gap']};
+    column-gap: ${theme.click.flyout.space[type].content['column-gap']};
+    padding: ${theme.click.flyout.space[type].y} ${theme.click.flyout.space[type].content.x};
+  `}
 `;
 
 interface FlyoutButtonProps extends Omit<ButtonProps, 'children'> {


### PR DESCRIPTION
## Problem

After `Container` migrated to CSS Modules, its base `.container` rule started **beating equal-specificity `styled-components` overrides** of layout properties like `padding` and `gap`. CSS Module rules are injected after styled-components in our build, so at the same specificity the module wins.

Two consequences:

1. **Flyout needed an `&&` hack.** In #1095 `Flyout.Element/Header/Footer` had their padding/gap wrapped in `&& { … }` purely to out-specify `.container`. As @gareth-jones noted at the time, this was *"a temporary workaround until we convert the flyout to css."*
2. **Downstream overrides silently broke.** Any consumer doing `styled(Flyout.Header)` / `styled(Container)` to tweak `padding` now loses to `.container`. Concretely, control-plane's sidebar header (`styled(Flyout.Header)` with custom padding) stopped applying on `0.6.2-rc1`, shifting the logo and shrinking the header by 8px:

| | top | bottom | left | right |
|---|---|---|---|---|
| `0.6.1` (consumer override wins) | 16px | 16px | 16px | 8px |
| `0.6.2-rc1` (Flyout `&&` default wins) | 24px | 0 | 24px | 24px |

Converting Flyout to CSS Modules cleans up the hack but does **not** fix consequence (2) — a styled-components consumer would still lose to the CSS-Module `.container`. The fix has to live in `Container`.

## Fix

Scope the `Container` base rule with `:where(.container)` so it sits at **zero specificity**. Modifier classes (`.container_padding_md`, `.container_gap_sm`, …) and consumer `styled(Container)` overrides then win naturally, no specificity hack required. The `&&` workaround in `Flyout` is removed.

**No rendering change** — modifier classes already won over the base by source order, so they keep winning (now by specificity). This only changes what happens when a *consumer* overrides a base layout property: it now works, as it did before the CSS-Modules migration.

## Testing

- `yarn lint:css` / `yarn lint:code` clean (only pre-existing warnings elsewhere)
- `Container` + `Flyout` unit tests pass (8/8)
- Visual-regression baselines should be unaffected (specificity-only change); relying on CI to confirm since they require the Linux runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)