### PR TITLE
feat(EllipsisContent): show Click UI Tooltip on overflow instead of title attribute

### DIFF
--- a/.changeset/ellipsis-content-tooltip.md
+++ b/.changeset/ellipsis-content-tooltip.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': minor
+---
+
+`EllipsisContent` now shows the Click UI `Tooltip` with the full text when its content is truncated, instead of setting the native `title` attribute. Also adds an `asChild` prop to `Tooltip.Trigger` so a caller's own element can be used as the trigger without the default wrapping `div`.

--- a/src/components/EllipsisContent/EllipsisContent.tsx
+++ b/src/components/EllipsisContent/EllipsisContent.tsx
@@ -4,9 +4,11 @@ import {
   ElementType,
   ReactNode,
   forwardRef,
+  useState,
 } from 'react';
 import { mergeRefs } from '@/utils/mergeRefs';
 import { cn } from '@/lib/cva';
+import { Tooltip } from '@/components/Tooltip';
 import styles from './EllipsisContent.module.css';
 
 export interface EllipsisContentProps<T extends ElementType = 'div'> {
@@ -17,7 +19,7 @@ type EllipsisPolymorphicComponent = <T extends ElementType = 'div'>(
   props: Omit<ComponentProps<T>, keyof EllipsisContentProps<T>> & EllipsisContentProps<T>
 ) => ReactNode;
 
-const _EllipsisContent = <T extends ElementType = 'div'>(
+const EllipsisContentComponent = <T extends ElementType = 'div'>(
   {
     component,
     className,
@@ -27,13 +29,17 @@ const _EllipsisContent = <T extends ElementType = 'div'>(
   ref: ComponentPropsWithRef<T>['ref']
 ) => {
   const Component = component ?? 'div';
-  return (
+  const [tooltipContent, setTooltipContent] = useState<string | null>(null);
+
+  const content = (
     <Component
       ref={mergeRefs([
         ref,
         node => {
-          if (node && node.scrollWidth > node.clientWidth) {
-            node.title = node.innerText;
+          if (node) {
+            setTooltipContent(
+              node.scrollWidth > node.clientWidth ? node.innerText : null
+            );
           }
         },
       ])}
@@ -41,6 +47,19 @@ const _EllipsisContent = <T extends ElementType = 'div'>(
       className={cn(styles['ellipsis-content'], className)}
     />
   );
+
+  if (!tooltipContent) {
+    return content;
+  }
+
+  return (
+    <Tooltip>
+      <Tooltip.Trigger asChild>{content}</Tooltip.Trigger>
+      <Tooltip.Content>{tooltipContent}</Tooltip.Content>
+    </Tooltip>
+  );
 };
 
-export const EllipsisContent: EllipsisPolymorphicComponent = forwardRef(_EllipsisContent);
+export const EllipsisContent: EllipsisPolymorphicComponent = forwardRef(
+  EllipsisContentComponent
+);

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,8 +1,8 @@
 import * as RadixTooltip from '@radix-ui/react-tooltip';
-import { CSSProperties, HTMLAttributes } from 'react';
+import { CSSProperties } from 'react';
 import { cn } from '@/lib/cva';
 import { useResolvedPortalContainer } from '@/providers/PortalContext';
-import { TooltipContentProps, TooltipProps } from './Tooltip.types';
+import { TooltipContentProps, TooltipProps, TooltipTriggerProps } from './Tooltip.types';
 import styles from './Tooltip.module.css';
 
 export const Tooltip = ({ children, open, disabled, ...props }: TooltipProps) => {
@@ -16,10 +16,10 @@ export const Tooltip = ({ children, open, disabled, ...props }: TooltipProps) =>
   );
 };
 
-const TooltipTrigger = (props: HTMLAttributes<HTMLDivElement>) => {
+const TooltipTrigger = ({ asChild, children, ...props }: TooltipTriggerProps) => {
   return (
     <RadixTooltip.Trigger asChild>
-      <div {...props} />
+      {asChild ? children : <div {...props}>{children}</div>}
     </RadixTooltip.Trigger>
   );
 };

--- a/src/components/Tooltip/Tooltip.types.ts
+++ b/src/components/Tooltip/Tooltip.types.ts
@@ -1,7 +1,16 @@
 import * as RadixTooltip from '@radix-ui/react-tooltip';
+import { HTMLAttributes } from 'react';
 
 export interface TooltipProps extends RadixTooltip.TooltipProps {
   disabled?: boolean;
+}
+
+export interface TooltipTriggerProps extends HTMLAttributes<HTMLDivElement> {
+  /**
+   * Use the single child element as the trigger instead of wrapping it in a
+   * `div`. The child must forward `ref` and props.
+   */
+  asChild?: boolean;
 }
 
 export interface TooltipContentProps extends RadixTooltip.TooltipContentProps {

--- a/tests/display/ellipsis-content.spec.ts
+++ b/tests/display/ellipsis-content.spec.ts
@@ -44,14 +44,20 @@ describe('EllipsisContent Visual Regression', () => {
     });
 
     it('with child element matches snapshot', async ({ page }) => {
-      await page.goto(getStoryUrl('display-ellipsiscontent--with-child-element', 'light'), {
-        waitUntil: 'networkidle',
-      });
+      await page.goto(
+        getStoryUrl('display-ellipsiscontent--with-child-element', 'light'),
+        {
+          waitUntil: 'networkidle',
+        }
+      );
       const harness = page.locator(harnessLocator).first();
       await expect(harness).toBeVisible({ timeout: 10000 });
-      await expect(harness).toHaveScreenshot('ellipsis-content-with-child-element-light.png', {
-        maxDiffPixels: 100,
-      });
+      await expect(harness).toHaveScreenshot(
+        'ellipsis-content-with-child-element-light.png',
+        {
+          maxDiffPixels: 100,
+        }
+      );
     });
   });
 
@@ -97,34 +103,53 @@ describe('EllipsisContent Visual Regression', () => {
       });
       const harness = page.locator(harnessLocator).first();
       await expect(harness).toBeVisible({ timeout: 10000 });
-      await expect(harness).toHaveScreenshot('ellipsis-content-with-child-element-dark.png', {
-        maxDiffPixels: 100,
-      });
+      await expect(harness).toHaveScreenshot(
+        'ellipsis-content-with-child-element-dark.png',
+        {
+          maxDiffPixels: 100,
+        }
+      );
     });
   });
 
-  describe('Title attribute on overflow (existing behavior)', () => {
-    it('sets the title attribute to the text when it overflows', async ({ page }) => {
+  describe('Tooltip on overflow', () => {
+    const fullText = 'This is a very long line of text that should be truncated';
+
+    // The tooltip panel is portaled by Radix and, once shown, carries both a
+    // data-state and a data-side. The trigger also gets data-state (and the same
+    // inline text), so we key on data-side — which only the content panel has —
+    // to avoid matching the trigger.
+    const tooltipPanel = (page: import('@playwright/test').Page) =>
+      page.locator(
+        '[data-side][data-state="instant-open"], [data-side][data-state="delayed-open"]'
+      );
+
+    it('shows the tooltip with the full text on hover when it overflows', async ({
+      page,
+    }) => {
       await page.goto(getStoryUrl('display-ellipsiscontent--truncated', 'light'), {
         waitUntil: 'networkidle',
       });
-      const content = page
-        .locator(`${harnessLocator} > *`)
-        .first();
-      await expect(content).toHaveAttribute(
-        'title',
-        'This is a very long line of text that should be truncated'
-      );
+      const content = page.locator(`${harnessLocator} > *`).first();
+      // The native title attribute is no longer used; the tooltip replaces it.
+      await expect(content).not.toHaveAttribute('title', /.+/);
+      await content.hover();
+      const panel = tooltipPanel(page);
+      await expect(panel).toBeVisible({ timeout: 10000 });
+      await expect(panel).toContainText(fullText);
     });
 
-    it('does not set the title attribute when text fits', async ({ page }) => {
+    it('does not show a tooltip when the text fits', async ({ page }) => {
       await page.goto(getStoryUrl('display-ellipsiscontent--not-truncated', 'light'), {
         waitUntil: 'networkidle',
       });
-      const content = page
-        .locator(`${harnessLocator} > *`)
-        .first();
+      const content = page.locator(`${harnessLocator} > *`).first();
       await expect(content).not.toHaveAttribute('title', /.+/);
+      await content.hover();
+      // Nothing to open — the trigger is not wrapped in a Tooltip at all.
+      await expect(
+        page.locator('[data-state="instant-open"], [data-state="delayed-open"]')
+      ).toHaveCount(0);
     });
   });
 });


### PR DESCRIPTION
## What

Per @ariser 's request, `EllipsisContent` now shows the Click UI `Tooltip` with the full text when its content is truncated, instead of setting the native `title` attribute.

## Why

The native `title` tooltip is unstyled, slow to appear, and inconsistent with the rest of the design system. Using the Click UI `Tooltip` gives truncated content a styled, on-brand tooltip on hover.

<img width="2266" height="632" alt="CleanShot 2026-07-02 at 16 35 17@2x" src="https://github.com/user-attachments/assets/81437a33-dc23-47ab-b80b-857ce1c85f2d" />

## How

- **`EllipsisContent.tsx`** — the ref still measures `scrollWidth > clientWidth`, but instead of writing `node.title` it stores the overflowing text in state and, when truncated, wraps the element in `<Tooltip>`. Non-truncated content renders bare (identical DOM to before). The inner render fn was renamed to a PascalCase name so `react-hooks/rules-of-hooks` recognizes it as a component now that it uses `useState`.
- **`Tooltip.tsx` / `Tooltip.types.ts`** — added an `asChild` prop to `Tooltip.Trigger`. This is required: the trigger otherwise wraps children in an extra `<div>`, which would break the ellipsis in flex consumers like `IconWrapper` (the `EllipsisContent` element needs to be the direct flex child to shrink and truncate). With `asChild`, the element itself becomes the trigger, keeping the rendered DOM a single element. Backward-compatible — the default path is unchanged.
- **`tests/display/ellipsis-content.spec.ts`** — replaced the "Title attribute on overflow" tests (now invalid) with "Tooltip on overflow": hover a truncated element → the portaled tooltip shows the full text and no `title` is set; non-truncated → no tooltip and no `title`.

## Testing

Ran the affected visual specs in Docker against the committed baselines:

- **EllipsisContent: 10/10 pass** — the 8 static screenshots match existing baselines unchanged (the tooltip is portaled and only appears on hover, so it's visually inert), plus both new behavioral tests. No baselines needed regenerating.
- **Table (a consumer): all pass**, including `long-text-truncated` and `column-level-truncation`.
- **Tooltip: all pass** — the `asChild` addition didn't disturb existing behavior.
- Typecheck / ESLint / Prettier clean.

> Note: CI's affected-specs resolver runs the full visual suite here because `EllipsisContent`/`Tooltip` are shared components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)