### PR TITLE
fix(Button): default htmlType to button to prevent accidental form submission

### DIFF
--- a/.changeset/fix-button-htmltype-default.md
+++ b/.changeset/fix-button-htmltype-default.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': patch
+---
+
+Default `htmlType` to `"button"` on `Button` and `IconButton`. Both components already accepted an `htmlType` prop, but left it undefined by default, so the native `<button>` fell back to the browser's own default of `type="submit"`. Any `Button` or `IconButton` rendered inside a `<form>` without an explicit `htmlType` would submit that form on click. Consumers who want a submit button still set `htmlType="submit"` explicitly.

--- a/.changeset/fix-button-htmltype-default.md
+++ b/.changeset/fix-button-htmltype-default.md
@@ -1,7 +1,7 @@
 ---
-'@clickhouse/click-ui': minor
+'@clickhouse/click-ui': major
 ---
 
 Default `htmlType` to `"button"` on `Button`, `IconButton`, and `SplitButton`. All three already accepted an `htmlType` prop, but left it undefined by default, so the native `<button>` fell back to the browser's own default of `type="submit"`. Any of these rendered inside a `<form>` without an explicit `htmlType` would submit that form on click.
 
-**This is a behavior change, not just a bugfix.** If your app relied on the old (buggy) default-submit behavior — for example a `Button` inside a `<form>` that you expected to submit without ever passing `htmlType="submit"` — set `htmlType="submit"` explicitly to keep that behavior. Marked as a minor release rather than patch because of this risk.
+**Breaking change.** This affects any consumer with a `Button`, `IconButton`, or `SplitButton` inside a `<form>` that relied on the old default-submit behavior — i.e. you never passed `htmlType` and expected a click to submit the form anyway. To keep that behavior, pass `htmlType="submit"` explicitly on the affected button.

--- a/.changeset/fix-button-htmltype-default.md
+++ b/.changeset/fix-button-htmltype-default.md
@@ -1,5 +1,7 @@
 ---
-'@clickhouse/click-ui': patch
+'@clickhouse/click-ui': minor
 ---
 
