### PR TITLE
fix: stop buttons from accidentally submitting their enclosing form

### DIFF
--- a/.changeset/fix-iconbutton-html-type.md
+++ b/.changeset/fix-iconbutton-html-type.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': patch
+---
+
+ `IconButton` now accepts `htmlType` prop to support native HTML `type` attribute.

--- a/.changeset/fix-iconbutton-html-type.md
+++ b/.changeset/fix-iconbutton-html-type.md
@@ -2,4 +2,12 @@
 '@clickhouse/click-ui': patch
 ---
 
- `IconButton` now accepts `htmlType` prop to support native HTML `type` attribute.
+Fix buttons unintentionally submitting their enclosing `<form>`. A native `<button>` without an explicit `type` defaults to `type="submit"`, so several components triggered form submission when used inside a form.
+
+New `htmlType` escape hatch (for general-purpose action buttons whose visual `type` prop shadows the native attribute):
+
+- `IconButton` now accepts an `htmlType` prop to set the native button `type` (mirrors `Button`).
+
+Internal buttons that are never meant to submit now default to `type="button"` (non-breaking; consumers can still override):
+
+- `ButtonGroup` options

--- a/.changeset/fix-iconbutton-html-type.md
+++ b/.changeset/fix-iconbutton-html-type.md
@@ -7,6 +7,7 @@ Fix buttons unintentionally submitting their enclosing `<form>`. A native `<butt
 New `htmlType` escape hatch (for general-purpose action buttons whose visual `type` prop shadows the native attribute):
 
 - `IconButton` now accepts an `htmlType` prop to set the native button `type` (mirrors `Button`).
+- `SplitButton` now accepts an `htmlType` prop to set the native `type` on its primary action button.
 
 Internal buttons that are never meant to submit now default to `type="button"` (non-breaking; consumers can still override):
 

--- a/.changeset/fix-iconbutton-html-type.md
+++ b/.changeset/fix-iconbutton-html-type.md
@@ -12,3 +12,12 @@ New `htmlType` escape hatch (for general-purpose action buttons whose visual `ty
 Internal buttons that are never meant to submit now default to `type="button"` (non-breaking; consumers can still override):
 
 - `ButtonGroup` options
+- `Alert` dismiss buttons
+- `InputWrapper` icon button
+- `Select` search clear button
+- `DatePicker` calendar title button
+- `FileTabs` close button
+- `CardPromotion` dismiss button
+- `Table` row edit/delete buttons
+- `VerticalStepper` step trigger
+- `CrossButton`

--- a/src/components/Alert/Alert.test.tsx
+++ b/src/components/Alert/Alert.test.tsx
@@ -1,10 +1,28 @@
 import { Alert, AlertProps } from '@/components/Alert';
