### PR TITLE
test(datetimerangepicker): fix flaky visual test by pinning date

### DIFF
--- a/src/components/DatePicker/DateTimeRangePicker.stories.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.stories.tsx
@@ -285,7 +285,9 @@ export const PredefinedTimesWithSetStartAndEndDate: Story = {
     maxRangeLength: 15,
   },
   render: (args: Args) => {
-    const endDate = args.endDate ? new Date(args.endDate) : new Date();
+    const endDate = args.endDate
+      ? new Date(args.endDate)
+      : new Date('July 4, 2026 11:25 AM');
     const startDate = new Date(endDate.getTime() - oneHourInMilliseconds);
 
     const futureDatesDisabled = args.futureDatesDisabled ?? true;


### PR DESCRIPTION
## Why?

- A visual test based off a new storybook story was flaky because it used `new Date()`. The date is now pinned to July 4th, 2026