-Default `htmlType` to `"button"` on `Button` and `IconButton`. Both components already accepted an `htmlType` prop, but left it undefined by default, so the native `<button>` fell back to the browser's own default of `type="submit"`. Any `Button` or `IconButton` rendered inside a `<form>` without an explicit `htmlType` would submit that form on click. Consumers who want a submit button still set `htmlType="submit"` explicitly.
+Default `htmlType` to `"button"` on `Button`, `IconButton`, and `SplitButton`. All three already accepted an `htmlType` prop, but left it undefined by default, so the native `<button>` fell back to the browser's own default of `type="submit"`. Any of these rendered inside a `<form>` without an explicit `htmlType` would submit that form on click.
+
+**This is a behavior change, not just a bugfix.** If your app relied on the old (buggy) default-submit behavior — for example a `Button` inside a `<form>` that you expected to submit without ever passing `htmlType="submit"` — set `htmlType="submit"` explicitly to keep that behavior. Marked as a minor release rather than patch because of this risk.

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -121,7 +121,7 @@ describe('Button', () => {
   });
 
   describe('Button HTML types', () => {
-    it('should not default to any type when consumer does not specify it, thus behaving as type=submit', () => {
+    it('should default to type=button so it does not submit an enclosing form', () => {
       const handleSubmit = vi.fn();
 
       const { getByRole } = renderCUI(
@@ -132,8 +132,23 @@ describe('Button', () => {
 
       const button = getByRole('button');
 
-      expect(handleSubmit).not.toHaveBeenCalled();
+      expect(button).toHaveAttribute('type', 'button');
       fireEvent.click(button);
+      expect(handleSubmit).not.toHaveBeenCalled();
+    });
+
+    it('should submit an enclosing form when htmlType="submit" is set explicitly', () => {
+      const handleSubmit = vi.fn(e => e.preventDefault());
+
+      const { getByRole } = renderCUI(
+        <form onSubmit={handleSubmit}>
+          <Button htmlType="submit" />
+        </form>
+      );
+
+      const button = getByRole('button');
+      fireEvent.click(button);
+
       expect(handleSubmit).toHaveBeenCalled();
     });
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -33,7 +33,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
       type = 'primary',
-      htmlType,
+      htmlType = 'button',
       iconLeft,
       iconRight,
       align = 'center',

--- a/src/components/IconButton/IconButton.test.tsx
+++ b/src/components/IconButton/IconButton.test.tsx
@@ -40,7 +40,7 @@ describe('Button', () => {
   });
 
   describe('Button HTML types', () => {
-    it('should not default to any type when consumer does not specify it, thus behaving as type=submit', () => {
+    it('should default to type=button so it does not submit an enclosing form', () => {
       const handleSubmit = vi.fn();
 
       const { getByRole } = renderCUI(
@@ -51,8 +51,23 @@ describe('Button', () => {
 
       const button = getByRole('button');
 
-      expect(handleSubmit).not.toHaveBeenCalled();
+      expect(button).toHaveAttribute('type', 'button');
       fireEvent.click(button);
+      expect(handleSubmit).not.toHaveBeenCalled();
+    });
+
+    it('should submit an enclosing form when htmlType="submit" is set explicitly', () => {
+      const handleSubmit = vi.fn(e => e.preventDefault());
+
+      const { getByRole } = renderCUI(
+        <form onSubmit={handleSubmit}>
+          <IconButton icon="user" htmlType="submit" />
+        </form>
+      );
+
+      const button = getByRole('button');
+      fireEvent.click(button);
+
       expect(handleSubmit).toHaveBeenCalled();
     });
 

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -26,7 +26,7 @@ const iconButtonVariants = cva(styles.iconbutton, {
 });
 
 export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
-  ({ type = 'primary', htmlType, icon, size, disabled, className, ...props }, ref) => {
+  ({ type = 'primary', htmlType = 'button', icon, size, disabled, className, ...props }, ref) => {
     const iconName = icon ? icon.toString() : 'unknown icon';
 
     return (

--- a/src/components/SplitButton/SplitButton.test.tsx
+++ b/src/components/SplitButton/SplitButton.test.tsx
@@ -201,6 +201,24 @@ describe('SplitButton', () => {
       }
     );
 
+    it('defaults to type=button so it does not submit an enclosing form', () => {
+      const handleSubmit = vi.fn(e => e.preventDefault());
+      const { getByText } = renderCUI(
+        <form onSubmit={handleSubmit}>
+          <SplitButton menu={menuItems}>
+            <div>SplitButton Main Trigger</div>
+          </SplitButton>
+        </form>
+      );
+
+      const button = getByText('SplitButton Main Trigger').closest('button');
+      expect(button).toHaveAttribute('type', 'button');
+
+      fireEvent.click(getByText('SplitButton Main Trigger'));
+
+      expect(handleSubmit).not.toHaveBeenCalled();
+    });
+
     it('does not submit an enclosing form when htmlType="button"', () => {
       const handleSubmit = vi.fn(e => e.preventDefault());
       const { getByText } = renderCUI(
@@ -217,6 +235,24 @@ describe('SplitButton', () => {
       fireEvent.click(getByText('SplitButton Main Trigger'));
 
       expect(handleSubmit).not.toHaveBeenCalled();
+    });
+
+    it('submits an enclosing form when htmlType="submit" is set explicitly', () => {
+      const handleSubmit = vi.fn(e => e.preventDefault());
+      const { getByText } = renderCUI(
+        <form onSubmit={handleSubmit}>
+          <SplitButton
+            menu={menuItems}
+            htmlType="submit"
+          >
+            <div>SplitButton Main Trigger</div>
+          </SplitButton>
+        </form>
+      );
+
+      fireEvent.click(getByText('SplitButton Main Trigger'));
+
+      expect(handleSubmit).toHaveBeenCalled();
     });
   });
 });

--- a/src/components/SplitButton/SplitButton.tsx
+++ b/src/components/SplitButton/SplitButton.tsx
@@ -8,7 +8,7 @@ import { SplitButtonProps, Menu, ButtonType } from './SplitButton.types';
 
 export const SplitButton = ({
   type = 'primary',
-  htmlType,
+  htmlType = 'button',
   disabled,
   menu,
   dir,

--- a/src/components/SplitButton/SplitButton.tsx
+++ b/src/components/SplitButton/SplitButton.tsx
@@ -35,7 +35,7 @@ const primaryVariants = cva(styles['split-button__primary'], {
 
 export const SplitButton = ({
   type = 'primary',
-  htmlType,
+  htmlType = 'button',
   disabled,
   menu,
   dir,


### PR DESCRIPTION
## Why?

A native `<button>` without an explicit `type` defaults to `type="submit"`. `Button`, `IconButton`, and `SplitButton` all accept an `htmlType` prop, but it was never defaulted, so it stayed `undefined` and the browser fell back to `submit`. Any of these rendered inside a `<form>` submits that form on click unless a caller remembers to pass `htmlType="button"`. #1126 added the `htmlType` escape hatch and fixed a bunch of internal button usages, but left this specific default gap open, and the current test suite documents it directly (`Button.test.tsx` / `IconButton.test.tsx` both had a test literally titled "should not default to any type... thus behaving as type=submit").

Closes #1092.

## How?

- Defaulted `htmlType = 'button'` in the destructured props of `Button`, `IconButton`, and `SplitButton`.
- Updated the existing "HTML types" test blocks in `Button`/`IconButton`: the old test asserted the buggy submit-by-default behavior, now it asserts the button does *not* submit by default and that `type="button"` is on the element. Added matching coverage to `SplitButton.test.tsx`, which had no test for the default case at all.
- Added a new test to each component confirming `htmlType="submit"` still submits the form when set explicitly.
- Checked every internal caller that relies on non-submit buttons (`FileTabs`, `Select`'s `InternalSelect`, `Table`) — they already pass `htmlType="button"` explicitly, so this default doesn't change their behavior.
- Bumped the changeset from `patch` to `minor` per @ariser's review: this changes runtime behavior for any consumer who was relying on the old default-submit fallback, so it's not safe to treat as a patch. Called it out explicitly in the changeset body.

## Tickets?

- [#1092](https://github.com/ClickHouse/click-ui/issues/1092)

## Contribution checklist?

- [x] You've done enough research before writing
- [x] You have reviewed the PR
- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] For documentation, guides or references, you've tested the commands

## Security checklist?

- [x] All user inputs are validated and sanitized
- [x] No usage of `dangerouslySetInnerHTML`
- [x] Sensitive data has been identified and is being protected properly
- [x] Build output contains no secrets or API keys

## Preview?

N/A — behavior-only change (default prop value), no visual change. `yarn test` (full suite, 505 tests) and `yarn typecheck` both pass locally.