-import { waitFor } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderCUI } from '@/utils/test-utils';
 
 describe('Alert', () => {
   const renderAlert = (props: AlertProps) => renderCUI(<Alert {...props} />);
+
+  it('renders the dismiss button with type="button" so it does not submit a form', () => {
+    const handleSubmit = vi.fn(e => e.preventDefault());
+    const { getByTestId } = renderCUI(
+      <form onSubmit={handleSubmit}>
+        <Alert
+          text="In a form"
+          dismissible
+        />
+      </form>
+    );
+
+    const dismissButton = getByTestId('click-alert-dismiss-button');
+    expect(dismissButton).toHaveAttribute('type', 'button');
+
+    fireEvent.click(dismissButton);
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
 
   it('given a dismissible alert, should not be visible after dismissing it', async () => {
     const text = 'Test alert component';

--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -133,7 +133,10 @@ export const Alert = ({
       className={cn(wrapperVariants({ state, type }))}
     >
       {dismissible && type === 'banner' && (
-        <button className={styles.alert__dismiss}></button>
+        <button
+          type="button"
+          className={styles.alert__dismiss}
+        ></button>
       )}
       {showIcon && (
         <div className={cn(iconWrapperVariants({ state, size, type }))}>
@@ -151,6 +154,7 @@ export const Alert = ({
       </div>
       {dismissible && (
         <button
+          type="button"
           data-testid="click-alert-dismiss-button"
           onClick={handleDismiss}
           className={styles.alert__dismiss}

--- a/src/components/ButtonGroup/ButtonGroup.test.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.test.tsx
@@ -265,4 +265,27 @@ describe('ButtonGroup', () => {
       expect(getByText('Option 2')).toHaveAttribute('aria-pressed', 'false');
     });
   });
+
+  describe('native button type', () => {
+    it('renders options with type="button" so they do not submit a form', () => {
+      const { getByText } = renderButtonGroup({ options });
+
+      options.forEach(option => {
+        expect(getByText(option.label)).toHaveAttribute('type', 'button');
+      });
+    });
+
+    it('does not submit an enclosing form when an option is clicked', () => {
+      const handleSubmit = vi.fn(e => e.preventDefault());
+      const { getByText } = renderCUI(
+        <form onSubmit={handleSubmit}>
+          <ButtonGroup options={options} />
+        </form>
+      );
+
+      fireEvent.click(getByText('Option 1'));
+
+      expect(handleSubmit).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -128,6 +128,7 @@ export const ButtonGroup = forwardRef<HTMLDivElement, ButtonGroupProps>(
         return (
           <button
             key={value}
+            type="button"
             className={cn(buttonVariants({ type, iconOnly, fillWidth }), optionClassName)}
             aria-pressed={isActive}
             onClick={() => onButtonGroupClickCommonHandler(value)}

--- a/src/components/CardPromotion/CardPromotion.test.tsx
+++ b/src/components/CardPromotion/CardPromotion.test.tsx
@@ -16,5 +16,18 @@ describe('CardPromo Component', () => {
 
       expect(screen.getByText(label)).toBeDefined();
     });
+
+    it('renders the dismiss button with type="button" so it does not submit a form', () => {
+      renderCard({
+        label: 'Dismissible card',
+        icon: 'star',
+        dismissible: true,
+      });
+
+      expect(screen.getByTestId('click-alert-dismiss-button')).toHaveAttribute(
+        'type',
+        'button'
+      );
+    });
   });
 });

--- a/src/components/CardPromotion/CardPromotion.tsx
+++ b/src/components/CardPromotion/CardPromotion.tsx
@@ -86,6 +86,7 @@ export const CardPromotion = ({
 
         {dismissible && (
           <DismissWrapper
+            type="button"
             data-testid="click-alert-dismiss-button"
             onClick={() => setIsVisible(false)}
           >

--- a/src/components/CrossButton/CrossButton.tsx
+++ b/src/components/CrossButton/CrossButton.tsx
@@ -2,7 +2,7 @@ import { styled } from 'styled-components';
 import { EmptyButton } from '@/components/EmptyButton';
 
 export const CrossButton = styled(EmptyButton).attrs<{
-  type?: 'button' | 'submit' | 'reset';
+  type?: React.ButtonHTMLAttributes<HTMLButtonElement>['type'];
 }>(({ type = 'button' }) => ({ type }))`
   padding: ${({ theme }) => theme.click.button.iconButton.sm.space.y}
     ${({ theme }) => theme.click.button.iconButton.sm.space.x};

--- a/src/components/CrossButton/CrossButton.tsx
+++ b/src/components/CrossButton/CrossButton.tsx
@@ -1,7 +1,9 @@
 import { styled } from 'styled-components';
 import { EmptyButton } from '@/components/EmptyButton';
 
-export const CrossButton = styled(EmptyButton)`
+export const CrossButton = styled(EmptyButton).attrs<{
+  type?: 'button' | 'submit' | 'reset';
+}>(({ type = 'button' }) => ({ type }))`
   padding: ${({ theme }) => theme.click.button.iconButton.sm.space.y}
     ${({ theme }) => theme.click.button.iconButton.sm.space.x};
   background: ${({ theme }) =>

--- a/src/components/DatePicker/Common.tsx
+++ b/src/components/DatePicker/Common.tsx
@@ -986,6 +986,7 @@ export const CalendarRenderer = ({
         />
         {view === DAYS && allowYearMonthSelection ? (
           <ClickableTitle
+            type="button"
             ref={el => {
               headerNavRefs.current[1] = el as HTMLButtonElement;
             }}

--- a/src/components/FileTabs/FileTabs.test.tsx
+++ b/src/components/FileTabs/FileTabs.test.tsx
@@ -57,6 +57,11 @@ describe('FileTabs', () => {
     expect(tabElements).toHaveLength(3);
   });
 
+  it('renders close buttons with type="button" so they do not submit a form', () => {
+    const { getByTestId } = renderTabs({});
+    expect(getByTestId('tab-element-0-close')).toHaveAttribute('type', 'button');
+  });
+
   it('should call onSelect on clicking tab', () => {
     const { getByTestId } = renderTabs({});
     const tabElement = getByTestId('tab-element-0');

--- a/src/components/FileTabs/FileTabs.tsx
+++ b/src/components/FileTabs/FileTabs.tsx
@@ -368,6 +368,7 @@ const Tab = ({
       </TabContent>
       <EmptyButton
         as={IconButton}
+        htmlType="button"
         icon="cross"
         onClick={onClose}
         data-type="close"

--- a/src/components/IconButton/IconButton.test.tsx
+++ b/src/components/IconButton/IconButton.test.tsx
@@ -38,4 +38,31 @@ describe('Button', () => {
     expect(counter).toEqual(0);
     expect(button).toBeDisabled();
   });
+
+  describe('Button HTML types', () => {
+    it('should not default to any type when consumer does not specify it, thus behaving as type=submit', () => {
+      const handleSubmit = vi.fn();
+
+      const { getByRole } = renderCUI(
+        <form onSubmit={handleSubmit}>
+          <IconButton icon="user" />
+        </form>
+      );
+
+      const button = getByRole('button');
+
+      expect(handleSubmit).not.toHaveBeenCalled();
+      fireEvent.click(button);
+      expect(handleSubmit).toHaveBeenCalled();
+    });
+
+    it.each(['submit', 'button', 'reset'] as const)(
+      'should use htmlType to set type=%s',
+      type => {
+        const { getByRole } = renderButton({ icon: 'user', htmlType: type });
+        const button = getByRole('button');
+        expect(button).toHaveAttribute('type', type);
+      }
+    );
+  });
 });

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -26,12 +26,13 @@ const iconButtonVariants = cva(styles.iconbutton, {
 });
 
 export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
-  ({ type = 'primary', icon, size, disabled, className, ...props }, ref) => {
+  ({ type = 'primary', htmlType, icon, size, disabled, className, ...props }, ref) => {
     const iconName = icon ? icon.toString() : 'unknown icon';
 
     return (
       <button
         {...props}
+        type={htmlType}
         className={cn(iconButtonVariants({ type, size }), className)}
         disabled={disabled}
         ref={ref}

--- a/src/components/IconButton/IconButton.types.ts
+++ b/src/components/IconButton/IconButton.types.ts
@@ -6,7 +6,12 @@ export type IconButtonSize = 'default' | 'sm' | 'xs';
 export interface IconButtonProps extends HTMLAttributes<HTMLButtonElement> {
   size?: 'default' | 'sm' | 'xs';
   disabled?: boolean;
+  // TODO: The type prop ('primary' | 'secondary' | 'ghost' | 'danger' | 'info') shadows the native <button type="submit|reset|button"> attribute. Since type is destructured before ...props, consumers can never pass type="submit" for form submission. Consider renaming the visual variant prop to variant (consistent with the CSS class names iconbutton_type_primary etc.). This is a public API problem!
+  /** The visual style variant of the button */
   type?: 'primary' | 'secondary' | 'ghost' | 'danger' | 'info';
+  // TODO: A workaround to fix native prop shadowing by the `type` prop. Refactor in the next major update.
+  /** Used for native button type attribute  */
+  htmlType?: React.ButtonHTMLAttributes<HTMLButtonElement>['type'];
   // TODO: The consumer app seem to expect to use other assets
   // this needs to be investigated why it had type IconName
   // or why consumer was doing it wrong

--- a/src/components/InputWrapper/InputWrapper.tsx
+++ b/src/components/InputWrapper/InputWrapper.tsx
@@ -188,6 +188,7 @@ export const IconButton = forwardRef<
 >(({ className, ...props }, ref) => (
   <button
     ref={ref}
+    type="button"
     {...props}
     className={cn(styles['icon-button'], className)}
   />

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -63,6 +63,14 @@ describe('Select', () => {
     expect(queryByText('Content0')).not.toBeNull();
   });
 
+  it('renders the search clear button with type="button" so it does not submit a form', () => {
+    const { queryByText, getByTestId } = renderSelect({ showSearch: true });
+    const selectTrigger = queryByText('Select an option');
+    selectTrigger && fireEvent.click(selectTrigger);
+
+    expect(getByTestId('select-search-close')).toHaveAttribute('type', 'button');
+  });
+
   it('should show error', () => {
     const { queryByText } = renderSelect({
       error: 'Select Error',

--- a/src/components/Select/common/InternalSelect.tsx
+++ b/src/components/Select/common/InternalSelect.tsx
@@ -503,6 +503,7 @@ export const InternalSelect = ({
                   />
                   <SearchClose
                     as={IconButton}
+                    htmlType="button"
                     icon="cross"
                     onClick={clearSearch}
                     data-testid="select-search-close"

--- a/src/components/SplitButton/SplitButton.test.tsx
+++ b/src/components/SplitButton/SplitButton.test.tsx
@@ -7,6 +7,7 @@ import { renderCUI } from '@/utils/test-utils';
 
 interface Props extends DropdownMenuProps {
   disabled?: boolean;
+  htmlType?: React.ButtonHTMLAttributes<HTMLButtonElement>['type'];
 }
 
 const menuItems: Menu[] = [
@@ -188,5 +189,34 @@ describe('SplitButton', () => {
     item && fireEvent.pointerDown(item);
     expect(item).not.toBeNull();
     expect(queryByText('Content2')).not.toBeNull();
+  });
+
+  describe('native button type', () => {
+    it.each(['submit', 'button', 'reset'] as const)(
+      'uses htmlType to set type=%s on the primary button',
+      htmlType => {
+        const { getByText } = renderDropdown({ htmlType });
+        const button = getByText('SplitButton Main Trigger').closest('button');
+        expect(button).toHaveAttribute('type', htmlType);
+      }
+    );
+
+    it('does not submit an enclosing form when htmlType="button"', () => {
+      const handleSubmit = vi.fn(e => e.preventDefault());
+      const { getByText } = renderCUI(
+        <form onSubmit={handleSubmit}>
+          <SplitButton
+            menu={menuItems}
+            htmlType="button"
+          >
+            <div>SplitButton Main Trigger</div>
+          </SplitButton>
+        </form>
+      );
+
+      fireEvent.click(getByText('SplitButton Main Trigger'));
+
+      expect(handleSubmit).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/SplitButton/SplitButton.tsx
+++ b/src/components/SplitButton/SplitButton.tsx
@@ -8,6 +8,7 @@ import { SplitButtonProps, Menu, ButtonType } from './SplitButton.types';
 
 export const SplitButton = ({
   type = 'primary',
+  htmlType,
   disabled,
   menu,
   dir,
@@ -63,6 +64,7 @@ export const SplitButton = ({
           $type={type}
           $fillWidth={fillWidth}
           {...props}
+          type={htmlType}
         >
           <ButtonData
             as={IconWrapper}

--- a/src/components/SplitButton/SplitButton.types.ts
+++ b/src/components/SplitButton/SplitButton.types.ts
@@ -30,7 +30,12 @@ export type Menu = SubMenu | MenuGroup | MenuItem;
 
 export interface SplitButtonProps
   extends DropdownMenuProps, Omit<HTMLAttributes<HTMLButtonElement>, 'dir' | 'style'> {
+  // TODO: The type prop ('primary' | 'secondary') shadows the native <button type="submit|reset|button"> attribute. Since type is destructured before ...props, consumers can never pass type="submit" for form submission. Consider renaming the visual variant prop to variant in the next major. This is a public API problem!
+  /** The visual style variant of the button */
   type?: ButtonType;
+  // TODO: A workaround to fix native prop shadowing by the `type` prop. Refactor in the next major update.
+  /** Used for native button type attribute on the primary action button */
+  htmlType?: React.ButtonHTMLAttributes<HTMLButtonElement>['type'];
   disabled?: boolean;
   fillWidth?: boolean;
   menu: Array<Menu>;

--- a/src/components/Table/Table.test.tsx
+++ b/src/components/Table/Table.test.tsx
@@ -99,6 +99,18 @@ describe('Table', () => {
     expect(onEdit).toBeCalledTimes(1);
   });
 
+  it('renders row action buttons with type="button" so they do not submit a form', () => {
+    const { queryAllByTestId } = renderTable({
+      isSelectable: true,
+      onEdit: vi.fn(),
+      onDelete: vi.fn(),
+    });
+    [
+      ...queryAllByTestId('table-row-edit'),
+      ...queryAllByTestId('table-row-delete'),
+    ].forEach(button => expect(button).toHaveAttribute('type', 'button'));
+  });
+
   it('should resize column width on ArrowRight key press', () => {
     const { queryAllByRole } = renderTable({
       resizableColumns: true,

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -677,6 +677,7 @@ const TableBodyRow = ({
               <EditButton
                 as={IconButton}
                 type="ghost"
+                htmlType="button"
                 disabled={isDisabled || isDeleted || !isEditable}
                 icon="pencil"
                 onClick={onEdit}
@@ -689,6 +690,7 @@ const TableBodyRow = ({
                 disabled={isDisabled || !isDeletable}
                 $isDeleted={isDeleted}
                 type="ghost"
+                htmlType="button"
                 icon="cross"
                 onClick={onDelete}
                 data-testid="table-row-delete"

--- a/src/components/VerticalStepper/VerticalStepper.test.tsx
+++ b/src/components/VerticalStepper/VerticalStepper.test.tsx
@@ -97,6 +97,11 @@ describe('VerticalStepper', () => {
     expect(queryAllByTestId('stepper-value-4')).toHaveLength(0);
   });
 
+  test('step triggers have type="button" so they do not submit a form', () => {
+    const { getByTestId } = renderVerticalStepper({});
+    expect(getByTestId('stepper-1')).toHaveAttribute('type', 'button');
+  });
+
   test('inactive step is disabled', () => {
     const { queryAllByTestId, getByTestId } = renderVerticalStepper({});
 

--- a/src/components/VerticalStepper/VerticalStepper.tsx
+++ b/src/components/VerticalStepper/VerticalStepper.tsx
@@ -182,6 +182,7 @@ const VerticalStep = ({
       $isOpen={isOpen}
     >
       <StepTrigger
+        type="button"
         $status={status}
         disabled={status === 'incomplete' || disabled}
         {...props}


### PR DESCRIPTION
## Summary

A native `<button>` without an explicit `type` defaults to `type="submit"`, so several click-ui components triggered **form submission** when used inside a `<form>` — e.g. clicking a `ButtonGroup` option or an `Alert` dismiss button would submit the surrounding form. This PR fixes that across the library using two strategies:

**`htmlType` escape hatch** — for general-purpose action buttons whose visual `type` prop shadows the native attribute (and where submitting is sometimes legitimate):
- `IconButton` — new `htmlType` prop (mirrors `Button` from #1077)
- `SplitButton` — new `htmlType` prop on its primary action button

**Internal `type="button"` default** — non-breaking, for buttons that should *never* submit (no public-API change):
- `ButtonGroup` options
- `Alert` dismiss buttons
- `InputWrapper` icon button
- `Select` search clear button
- `DatePicker` calendar title button
- `FileTabs` close button
- `CardPromotion` dismiss button
- `Table` row edit/delete buttons
- `VerticalStepper` step trigger
- `CrossButton`

Components rendering via `as={IconButton}` (FileTabs, Table, Select) use `htmlType="button"` rather than `type="button"`, since `type` is IconButton's visual variant — which is exactly why the `htmlType` prop was needed.

## Notes / judgment calls
- `EmptyButton` (the generic styled-button primitive) was left as-is — unlike `CrossButton` it's genuinely general-purpose and could legitimately be a submit button; it already forwards a native `type`.
- `InputWrapper` and `CrossButton` have no existing test suites, so they got the fix but no dedicated test.

## Testing
- Regression tests added to every edited component that has a test suite (type-attribute assertions + "does not submit a form" checks).
- All affected suites pass; `eslint` clean.
- `tsc` shows only 3 **pre-existing** errors in `DatePicker/Common.tsx:944` (a `weekdays`/`weekDays` typo already on `main`) — confirmed present with or without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)