### PR TITLE
fix(datetimerangepicker): fix date comparison so predefined dates get isSelected treatment

### DIFF
--- a/.changeset/frank-windows-raise.md
+++ b/.changeset/frank-windows-raise.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': patch
+---
+
+Fix a `DateTimeRangePicker` bug that caused preselected dates not to be marked as selected under certain situations

--- a/src/components/DatePicker/DateTimeRangePicker.stories.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.stories.tsx
@@ -4,6 +4,8 @@ import { DateRangeListItem, getPredefinedTimePeriodsForDateTimePicker } from './
 import dayjs from 'dayjs';
 import { Text } from '../Text';
 
+const oneHourInMilliseconds = 3600 * 1000;
+
 const meta: Meta<typeof DateTimeRangePicker> = {
   component: DateTimeRangePicker,
   args: {
@@ -271,6 +273,36 @@ export const SetStartAndEndDate: Story = {
         maxRangeLength={args.maxRangeLength}
         onSelectDateRange={args.onSelectDateRange}
         placeholder={args.placeholder}
+        startDate={startDate}
+        shouldShowSeconds={args.shouldShowSeconds}
+      />
+    );
+  },
+};
+
+export const PredefinedTimesWithSetStartAndEndDate: Story = {
+  args: {
+    maxRangeLength: 15,
+  },
+  render: (args: Args) => {
+    const endDate = args.endDate ? new Date(args.endDate) : new Date();
+    const startDate = new Date(endDate.getTime() - oneHourInMilliseconds);
+
+    const futureDatesDisabled = args.futureDatesDisabled ?? true;
+    const predefinedTimesList = getPredefinedTimePeriodsForDateTimePicker();
+
+    return (
+      <DateTimeRangePicker
+        key="default"
+        defaultActiveTab="endDate"
+        endDate={endDate}
+        disabled={args.disabled}
+        futureDatesDisabled={futureDatesDisabled}
+        futureStartDatesDisabled={args.futureStartDatesDisabled}
+        maxRangeLength={args.maxRangeLength}
+        onSelectDateRange={args.onSelectDateRange}
+        placeholder={args.placeholder}
+        predefinedTimesList={predefinedTimesList}
         startDate={startDate}
         shouldShowSeconds={args.shouldShowSeconds}
       />

--- a/src/components/DatePicker/DateTimeRangePicker.test.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.test.tsx
@@ -1175,6 +1175,52 @@ describe('DateTimeRangePicker', () => {
 
       expect(predefinedDateLabel).toBe('Past hour');
     });
+
+    it('marks the predefined range matching the provided start and end dates as selected', async () => {
+      const predefinedTimesList = getPredefinedTimePeriodsForDateTimePicker();
+      const pastHour = predefinedTimesList.find(item => item.label === 'Past hour');
+      if (!pastHour) {
+        throw new Error('expected a "Past hour" predefined range');
+      }
+
+      const { getByTestId } = renderCUI(
+        <DateTimeRangePicker
+          onSelectDateRange={vi.fn()}
+          predefinedTimesList={predefinedTimesList}
+          startDate={new Date(pastHour.dateRange.startDate)}
+          endDate={new Date(pastHour.dateRange.endDate)}
+        />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+
+      expect(getByTestId('Past hour')).toHaveAttribute('data-selected', 'true');
+      expect(getByTestId('Past 15 minutes')).toHaveAttribute('data-selected', 'false');
+    });
+
+    it('marks exactly one predefined range as selected for a matching range', async () => {
+      const predefinedTimesList = getPredefinedTimePeriodsForDateTimePicker();
+      const pastHour = predefinedTimesList.find(item => item.label === 'Past hour');
+      if (!pastHour) {
+        throw new Error('expected a "Past hour" predefined range');
+      }
+
+      const { getByTestId } = renderCUI(
+        <DateTimeRangePicker
+          onSelectDateRange={vi.fn()}
+          predefinedTimesList={predefinedTimesList}
+          startDate={new Date(pastHour.dateRange.startDate)}
+          endDate={new Date(pastHour.dateRange.endDate)}
+        />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+
+      const selected = document.querySelectorAll(
+        '[data-testid="predefined-times-list"] [data-selected="true"]'
+      );
+      expect(selected).toHaveLength(1);
+    });
   });
 
   describe('when configured for the UTC timezone', () => {

--- a/src/components/DatePicker/DateTimeRangePicker.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.tsx
@@ -333,9 +333,9 @@ const PredefinedTimes = ({
 
           const rangeIsSelected =
             selectedEndDate &&
-            selectedEndDate === endDate &&
+            selectedEndDate.getTime() === endDate.getTime() &&
             selectedStartDate &&
-            selectedStartDate === startDate;
+            selectedStartDate.getTime() === startDate.getTime();
 
           return (
             <StyledDropdownItem


### PR DESCRIPTION
The old comparison didn't cause the checkmark to be rendered

<img width="433" height="354" alt="Screenshot 2026-07-02 at 5 53 26 PM" src="https://github.com/user-attachments/assets/e25a2dd7-60a9-4592-8826-20e7a3ff23da" />
