### PR TITLE
fix(CardSecondary): underline Read More link on hover

### DIFF
--- a/.changeset/cardsecondary-readmore-hover-underline.md
+++ b/.changeset/cardsecondary-readmore-hover-underline.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': patch
+---
+
+Underline the CardSecondary "Read More" link text on hover and focus, matching the Link component's hover styling.

--- a/src/components/CardSecondary/CardSecondary.tsx
+++ b/src/components/CardSecondary/CardSecondary.tsx
@@ -75,6 +75,9 @@ const Wrapper = styled.div<{
     ${LinkIcon} {
       color: ${({ theme }) => theme.click.card.secondary.color.link.hover};
     }
+    ${LinkText} {
+      text-decoration: underline;
+    }
   }
 
   &[aria-disabled='true'],


### PR DESCRIPTION
## What

The CardSecondary "Read More" link changes color on card hover/focus but does not underline. The shared Link component (via `src/styles/linkStyles.ts`) underlines its text on `:hover`/`:focus`. This adds the same underline to CardSecondary's Read More text for design consistency.

## Change

In the `Wrapper`'s `&:hover, :focus` rule, the Read More **text** (`LinkText`) now gets `text-decoration: underline` alongside the existing `color: link.hover`. The chevron icon (`LinkIcon`) is intentionally left without an underline.

This is a minimal, standalone visual fix on the current styled-components CardSecondary — no refactor to the `Link` component, no other changes.

## Verification

- `yarn lint:css` — pass
- `yarn lint:code` — pass (only pre-existing warnings, 0 errors)
- `yarn format` — pass
- `yarn build` — pass

There is no CardSecondary visual-regression spec on the current main, so no VR run applies. This is an intentional visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)