### PR TITLE
chore(ContextMenu): migrate residual styled-components to CSS Modules

### DIFF
--- a/.changeset/migrate-contextmenu-to-css-modules.md
+++ b/.changeset/migrate-contextmenu-to-css-modules.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': patch
+---
+
+Migrate ContextMenu from styled-components to css modules with no change in behavior

--- a/src/components/ContextMenu/ContextMenu.module.css
+++ b/src/components/ContextMenu/ContextMenu.module.css
@@ -1,3 +1,10 @@
+/* stylelint-disable custom-property-pattern -- design tokens use camelCase (e.g. genericMenu) */
+
+.trigger:focus-visible {
+  outline: 2px solid var(--click-global-color-outline-default);
+  outline-offset: 2px;
+}
+
 .right-menu-content {
   z-index: 1;
   flex-direction: column;
@@ -25,4 +32,9 @@
 
 .right-menu-content_show-arrow[data-side='right'] .popover-arrow {
   margin-left: 1rem;
+}
+
+.group {
+  width: 100%;
+  border-bottom: 1px solid var(--click-genericMenu-item-color-default-stroke-default);
 }

--- a/src/components/ContextMenu/ContextMenu.tsx
+++ b/src/components/ContextMenu/ContextMenu.tsx
@@ -1,5 +1,4 @@
 import * as RightMenu from '@radix-ui/react-context-menu';
-import { styled } from 'styled-components';
 import {
   ComponentProps,
   ComponentPropsWithRef,
@@ -23,23 +22,17 @@ export const ContextMenu = (props: RightMenu.ContextMenuProps) => (
   <RightMenu.Root {...props} />
 );
 
-const TriggerDiv = styled.div`
-  &:focus-visible {
-    outline: 2px solid ${({ theme }) => theme.click.global.color.outline.default};
-    outline-offset: 2px;
-  }
-`;
-
 const ContextMenuTrigger = forwardRef<HTMLDivElement, RightMenu.ContextMenuTriggerProps>(
-  ({ disabled, ...props }, ref) => {
+  ({ disabled, className, ...props }, ref) => {
     return (
       <RightMenu.Trigger
         asChild
         disabled={disabled}
       >
-        <TriggerDiv
+        <div
           ref={ref}
           {...props}
+          className={cn(styles.trigger, className)}
         />
       </RightMenu.Trigger>
     );
@@ -177,26 +170,20 @@ const ContextMenuContent = ({
 ContextMenuContent.displayName = 'ContextMenuContent';
 ContextMenu.Content = ContextMenuContent;
 
-const RightMenuGroup = styled(RightMenu.Group)`
-  width: 100%;
-  border-bottom: 1px solid
-    ${({ theme }) => theme.click.genericMenu.item.color.default.stroke.default};
-`;
-
-const ContextMenuGroup = (props: RightMenu.ContextMenuGroupProps) => {
-  return <RightMenuGroup {...props} />;
+const ContextMenuGroup = ({ className, ...props }: RightMenu.ContextMenuGroupProps) => {
+  return (
+    <RightMenu.Group
+      {...props}
+      className={cn(styles.group, className)}
+    />
+  );
 };
 
 ContextMenuGroup.displayName = 'ContextMenuGroup';
 ContextMenu.Group = ContextMenuGroup;
 
-const RightMenuSub = styled(RightMenu.Sub)`
-  border-bottom: 1px solid
-    ${({ theme }) => theme.click.genericMenu.item.color.default.stroke.default};
-`;
-
 const ContextMenuSub = ({ ...props }: RightMenu.ContextMenuGroupProps) => {
-  return <RightMenuSub {...props} />;
+  return <RightMenu.Sub {...props} />;
 };
 
 ContextMenuSub.displayName = 'ContextMenuSub';


### PR DESCRIPTION
## Summary

Completes the ContextMenu CSS Modules migration. The GenericMenu-derived parts of ContextMenu were already migrated as part of the GenericMenu cluster PR; this PR migrates the few residual styled-components that remained in `ContextMenu.tsx`:

- `TriggerDiv` (`styled.div`) — `:focus-visible` outline → `.trigger` class
- `RightMenuGroup` (`styled(ContextMenu.Group)`) — width + bottom border → `.group` class
- `RightMenuSub` (`styled(ContextMenu.Sub)`) — bottom border. Radix `Sub` renders no DOM and never accepted `className`, so the rule was inert at runtime; the migrated `<RightMenu.Sub>` preserves that exact (no-op) behavior, so no dead class is emitted.

New classes are appended to the existing `ContextMenu.module.css` and applied with `cn(styles[...], className)` to preserve consumer `className` passthrough, mirroring the already-migrated parts in this file.

## Verification

- `yarn test:visual tests/overlays/genericmenu.spec.ts` passes with zero snapshot regenerations (existing ContextMenu coverage in the GenericMenu overlays spec)
- `yarn test ContextMenu`, `yarn lint:css`, `yarn lint:code`, `yarn format`, `yarn build` all green
- `grep "from 'styled-components'" src/components/ContextMenu/ContextMenu.tsx` is empty

No behavior change.