### PR TITLE
fix(Flyout): remove container gap that doubled section spacing

### DIFF
--- a/.changeset/fix-flyout-section-spacing.md
+++ b/.changeset/fix-flyout-section-spacing.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': patch
+---
+
+Fix doubled spacing around Flyout section separators. The `FlyoutContent` container gap stacked on top of the separators' own margins, adding extra padding between the header, body, and footer. Section spacing now matches the design.

--- a/src/components/Flyout/Flyout.tsx
+++ b/src/components/Flyout/Flyout.tsx
@@ -81,7 +81,9 @@ const FlyoutContent = styled(DialogContent)<{
     position: ${$strategy};
     height: ${$strategy === 'relative' ? '100%' : 'auto'};
     padding: 0 ${theme.click.flyout.space[$type].x};
-    gap: ${theme.click.flyout.space[$type].gap};
+    /* Section spacing comes from the separators' own margins (Separator size), not a
+       container gap. A gap here would stack on those margins and double the spacing. */
+    gap: 0;
     box-shadow: ${
       $hasShadow === false
         ? 'none'


### PR DESCRIPTION
## Problem

PR #1095 looked like a typo fix — adding a missing semicolon to the `padding` declaration on `FlyoutContent`:

```diff
- padding: 0 ${theme.click.flyout.space[$type].x}
+ padding: 0 ${theme.click.flyout.space[$type].x};
```

But that "missing" semicolon was load-bearing by absence. Without it, the CSS parser merged the next line into one malformed declaration (`padding: 0 0 gap: 16px;`) and dropped it — so `gap` was never applied. Adding the semicolon **activated a previously-dead `gap: 16px`** on `FlyoutContent` (and `FlyoutContainer`'s `gap: inherit` resolved to 16px too).

The flyout has always spaced its sections via the **separators' own margins** — the header `Separator` (size `lg`) already carries `margin: 16px 0`. So the newly-activated container gap stacked on top of those margins, doubling the spacing around separators from 16px → ~32px. That's the extra padding between the header, body, and footer.

## Fix

Set the `FlyoutContent` gap back to `0`, with a comment so it doesn't get "fixed" a third time.

Verified by rendering the Storybook story and measuring the DOM: spacing around the header separator is now exactly 16px (desc→sep and sep→body), matching the [Figma design](https://www.figma.com/design/mjSci5n5YREyVlvaVjMSDq/Click-UI-Library?node-id=5126-11104).

🤖 Generated with [Claude Code](https://claude.com/claude-code)