### PR TITLE
fix(Table): resize handles no longer render above portaled overlays

### DIFF
--- a/.changeset/fix-table-resizer-z-index.md
+++ b/.changeset/fix-table-resizer-z-index.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': patch
+---
+
+`Table` column resize handles no longer render on top of portaled overlays (dropdowns, flyouts). The handle's positive `z-index` was lifting the delimiter above the page overlay layer; it's redundant for stacking above the header content, so it has been removed.

--- a/src/components/Table/Table.module.css
+++ b/src/components/Table/Table.module.css
@@ -86,9 +86,6 @@
 }
 
 .table__resizer {
-  /* No positive z-index: the resizer is absolutely positioned and the last child of the header, so
-     it already paints above the (statically positioned) header content. A positive z-index instead
-     lifted it above portaled overlays (dropdowns, flyouts), leaving the delimiters bleeding on top. */
   position: absolute;
   top: 0;
   right: 0;

--- a/src/components/Table/Table.module.css
+++ b/src/components/Table/Table.module.css
@@ -86,8 +86,10 @@
 }
 
 .table__resizer {
+  /* No positive z-index: the resizer is absolutely positioned and the last child of the header, so
+     it already paints above the (statically positioned) header content. A positive z-index instead
+     lifted it above portaled overlays (dropdowns, flyouts), leaving the delimiters bleeding on top. */
   position: absolute;
-  z-index: 1;
   top: 0;
   right: 0;
   width: 24px;


### PR DESCRIPTION
## Problem

The `Table` column **resize handles** (the vertical delimiter ticks in the header) render **on top of portaled overlays** — dropdown menus and flyouts that open over the table. Reported from ClickHouse Control-Plane sysadmin:

- A header delimiter cuts through the **Columns** visibility dropdown.
- Delimiter ticks bleed over a **Create service** flyout.

## Root cause

`.table__resizer` carries `z-index: 1`. The handle is `position: absolute` and is the **last child** of the header, so it already paints above the header's (statically positioned) content by paint order — the positive `z-index` is redundant for that. What it *does* do is lift the handle into a stacking level that competes with portaled overlays, so the delimiters win over dropdowns/flyouts.

## Fix

Remove `z-index: 1` from `.table__resizer`. The delimiter still sits above adjacent header content (positioned element paints after static content in the same stacking context), but no longer above overlays.

```diff
 .table__resizer {
   position: absolute;
-  z-index: 1;
   top: 0;
```

## Testing

- `stylelint` clean; existing `Table.test.tsx` (11 tests) pass; `typecheck` clean.
- CSS stacking against overlays isn't meaningfully assertable in jsdom and the isolated Table story has no overlay, so no unit/visual test was added — verified via the reported sysadmin repro (dropdown + flyout no longer occluded by the delimiters).

## Notes

Patch changeset included. Consumers (incl. `apps/web` and sysadmin) pick this up on the next click-ui release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)