### PR TITLE
feat(DateRangePicker): add allowOnlyDatesList prop to restrict selectable dates

### DIFF
--- a/.changeset/feat-daterangepicker-allow-only-dates-list.md
+++ b/.changeset/feat-daterangepicker-allow-only-dates-list.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': minor
+---
+
+Add `allowOnlyDatesList` prop to `DateRangePicker` to restrict selectable dates to an allow-list. Dates not in the list are greyed out and disabled, mirroring the existing `DatePicker` behavior. When omitted or empty, selection is unrestricted, and the prop composes with `futureDatesDisabled` and `maxRangeLength`.

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -3,7 +3,12 @@ import { isSameDate, UseCalendarOptions } from '@h6s/calendar';
 import * as Popover from '@radix-ui/react-popover';
 import { styled } from 'styled-components';
 import { Body, CalendarRenderer, DatePickerInput, DateTableCell } from './Common';
-import { shiftFromTimezone, shiftToTimezone, Timezone } from './utils';
+import {
+  isDateNotInAllowList,
+  shiftFromTimezone,
+  shiftToTimezone,
+  Timezone,
+} from './utils';
 import { useResolvedPortalContainer } from '@/providers/PortalContext';
 
 const DAYS_IN_WEEK = 7;
@@ -153,12 +158,7 @@ const Calendar = ({
           const isSelected = shiftedSelected && isSameDate(shiftedSelected, fullDate);
           const isPresent = isSameDate(today, fullDate);
 
-          const isNotAllowed =
-            shiftedAllowList &&
-            shiftedAllowList.length > 0 &&
-            !shiftedAllowList.some((shiftedDate: Date) => {
-              return isSameDate(shiftedDate, fullDate);
-            });
+          const isNotAllowed = isDateNotInAllowList(shiftedAllowList, fullDate);
 
           const isFutureDisabled = futureDatesDisabled && fullDate > today;
           const isDisabled = isNotAllowed || isFutureDisabled;

--- a/src/components/DatePicker/DateRangePicker.stories.tsx
+++ b/src/components/DatePicker/DateRangePicker.stories.tsx
@@ -1,7 +1,10 @@
 import { Args, Meta, StoryObj } from '@storybook/react-vite';
 import dayjs from 'dayjs';
 import { DateRangePicker } from './DateRangePicker';
-import { getPredefinedMonthsForDateRangePicker } from './utils';
+import {
+  getNextNDatesForDatePickerAllowOnlyList,
+  getPredefinedMonthsForDateRangePicker,
+} from './utils';
 import { Text } from '../Text';
 
 const meta: Meta<typeof DateRangePicker> = {
@@ -31,6 +34,32 @@ export const Default: Story = {
     return (
       <DateRangePicker
         key="default"
+        endDate={endDate}
+        disabled={args.disabled}
+        futureDatesDisabled={args.futureDatesDisabled}
+        futureStartDatesDisabled={args.futureStartDatesDisabled}
+        maxRangeLength={args.maxRangeLength}
+        onSelectDateRange={args.onSelectDateRange}
+        placeholder={args.placeholder}
+        startDate={startDate}
+      />
+    );
+  },
+};
+
+export const DateRangePickerAllowOnlyNext30Days: Story = {
+  args: {
+    allowOnlyDatesList: getNextNDatesForDatePickerAllowOnlyList(30),
+    predefinedDatesList: [],
+  },
+  render: (args: Args) => {
+    const endDate = args.endDate ? new Date(args.endDate) : undefined;
+    const startDate = args.startDate ? new Date(args.startDate) : undefined;
+
+    return (
+      <DateRangePicker
+        key="default"
+        allowOnlyDatesList={args.allowOnlyDatesList}
         endDate={endDate}
         disabled={args.disabled}
         futureDatesDisabled={args.futureDatesDisabled}

--- a/src/components/DatePicker/DateRangePicker.test.tsx
+++ b/src/components/DatePicker/DateRangePicker.test.tsx
@@ -190,6 +190,90 @@ describe('DateRangePicker', () => {
       fireEvent.click(await findByText('15'));
       expect(handleSelectDate).toHaveBeenCalled();
     });
+
+    it('disables selecting dates not in allowOnlyDatesList', async () => {
+      const allowOnlyDatesList = [new Date('07-04-2020'), new Date('07-06-2020')];
+      const handleSelectDate = vi.fn();
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+      const { getByTestId, findByText, getByText } = renderCUI(
+        <DateRangePicker
+          allowOnlyDatesList={allowOnlyDatesList}
+          onSelectDateRange={handleSelectDate}
+        />
+      );
+
+      user.click(getByTestId('daterangepicker-input'));
+      // Jul 5 is not in the allow list
+      user.click(await findByText('5'));
+
+      // A disabled date must not be selectable as the start date
+      expect(getByText('start date – end date')).toBeInTheDocument();
+      expect(handleSelectDate).not.toHaveBeenCalled();
+    });
+
+    it('allows selecting an end date that is in allowOnlyDatesList', async () => {
+      const startDate = new Date('07-04-2020');
+      const allowOnlyDatesList = [new Date('07-04-2020'), new Date('07-06-2020')];
+      const handleSelectDate = vi.fn();
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+      const { getByTestId, findByText } = renderCUI(
+        <DateRangePicker
+          allowOnlyDatesList={allowOnlyDatesList}
+          startDate={startDate}
+          onSelectDateRange={handleSelectDate}
+        />
+      );
+
+      user.click(getByTestId('daterangepicker-input'));
+      // Jul 6 is in the allow list
+      fireEvent.click(await findByText('6'));
+
+      const [selectedStart, selectedEnd] = handleSelectDate.mock.lastCall ?? [];
+      expect(selectedStart).toEqual(new Date('2020-07-04 00:00.00'));
+      expect(selectedEnd).toEqual(new Date('2020-07-06 00:00.00'));
+    });
+
+    it('treats an empty allowOnlyDatesList as no restriction', async () => {
+      const handleSelectDate = vi.fn();
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+      const { getByTestId, findByText, getByText } = renderCUI(
+        <DateRangePicker
+          allowOnlyDatesList={[]}
+          onSelectDateRange={handleSelectDate}
+        />
+      );
+
+      user.click(getByTestId('daterangepicker-input'));
+      fireEvent.click(await findByText('10'));
+
+      // With no restriction, Jul 10 is selectable as the start date
+      expect(getByText('Jul 10, 2020')).toBeInTheDocument();
+    });
+
+    it('disables future dates in allowOnlyDatesList when futureDatesDisabled', async () => {
+      // System time is July 4, 2020
+      const allowOnlyDatesList = [new Date('07-04-2020'), new Date('07-06-2020')];
+      const handleSelectDate = vi.fn();
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+
+      const { getByTestId, findByText, getByText } = renderCUI(
+        <DateRangePicker
+          allowOnlyDatesList={allowOnlyDatesList}
+          futureDatesDisabled
+          onSelectDateRange={handleSelectDate}
+        />
+      );
+
+      user.click(getByTestId('daterangepicker-input'));
+      // Jul 6 is in the allow list but is a future date
+      user.click(await findByText('6'));
+
+      expect(getByText('start date – end date')).toBeInTheDocument();
+      expect(handleSelectDate).not.toHaveBeenCalled();
+    });
   });
 
   describe('when a range is already selected and maxRangeLength is set', () => {

--- a/src/components/DatePicker/DateRangePicker.tsx
+++ b/src/components/DatePicker/DateRangePicker.tsx
@@ -6,6 +6,7 @@ import {
   useCallback,
   useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -28,6 +29,7 @@ import {
   formatDateHeader,
   formatSelectedDate,
   shiftFromTimezone,
+  isDateNotInAllowList,
   isDateRangeTheWholeMonth,
   Timezone,
   shiftToTimezone,
@@ -84,6 +86,7 @@ const DateRangeTableCell = styled(DateTableCell)<{
 `;
 
 interface CalendarProps {
+  allowOnlyDatesList?: Array<Date>;
   calendarBody: Body;
   closeDatepicker: () => void;
   futureDatesDisabled: boolean;
@@ -96,6 +99,7 @@ interface CalendarProps {
 }
 
 const Calendar = ({
+  allowOnlyDatesList,
   calendarBody,
   closeDatepicker,
   futureDatesDisabled,
@@ -111,6 +115,12 @@ const Calendar = ({
   const today = shiftToTimezone(new Date(), timezone);
   const shiftedStart = startDate ? shiftToTimezone(startDate, timezone) : undefined;
   const shiftedEnd = endDate ? shiftToTimezone(endDate, timezone) : undefined;
+
+  const shiftedAllowList = useMemo(() => {
+    return allowOnlyDatesList?.map(date => {
+      return shiftToTimezone(date, timezone);
+    });
+  }, [allowOnlyDatesList, timezone]);
 
   const handleMouseOut = (): void => {
     setHoveredDate(undefined);
@@ -144,6 +154,10 @@ const Calendar = ({
             !datesAreWithinMaxRange(shiftedStart, fullDate, maxRangeLength) &&
             fullDate > shiftedStart
           ) {
+            isDisabled = true;
+          }
+
+          if (isDateNotInAllowList(shiftedAllowList, fullDate)) {
             isDisabled = true;
           }
 
@@ -292,6 +306,7 @@ const PredefinedDates = ({
 };
 
 export interface DateRangePickerProps {
+  allowOnlyDatesList?: Array<Date>;
   endDate?: Date;
   disabled?: boolean;
   futureDatesDisabled?: boolean;
@@ -307,6 +322,7 @@ export interface DateRangePickerProps {
 }
 
 export const DateRangePicker = ({
+  allowOnlyDatesList,
   endDate,
   startDate,
   disabled = false,
@@ -478,6 +494,7 @@ export const DateRangePicker = ({
                 >
                   {(body: Body) => (
                     <Calendar
+                      allowOnlyDatesList={allowOnlyDatesList}
                       calendarBody={body}
                       closeDatepicker={closeDatePicker}
                       futureDatesDisabled={futureDatesDisabled}
@@ -502,6 +519,7 @@ export const DateRangePicker = ({
           >
             {(body: Body) => (
               <Calendar
+                allowOnlyDatesList={allowOnlyDatesList}
                 calendarBody={body}
                 closeDatepicker={closeDatePicker}
                 futureDatesDisabled={futureDatesDisabled}

--- a/src/components/DatePicker/utils.test.ts
+++ b/src/components/DatePicker/utils.test.ts
@@ -113,7 +113,9 @@ describe('DatePicker utils', () => {
     it('matches by calendar day, ignoring the time of day', () => {
       const allowList = [new Date('2025-07-04T00:00:00')];
       // Same calendar day, different time — still counts as allowed.
-      expect(isDateNotInAllowList(allowList, new Date('2025-07-04T23:59:59'))).toBe(false);
+      expect(isDateNotInAllowList(allowList, new Date('2025-07-04T23:59:59'))).toBe(
+        false
+      );
     });
   });
 

--- a/src/components/DatePicker/utils.test.ts
+++ b/src/components/DatePicker/utils.test.ts
@@ -5,6 +5,7 @@ import {
   formatSelectedDate,
   formatSelectedDateTime,
   shiftFromTimezone,
+  isDateNotInAllowList,
   isDateRangeTheWholeMonth,
   shiftToTimezone,
 } from './utils';
@@ -87,6 +88,32 @@ describe('DatePicker utils', () => {
         const endDate = new Date('2026-04-30T23:59:59.999Z');
         expect(isDateRangeTheWholeMonth({ startDate, endDate }, 'UTC')).toBeTruthy();
       });
+    });
+  });
+
+  describe('checking if a date is excluded by an allow-list', () => {
+    it('returns false when there is no allow-list (undefined)', () => {
+      expect(isDateNotInAllowList(undefined, new Date('07-04-2025'))).toBe(false);
+    });
+
+    it('returns false when the allow-list is empty', () => {
+      expect(isDateNotInAllowList([], new Date('07-04-2025'))).toBe(false);
+    });
+
+    it('returns false when the date is in the allow-list', () => {
+      const allowList = [new Date('07-04-2025'), new Date('07-06-2025')];
+      expect(isDateNotInAllowList(allowList, new Date('07-06-2025'))).toBe(false);
+    });
+
+    it('returns true when the date is not in the allow-list', () => {
+      const allowList = [new Date('07-04-2025'), new Date('07-06-2025')];
+      expect(isDateNotInAllowList(allowList, new Date('07-05-2025'))).toBe(true);
+    });
+
+    it('matches by calendar day, ignoring the time of day', () => {
+      const allowList = [new Date('2025-07-04T00:00:00')];
+      // Same calendar day, different time — still counts as allowed.
+      expect(isDateNotInAllowList(allowList, new Date('2025-07-04T23:59:59'))).toBe(false);
     });
   });
 

--- a/src/components/DatePicker/utils.ts
+++ b/src/components/DatePicker/utils.ts
@@ -1,3 +1,4 @@
+import { isSameDate } from '@h6s/calendar';
 import { dayjs } from '@/utils/date';
 
 export type Timezone = 'system' | 'UTC';
@@ -179,6 +180,14 @@ export const getNextNDatesForDatePickerAllowOnlyList = (numberOfDays: number): D
     now.add(i, 'day').startOf('day').toDate()
   );
 };
+
+export const isDateNotInAllowList = (
+  allowList: Array<Date> | undefined,
+  date: Date
+): boolean =>
+  !!allowList &&
+  allowList.length > 0 &&
+  !allowList.some(allowedDate => isSameDate(allowedDate, date));
 
 export const datesAreWithinMaxRange = (
   startDate: Date,

--- a/src/components/DatePicker/utils.ts
+++ b/src/components/DatePicker/utils.ts
@@ -185,7 +185,7 @@ export const isDateNotInAllowList = (
   allowList: Array<Date> | undefined,
   date: Date
 ): boolean =>
-  !!allowList &&
+  Array.isArray(allowList) &&
   allowList.length > 0 &&
   !allowList.some(allowedDate => isSameDate(allowedDate, date));
 


### PR DESCRIPTION
## Why?

Consumers need to restrict range selection to a fixed set of allowed days — e.g. "only let the user pick within the next 30 days." The single `DatePicker` already supports this via `allowOnlyDatesList`, but `DateRangePicker` had no equivalent, so range selectors couldn't enforce a lower bound on the selectable window.

This adds the same capability to `DateRangePicker`, mirroring the existing `DatePicker` behavior exactly. The prop is optional and additive — when omitted (or empty), behavior is unchanged, so this is non-breaking.

## How?

- Added an optional `allowOnlyDatesList?: Array<Date>` prop to `DateRangePicker` (and its internal `Calendar`). When set and non-empty, any calendar day **not** in the list is greyed out and disabled.
- Matching is by calendar day via `isSameDate`, so time components are ignored — pass any `Date` on an allowed day.
- The list is timezone-shifted with a `useMemo` (mirrors `DatePicker`) so matching stays correct in UTC mode.
- Composes with the existing constraints rather than replacing them: `futureDatesDisabled` / `futureStartDatesDisabled` cap the top, `maxRangeLength` caps the span, and the allow-list adds the lower bound.
- An empty array is treated as "no restriction" (same as `undefined`), matching `DatePicker`.
- Extracted the shared "not in allow-list" predicate into an `isDateNotInAllowList(allowList, date)` helper in `utils.ts`, and wired **both `DateRangePicker` and the existing `DatePicker`** to it. `DatePicker` previously had its own inline copy of the same check; sharing one helper keeps the two pickers from drifting apart.
- Passed the prop through at both `<Calendar />` render sites (the predefined-dates path and the full-calendar path).

### Performance — why not a `Set`?

The allow-list membership test is a linear `.some()` scan (via `isDateNotInAllowList`), run once per rendered day cell. We considered building a `Set` of day-keys for O(1) lookups instead, but **deliberately kept the linear scan for consistency with the existing `DatePicker`**, which uses the same `isSameDate` / `.some()` matching. For realistic allow-lists (tens of dates) the two are indistinguishable in practice, and keeping both pickers on the same approach is easier to reason about and maintain. The `Set` optimization can be revisited if a real use case ever passes a large allow-list.

## Tickets?

N/A

## Contribution checklist?

- [x] You've done enough research before writing
- [x] You have reviewed the PR
- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [x] Assets or static content are linked and stored in the project
- [x] For documentation, guides or references, you've tested the commands

## Security checklist?

- [x] All user inputs are validated and sanitized
- [x] No usage of `dangerouslySetInnerHTML`
- [x] Sensitive data has been identified and is being protected properly
- [x] Build output contains no secrets or API keys

## Preview?

Verified in Storybook → **Display → DateRangePicker → "Date Range Picker Allow Only Next 30 Days"** — open the picker and confirm every day outside the next 30 is greyed out and unselectable.

```tsx
<DateRangePicker
  allowOnlyDatesList={getNextNDatesForDatePickerAllowOnlyList(30)}
  onSelectDateRange={(start, end) => console.log(start, end)}
/>
```

Validation run locally (all green):

- `tsc --noEmit` — no type errors
- `eslint` on the changed files — clean
- `vitest run` — DateRangePicker (28) + DatePicker (25) + utils (26) suites pass
- `yarn build` — dist output health check passes

### Changed files

- `src/components/DatePicker/DateRangePicker.tsx` — new prop, memoized allow-list, disable logic, prop threaded to both `Calendar` render sites
- `src/components/DatePicker/DatePicker.tsx` — swapped its inline allow-list check for the shared `isDateNotInAllowList` helper (no behavior change)
- `src/components/DatePicker/utils.ts` — new `isDateNotInAllowList` helper, shared by both pickers
- `src/components/DatePicker/DateRangePicker.test.tsx` — 4 tests (disallowed date disabled, allowed range selectable, empty list = no restriction, allow-list + `futureDatesDisabled` composition)
- `src/components/DatePicker/DateRangePicker.stories.tsx` — `DateRangePickerAllowOnlyNext30Days` story
- `.changeset/feat-daterangepicker-allow-only-dates-list.md` — minor bump
