### PR TITLE
feat(css): adopt clickui cascade layers for predictable overrides

### DIFF
--- a/.changeset/feat-clickui-cascade-layers.md
+++ b/.changeset/feat-clickui-cascade-layers.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': minor
+---
+
+Wrap all component styles in a `clickui` CSS cascade layer for predictable overrides. Any unlayered app style (or a layer you declare after `clickui`) now beats click-ui's styles regardless of stylesheet order or specificity, so consumer overrides no longer depend on bundle order or specificity hacks. Internally this removes the `:where()` bases, doubled-class boosts, and `:not()` specificity chains; rendering is unchanged (verified against the full visual-regression suite). Requires a browser with `@layer` support (Chrome/Edge 99+, Firefox 97+, Safari 15.4+).

--- a/README.md
+++ b/README.md
@@ -191,6 +191,29 @@ Most modern React frameworks support CSS Modules out of the box, including Next.
 
 CSS Modules align naturally with component-level imports. When you import a component like `Button`, its `Button.module.css` is automatically included. If you don't use the component, neither the JavaScript, or CSS will be bundled in your application's output. Only the necessary stylesheets will be included in the output bundle.
 
+#### Overriding styles
+
+All click-ui component styles live in a single CSS [cascade layer](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer) named `clickui`. Cascade layers make overrides predictable: any style you write **outside** a layer — a plain rule, a CSS Module class, or a `styled(...)` override — always beats click-ui's styles, regardless of stylesheet import order or selector specificity. No `!important` or specificity hacks required.
+
+```css
+/* Your app — unlayered, so it always wins over click-ui */
+.my-button {
+  background: hotpink;
+}
+```
+
+If your app organizes its own styles into cascade layers, declare your layer **after** `clickui` so it still takes precedence:
+
+```css
+@layer clickui, app;
+
+@layer app {
+  .my-button {
+    background: hotpink;
+  }
+}
+```
+
 #### Custom Build Configurations
 
 Although most modern React setups have CSS Modules built-in, if your build tool doesn't support it by default, you'll need to configure it.

--- a/plugins/css-colocate/css-preprocess.ts
+++ b/plugins/css-colocate/css-preprocess.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import postcss from 'postcss';
 import postcssModules from 'postcss-modules';
 import { getTempDir, findFiles, generateScopedName } from './utils';
+import { wrapInClickuiLayers } from './postcss-clickui-layers';
 
 export async function preprocessCssModules(rootDir: string): Promise<void> {
   const srcDir = path.join(rootDir, 'src');
@@ -29,6 +30,10 @@ export async function preprocessCssModules(rootDir: string): Promise<void> {
     let classMapping: Record<string, string> = {};
 
     const result = await postcss([
+      // Wrap in the clickui cascade layers first (sees original BEM names),
+      // then scope the class names — matches the vite.config.ts css.postcss
+      // pipeline so per-component dist CSS layers identically to click-ui.css.
+      wrapInClickuiLayers(),
       postcssModules({
         generateScopedName,
         getJSON: (_, json) => {

--- a/plugins/css-colocate/postcss-clickui-layers.test.ts
+++ b/plugins/css-colocate/postcss-clickui-layers.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import postcss from 'postcss';
+import { wrapInClickuiLayers } from './postcss-clickui-layers';
+
+const run = async (css: string): Promise<string> => {
+  const result = await postcss([wrapInClickuiLayers()]).process(css, { from: undefined });
+  return result.css;
+};
+
+const ORDER = '@layer clickui.block, clickui.elem, clickui.mod;';
+
+describe('wrapInClickuiLayers', () => {
+  it('prepends the sub-layer order declaration exactly once', async () => {
+    const out = await run('.alert { color: red; }');
+    expect(out.startsWith(ORDER)).toBe(true);
+    expect(out.match(/@layer clickui\.block, clickui\.elem, clickui\.mod;/g)).toHaveLength(1);
+  });
+
+  it('routes a block rule to clickui.block', async () => {
+    const out = await run('.alert { color: red; }');
+    expect(out).toMatch(/@layer clickui\.block\s*{\s*\.alert\s*{\s*color: red;\s*}\s*}/);
+  });
+
+  it('routes an element rule to clickui.elem', async () => {
+    const out = await run('.alert__icon { width: 1rem; }');
+    expect(out).toMatch(/@layer clickui\.elem\s*{\s*\.alert__icon/);
+  });
+
+  it('routes a modifier rule to clickui.mod', async () => {
+    const out = await run('.alert_type_default { color: blue; }');
+    expect(out).toMatch(/@layer clickui\.mod\s*{\s*\.alert_type_default/);
+  });
+
+  it('routes an element+modifier rule to clickui.mod', async () => {
+    const out = await run('.alert__icon_size_lg { width: 2rem; }');
+    expect(out).toMatch(/@layer clickui\.mod\s*{\s*\.alert__icon_size_lg/);
+  });
+
+  it('routes to mod if any token in a compound selector is a modifier', async () => {
+    const out = await run('.wrapper.wrapper_selectable { cursor: pointer; }');
+    expect(out).toMatch(/@layer clickui\.mod\s*{[^}]*\.wrapper\.wrapper_selectable/);
+  });
+
+  it('keeps a pseudo-state on a block with its block', async () => {
+    const out = await run('.link:hover { color: green; }');
+    expect(out).toMatch(/@layer clickui\.block\s*{\s*\.link:hover/);
+  });
+
+  it('classifies a state via a modifier token inside :not() as mod', async () => {
+    const out = await run('.label:not(.label_error):hover { color: red; }');
+    expect(out).toMatch(/@layer clickui\.mod\s*{[^}]*\.label:not\(\.label_error\):hover/);
+  });
+
+  it('splits a grouped selector that mixes roles into separate layers', async () => {
+    const out = await run('.link, .link_size_xs { color: red; }');
+    expect(out).toMatch(/@layer clickui\.block\s*{\s*\.link\s*{/);
+    expect(out).toMatch(/@layer clickui\.mod\s*{\s*\.link_size_xs\s*{/);
+  });
+
+  it('splits a @media block by the role of its inner rules', async () => {
+    const out = await run(
+      '@media (max-width: 768px) { .container { width: 100%; } .container_responsive { flex-direction: column; } }'
+    );
+    // block-role inner rule under clickui.block, modifier under clickui.mod
+    expect(out).toMatch(/@layer clickui\.block\s*{\s*@media[^{]*{\s*\.container\s*{/);
+    expect(out).toMatch(/@layer clickui\.mod\s*{\s*@media[^{]*{\s*\.container_responsive\s*{/);
+  });
+
+  it('leaves @keyframes unlayered', async () => {
+    const out = await run('@keyframes spin { from { transform: rotate(0); } to { transform: rotate(360deg); } }');
+    expect(out).toContain('@keyframes spin');
+    // keyframes must not be nested inside a clickui.* layer
+    expect(out).not.toMatch(/@layer clickui\.[a-z]+\s*{\s*@keyframes/);
+  });
+
+  it('leaves a classless global rule unlayered', async () => {
+    const out = await run('.form-root { width: 100%; }\nsvg { fill: currentColor; }');
+    // .form-root (has a class) is layered; bare svg is not
+    expect(out).toMatch(/@layer clickui\.block\s*{\s*\.form-root/);
+    expect(out).not.toMatch(/@layer clickui\.[a-z]+\s*{[^}]*svg\s*{\s*fill/);
+  });
+
+  it('is idempotent — running twice does not double-wrap', async () => {
+    const once = await run('.alert { color: red; }');
+    const twice = await run(once);
+    expect(twice).toBe(once);
+  });
+});

--- a/plugins/css-colocate/postcss-clickui-layers.test.ts
+++ b/plugins/css-colocate/postcss-clickui-layers.test.ts
@@ -7,13 +7,15 @@ const run = async (css: string): Promise<string> => {
   return result.css;
 };
 
-const ORDER = '@layer clickui.block, clickui.elem, clickui.mod;';
+const ORDER = '@layer clickui.block, clickui.elem, clickui.mod, clickui.override;';
 
 describe('wrapInClickuiLayers', () => {
   it('prepends the sub-layer order declaration exactly once', async () => {
     const out = await run('.alert { color: red; }');
     expect(out.startsWith(ORDER)).toBe(true);
-    expect(out.match(/@layer clickui\.block, clickui\.elem, clickui\.mod;/g)).toHaveLength(1);
+    expect(
+      out.match(/@layer clickui\.block, clickui\.elem, clickui\.mod, clickui\.override;/g)
+    ).toHaveLength(1);
   });
 
   it('routes a block rule to clickui.block', async () => {
@@ -63,11 +65,15 @@ describe('wrapInClickuiLayers', () => {
     );
     // block-role inner rule under clickui.block, modifier under clickui.mod
     expect(out).toMatch(/@layer clickui\.block\s*{\s*@media[^{]*{\s*\.container\s*{/);
-    expect(out).toMatch(/@layer clickui\.mod\s*{\s*@media[^{]*{\s*\.container_responsive\s*{/);
+    expect(out).toMatch(
+      /@layer clickui\.mod\s*{\s*@media[^{]*{\s*\.container_responsive\s*{/
+    );
   });
 
   it('leaves @keyframes unlayered', async () => {
-    const out = await run('@keyframes spin { from { transform: rotate(0); } to { transform: rotate(360deg); } }');
+    const out = await run(
+      '@keyframes spin { from { transform: rotate(0); } to { transform: rotate(360deg); } }'
+    );
     expect(out).toContain('@keyframes spin');
     // keyframes must not be nested inside a clickui.* layer
     expect(out).not.toMatch(/@layer clickui\.[a-z]+\s*{\s*@keyframes/);
@@ -78,6 +84,18 @@ describe('wrapInClickuiLayers', () => {
     // .form-root (has a class) is layered; bare svg is not
     expect(out).toMatch(/@layer clickui\.block\s*{\s*\.form-root/);
     expect(out).not.toMatch(/@layer clickui\.[a-z]+\s*{[^}]*svg\s*{\s*fill/);
+  });
+
+  it('routes an annotated rule to clickui.override regardless of class name', async () => {
+    const out = await run('/* @clickui-layer override */\n.body { width: 20rem; }');
+    expect(out).toMatch(/@layer clickui\.override\s*{[^}]*\.body\s*{/);
+    // and NOT in the block layer despite being a block-role name
+    expect(out).not.toMatch(/@layer clickui\.block\s*{[^}]*\.body\s*{/);
+  });
+
+  it('honors an override annotation on an element/descendant selector', async () => {
+    const out = await run('/* @clickui-layer override */\n.header h3 { color: red; }');
+    expect(out).toMatch(/@layer clickui\.override\s*{[^}]*\.header h3\s*{/);
   });
 
   it('is idempotent — running twice does not double-wrap', async () => {

--- a/plugins/css-colocate/postcss-clickui-layers.ts
+++ b/plugins/css-colocate/postcss-clickui-layers.ts
@@ -1,0 +1,218 @@
+import { AtRule, Comment, Rule, type ChildNode, type Container, type Plugin } from 'postcss';
+
+/**
+ * PostCSS plugin: wrap every click-ui component rule in a nested set of BEM
+ * cascade layers so overrides are predictable without specificity hacks.
+ *
+ *   @layer clickui.block, clickui.elem, clickui.mod;
+ *   @layer clickui.block { .alert { … } }
+ *   @layer clickui.elem  { .alert__icon { … } }
+ *   @layer clickui.mod   { .alert_type_default { … } }
+ *
+ * Layer precedence is `unlayered > last-declared layer > … > first-declared`,
+ * and specificity only matters *within* a layer. Ordering the sub-layers
+ * `block → elem → mod` (mod last = highest) buys two guarantees:
+ *
+ *  1. A modifier always resolves above the block/element it modifies — from
+ *     layer order, not specificity — so internal specificity hacks (`:where()`
+ *     bases, doubled classes, `:not()` chains) are no longer needed.
+ *  2. Any unlayered consumer style (an app rule, or a `styled(Component)`
+ *     override) beats every `clickui.*` layer, with zero configuration.
+ *
+ * The public contract is just the top-level `clickui` layer; `block`/`elem`/
+ * `mod` are an internal implementation detail.
+ *
+ * Must run BEFORE CSS-Modules name scoping so it classifies the original BEM
+ * class names (in both pipelines it is ordered ahead of postcss-modules).
+ */
+
+const TOP_LAYER = 'clickui';
+const ROLES = ['block', 'elem', 'mod'] as const;
+type Role = (typeof ROLES)[number];
+
+/** The order declaration that fixes sub-layer precedence, emitted once per file. */
+const ORDER_PARAMS = ROLES.map(r => `${TOP_LAYER}.${r}`).join(', ');
+
+/**
+ * Classify a single BEM local class name.
+ *
+ * click-ui naming uses three separators: `__` = element, single `_` =
+ * modifier (`_key_value`), `-` = word within a name. So after neutralizing the
+ * element separators, a remaining `_` means "modifier"; otherwise the presence
+ * of `__` means "element"; otherwise it is a block. (The stylelint
+ * `selector-class-pattern` rule enforces that `_` is only ever a modifier
+ * separator, which is what makes this heuristic reliable.)
+ */
+function classRole(local: string): Role {
+  const noElemSep = local.split('__').join('·');
+  if (noElemSep.includes('_')) return 'mod';
+  return local.includes('__') ? 'elem' : 'block';
+}
+
+/** Extract the `.class` tokens from a selector (ignores elements/pseudos/attrs). */
+function classTokens(selector: string): string[] {
+  return (selector.match(/\.[a-zA-Z0-9_-]+/g) ?? []).map((token: string) => token.slice(1));
+}
+
+/**
+ * Role for one comma-free selector: `mod` if ANY class token is a modifier,
+ * else `elem` if any targets an element, else `block`. Returns null when the
+ * selector has no class token at all (global/element rule → left unlayered).
+ */
+function selectorRole(selector: string): Role | null {
+  const roles = classTokens(selector).map(classRole);
+  if (roles.length === 0) return null;
+  if (roles.includes('mod')) return 'mod';
+  if (roles.includes('elem')) return 'elem';
+  return 'block';
+}
+
+/** Split a selector list on top-level commas (commas inside `:not(…)` are kept). */
+function splitSelectorList(selector: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = '';
+  for (const char of selector) {
+    if (char === '(') depth++;
+    else if (char === ')') depth--;
+    if (char === ',' && depth === 0) {
+      parts.push(current);
+      current = '';
+    } else {
+      current += char;
+    }
+  }
+  parts.push(current);
+  return parts.map(part => part.trim()).filter(Boolean);
+}
+
+/** Conditional group at-rules whose children participate in the cascade. */
+const CONDITIONAL_AT_RULES = new Set(['media', 'supports', 'container']);
+
+type Buckets = { block: ChildNode[]; elem: ChildNode[]; mod: ChildNode[]; unlayered: ChildNode[] };
+
+const emptyBuckets = (): Buckets => ({ block: [], elem: [], mod: [], unlayered: [] });
+
+/**
+ * Sort the children of a container into block/elem/mod/unlayered buckets.
+ * Leading comments travel with the next rule they annotate.
+ */
+function bucketize(nodes: ChildNode[]): Buckets {
+  const buckets = emptyBuckets();
+  let pendingComments: Comment[] = [];
+
+  const flushInto = (target: ChildNode[]) => {
+    target.push(...pendingComments.map(comment => comment.clone()));
+    pendingComments = [];
+  };
+
+  for (const node of nodes) {
+    if (node.type === 'comment') {
+      pendingComments.push(node as Comment);
+      continue;
+    }
+
+    if (node.type === 'rule') {
+      const rule = node as Rule;
+      // Group this rule's selectors by role, splitting a mixed-role list so
+      // each part lands in its own layer (`.link, .link_size_xs` → two rules).
+      const byRole = new Map<Role | 'unlayered', string[]>();
+      for (const selector of splitSelectorList(rule.selector)) {
+        const role = selectorRole(selector) ?? 'unlayered';
+        const list = byRole.get(role) ?? [];
+        list.push(selector);
+        byRole.set(role, list);
+      }
+
+      let first = true;
+      // Deterministic order so a split rule reads block → elem → mod.
+      for (const role of ['block', 'elem', 'mod', 'unlayered'] as const) {
+        const selectors = byRole.get(role);
+        if (!selectors) continue;
+        const clone = rule.clone();
+        clone.selector = selectors.join(',\n');
+        const target = buckets[role];
+        if (first) flushInto(target);
+        target.push(clone);
+        first = false;
+      }
+      continue;
+    }
+
+    if (node.type === 'atrule') {
+      const atRule = node as AtRule;
+      if (CONDITIONAL_AT_RULES.has(atRule.name.toLowerCase())) {
+        // Classify by inner rules; a conditional block may appear in several
+        // layers, each carrying only the children of that role.
+        const inner = bucketize((atRule.nodes ?? []) as ChildNode[]);
+        let first = true;
+        for (const role of ['block', 'elem', 'mod', 'unlayered'] as const) {
+          if (inner[role].length === 0) continue;
+          const clone = atRule.clone();
+          clone.removeAll();
+          clone.append(...inner[role]);
+          const target = buckets[role];
+          if (first) flushInto(target);
+          target.push(clone);
+          first = false;
+        }
+      } else {
+        // @keyframes / @font-face / @property / etc. — not class rules, leave
+        // them unlayered so their behavior is untouched.
+        flushInto(buckets.unlayered);
+        buckets.unlayered.push(atRule.clone());
+      }
+      continue;
+    }
+
+    // Anything else (bare declarations, etc.) — keep unlayered.
+    flushInto(buckets.unlayered);
+    buckets.unlayered.push(node.clone());
+  }
+
+  // Trailing comments with no following rule.
+  flushInto(buckets.unlayered);
+  return buckets;
+}
+
+export function wrapInClickuiLayers(): Plugin {
+  return {
+    postcssPlugin: 'postcss-clickui-layers',
+    Once(root) {
+      // Idempotency guard: skip a root that is already layered.
+      const firstAtRule = root.first;
+      if (
+        firstAtRule?.type === 'atrule' &&
+        (firstAtRule as AtRule).name === 'layer' &&
+        (firstAtRule as AtRule).params === ORDER_PARAMS
+      ) {
+        return;
+      }
+
+      const buckets = bucketize(root.nodes as ChildNode[]);
+      root.removeAll();
+
+      // 1. Order declaration first — fixes sub-layer precedence by first mention,
+      //    idempotent across the many files concatenated into click-ui.css.
+      root.append(new AtRule({ name: 'layer', params: ORDER_PARAMS }));
+
+      // 2. Unlayered nodes (keyframes, globals) — order among these is preserved.
+      const appendInto = (container: Container, nodes: ChildNode[]) => {
+        for (const node of nodes) container.append(node);
+      };
+      appendInto(root, buckets.unlayered);
+
+      // 3. One `@layer clickui.<role> { … }` block per non-empty role.
+      for (const role of ROLES) {
+        if (buckets[role].length === 0) continue;
+        const layer = new AtRule({ name: 'layer', params: `${TOP_LAYER}.${role}` });
+        appendInto(layer, buckets[role]);
+        root.append(layer);
+      }
+    },
+  };
+}
+
+wrapInClickuiLayers.postcss = true;
+
+export default wrapInClickuiLayers;

--- a/plugins/css-colocate/postcss-clickui-layers.ts
+++ b/plugins/css-colocate/postcss-clickui-layers.ts
@@ -1,10 +1,17 @@
-import { AtRule, Comment, Rule, type ChildNode, type Container, type Plugin } from 'postcss';
+import {
+  AtRule,
+  Comment,
+  Rule,
+  type ChildNode,
+  type Container,
+  type Plugin,
+} from 'postcss';
 
 /**
  * PostCSS plugin: wrap every click-ui component rule in a nested set of BEM
  * cascade layers so overrides are predictable without specificity hacks.
  *
- *   @layer clickui.block, clickui.elem, clickui.mod;
+ *   @layer clickui.block, clickui.elem, clickui.mod, clickui.override;
  *   @layer clickui.block { .alert { … } }
  *   @layer clickui.elem  { .alert__icon { … } }
  *   @layer clickui.mod   { .alert_type_default { … } }
@@ -19,19 +26,45 @@ import { AtRule, Comment, Rule, type ChildNode, type Container, type Plugin } fr
  *  2. Any unlayered consumer style (an app rule, or a `styled(Component)`
  *     override) beats every `clickui.*` layer, with zero configuration.
  *
- * The public contract is just the top-level `clickui` layer; `block`/`elem`/
- * `mod` are an internal implementation detail.
+ * The highest sub-layer, `clickui.override`, is not derived from a class name;
+ * a rule opts in with a `/* @clickui-layer override *​/` comment. It is for the
+ * rare case where one click-ui component composes another and must override the
+ * composed component's own block/elem/mod rules on the same node (which the
+ * block/elem/mod order alone can't express). It still sits below unlayered
+ * styles, so consumer overrides keep winning.
+ *
+ * The public contract is just the top-level `clickui` layer; the sub-layers are
+ * an internal implementation detail.
  *
  * Must run BEFORE CSS-Modules name scoping so it classifies the original BEM
  * class names (in both pipelines it is ordered ahead of postcss-modules).
  */
 
 const TOP_LAYER = 'clickui';
-const ROLES = ['block', 'elem', 'mod'] as const;
-type Role = (typeof ROLES)[number];
+// Name-based classification yields block | elem | mod. `override` is the
+// highest internal sub-layer and is reachable ONLY via an explicit
+// `/* @clickui-layer override */` annotation — for a click-ui rule that
+// intentionally overrides a DIFFERENT click-ui component composed on the same
+// node (e.g. Flyout.Body overriding Container's width, DatePicker overriding a
+// Panel modifier). The block/elem/mod order can't express that cross-component
+// precedence, but `override` still sits below any unlayered consumer style, so
+// consumer overrides keep winning.
+const SUBLAYERS = ['block', 'elem', 'mod', 'override'] as const;
+type Layer = (typeof SUBLAYERS)[number];
 
 /** The order declaration that fixes sub-layer precedence, emitted once per file. */
-const ORDER_PARAMS = ROLES.map(r => `${TOP_LAYER}.${r}`).join(', ');
+const ORDER_PARAMS = SUBLAYERS.map(l => `${TOP_LAYER}.${l}`).join(', ');
+
+/** `/* @clickui-layer <layer> *​/` forces the next rule into that sub-layer. */
+const LAYER_ANNOTATION = /@clickui-layer\s+(block|elem|mod|override)\b/;
+
+const annotatedLayer = (comments: Comment[]): Layer | null => {
+  for (const comment of comments) {
+    const match = comment.text.match(LAYER_ANNOTATION);
+    if (match) return match[1] as Layer;
+  }
+  return null;
+};
 
 /**
  * Classify a single BEM local class name.
@@ -43,7 +76,7 @@ const ORDER_PARAMS = ROLES.map(r => `${TOP_LAYER}.${r}`).join(', ');
  * `selector-class-pattern` rule enforces that `_` is only ever a modifier
  * separator, which is what makes this heuristic reliable.)
  */
-function classRole(local: string): Role {
+function classRole(local: string): Layer {
   const noElemSep = local.split('__').join('·');
   if (noElemSep.includes('_')) return 'mod';
   return local.includes('__') ? 'elem' : 'block';
@@ -51,7 +84,9 @@ function classRole(local: string): Role {
 
 /** Extract the `.class` tokens from a selector (ignores elements/pseudos/attrs). */
 function classTokens(selector: string): string[] {
-  return (selector.match(/\.[a-zA-Z0-9_-]+/g) ?? []).map((token: string) => token.slice(1));
+  return (selector.match(/\.[a-zA-Z0-9_-]+/g) ?? []).map((token: string) =>
+    token.slice(1)
+  );
 }
 
 /**
@@ -59,7 +94,7 @@ function classTokens(selector: string): string[] {
  * else `elem` if any targets an element, else `block`. Returns null when the
  * selector has no class token at all (global/element rule → left unlayered).
  */
-function selectorRole(selector: string): Role | null {
+function selectorRole(selector: string): Layer | null {
   const roles = classTokens(selector).map(classRole);
   if (roles.length === 0) return null;
   if (roles.includes('mod')) return 'mod';
@@ -89,9 +124,19 @@ function splitSelectorList(selector: string): string[] {
 /** Conditional group at-rules whose children participate in the cascade. */
 const CONDITIONAL_AT_RULES = new Set(['media', 'supports', 'container']);
 
-type Buckets = { block: ChildNode[]; elem: ChildNode[]; mod: ChildNode[]; unlayered: ChildNode[] };
+type Bucket = Layer | 'unlayered';
+type Buckets = Record<Bucket, ChildNode[]>;
 
-const emptyBuckets = (): Buckets => ({ block: [], elem: [], mod: [], unlayered: [] });
+// block → elem → mod → override → unlayered; drives both split order and output.
+const BUCKET_ORDER: Bucket[] = ['block', 'elem', 'mod', 'override', 'unlayered'];
+
+const emptyBuckets = (): Buckets => ({
+  block: [],
+  elem: [],
+  mod: [],
+  override: [],
+  unlayered: [],
+});
 
 /**
  * Sort the children of a container into block/elem/mod/unlayered buckets.
@@ -114,9 +159,20 @@ function bucketize(nodes: ChildNode[]): Buckets {
 
     if (node.type === 'rule') {
       const rule = node as Rule;
+
+      // An explicit annotation forces the whole rule into one sub-layer,
+      // overriding name-based classification (used for cross-component
+      // overrides the block/elem/mod order can't express).
+      const forced = annotatedLayer(pendingComments);
+      if (forced) {
+        flushInto(buckets[forced]);
+        buckets[forced].push(rule.clone());
+        continue;
+      }
+
       // Group this rule's selectors by role, splitting a mixed-role list so
       // each part lands in its own layer (`.link, .link_size_xs` → two rules).
-      const byRole = new Map<Role | 'unlayered', string[]>();
+      const byRole = new Map<Bucket, string[]>();
       for (const selector of splitSelectorList(rule.selector)) {
         const role = selectorRole(selector) ?? 'unlayered';
         const list = byRole.get(role) ?? [];
@@ -126,7 +182,7 @@ function bucketize(nodes: ChildNode[]): Buckets {
 
       let first = true;
       // Deterministic order so a split rule reads block → elem → mod.
-      for (const role of ['block', 'elem', 'mod', 'unlayered'] as const) {
+      for (const role of BUCKET_ORDER) {
         const selectors = byRole.get(role);
         if (!selectors) continue;
         const clone = rule.clone();
@@ -146,7 +202,7 @@ function bucketize(nodes: ChildNode[]): Buckets {
         // layers, each carrying only the children of that role.
         const inner = bucketize((atRule.nodes ?? []) as ChildNode[]);
         let first = true;
-        for (const role of ['block', 'elem', 'mod', 'unlayered'] as const) {
+        for (const role of BUCKET_ORDER) {
           if (inner[role].length === 0) continue;
           const clone = atRule.clone();
           clone.removeAll();
@@ -202,12 +258,12 @@ export function wrapInClickuiLayers(): Plugin {
       };
       appendInto(root, buckets.unlayered);
 
-      // 3. One `@layer clickui.<role> { … }` block per non-empty role.
-      for (const role of ROLES) {
-        if (buckets[role].length === 0) continue;
-        const layer = new AtRule({ name: 'layer', params: `${TOP_LAYER}.${role}` });
-        appendInto(layer, buckets[role]);
-        root.append(layer);
+      // 3. One `@layer clickui.<layer> { … }` block per non-empty sub-layer.
+      for (const layer of SUBLAYERS) {
+        if (buckets[layer].length === 0) continue;
+        const layerNode = new AtRule({ name: 'layer', params: `${TOP_LAYER}.${layer}` });
+        appendInto(layerNode, buckets[layer]);
+        root.append(layerNode);
       }
     },
   };

--- a/src/components/Badge/Badge.module.css
+++ b/src/components/Badge/Badge.module.css
@@ -131,102 +131,90 @@
    opaque-text-* tokens, and dimensions are always md, regardless of the
    badge's actual `type`/`size`.
 
-   The doubled-class selectors below (e.g. `.badgecontent.badgecontent svg`)
-   raise specificity to (0,2,1) so these rules win over the Icon component's
-   own runtime-injected styled-components rule `.<sc-class> svg { width: ... }`
-   (specificity 0,1,1). styled-components used to inject the BadgeContent
-   stylesheet AFTER Icon's stylesheet at render time, so source order let
-   BadgeContent win at equal specificity; CSS Modules now bundle Badge's
-   stylesheet earlier than the runtime SC stylesheet, so we need the bump. */
-
-/* stylelint-disable no-descending-specificity -- doubled-class selectors below
-   raise specificity so they win over the Icon component's runtime-injected
-   styled-components `& svg` rule. */
+   Badge composes an <Icon>; these rules override the Icon's own svg styling on
+   the same nodes. The svg sizing overrides Icon's size modifier (a clickui.mod
+   rule), so it uses @clickui-layer override to win by layer order; the per-state
+   svg color rules land in clickui.mod, above Icon's block-layer svg color. */
 
 .badgecontent {
   width: auto;
   overflow: hidden;
 }
 
-.badgecontent.badgecontent svg {
+/* @clickui-layer override */
+.badgecontent svg {
   width: var(--click-badge-icon-md-size-width);
   height: var(--click-badge-icon-md-size-height);
   gap: inherit;
 }
 
-.badgecontent_state_default.badgecontent_state_default svg {
+.badgecontent_state_default svg {
   color: var(--click-badge-opaque-color-text-default);
 }
 
-.badgecontent_state_success.badgecontent_state_success svg {
+.badgecontent_state_success svg {
   color: var(--click-badge-opaque-color-text-success);
 }
 
-.badgecontent_state_neutral.badgecontent_state_neutral svg {
+.badgecontent_state_neutral svg {
   color: var(--click-badge-opaque-color-text-neutral);
 }
 
-.badgecontent_state_danger.badgecontent_state_danger svg {
+.badgecontent_state_danger svg {
   color: var(--click-badge-opaque-color-text-danger);
 }
 
-.badgecontent_state_disabled.badgecontent_state_disabled svg {
+.badgecontent_state_disabled svg {
   color: var(--click-badge-opaque-color-text-disabled);
 }
 
-.badgecontent_state_warning.badgecontent_state_warning svg {
+.badgecontent_state_warning svg {
   color: var(--click-badge-opaque-color-text-warning);
 }
 
-.badgecontent_state_info.badgecontent_state_info svg {
+.badgecontent_state_info svg {
   color: var(--click-badge-opaque-color-text-info);
 }
-
-/* stylelint-enable no-descending-specificity */
 
 /* Close icon — mirrors the SvgContainer styled.svg with as={Icon}. The
    styled-components version only passed $state (size and type defaulted),
    so width/height come from the default md/opaque tokens, and color from
    the opaque-text-<state> token.
 
-   The state classes below use doubled-class specificity (0,2,1) so they
-   always win over Icon's internal `SvgWrapper` styled-component rule that
-   sets `color: currentColor` on the same element at single-class specificity.
-   Without the bump, stylesheet-order would decide and CSS Modules bundle
-   before runtime SC styles, so the close icon would inherit the wrapper's
-   color (e.g. opaque-text-info for an info badge, but solid-text-info for
-   a solid info badge). Doubled class keeps the close icon on opaque-text-*
-   regardless. */
+   The state classes below land in the `clickui.mod` layer, so they win over
+   Icon's internal `SvgWrapper` `color: currentColor` (a `clickui.block` rule on
+   the same element) by layer order — keeping the close icon on opaque-text-*
+   regardless of source order. */
 
 .closeicon {
   width: var(--click-badge-icon-md-size-width);
   height: var(--click-badge-icon-md-size-height);
 }
 
-.closeicon_state_default.closeicon_state_default {
+.closeicon_state_default {
   color: var(--click-badge-opaque-color-text-default);
 }
 
-.closeicon_state_success.closeicon_state_success {
+.closeicon_state_success {
   color: var(--click-badge-opaque-color-text-success);
 }
 
-.closeicon_state_neutral.closeicon_state_neutral {
+.closeicon_state_neutral {
   color: var(--click-badge-opaque-color-text-neutral);
 }
 
-.closeicon_state_danger.closeicon_state_danger {
+.closeicon_state_danger {
   color: var(--click-badge-opaque-color-text-danger);
 }
 
-.closeicon_state_disabled.closeicon_state_disabled {
+.closeicon_state_disabled {
   color: var(--click-badge-opaque-color-text-disabled);
 }
 
-.closeicon_state_warning.closeicon_state_warning {
+.closeicon_state_warning {
   color: var(--click-badge-opaque-color-text-warning);
 }
 
-.closeicon_state_info.closeicon_state_info {
+.closeicon_state_info {
   color: var(--click-badge-opaque-color-text-info);
 }

--- a/src/components/Button/BaseButton.module.css
+++ b/src/components/Button/BaseButton.module.css
@@ -1,12 +1,8 @@
-/* Kept at zero specificity via :where() so that downstream styled-components
-   overrides on a styled(BaseButton) (SplitButton's PrimaryButton/SecondaryButton
-   override padding, border-radius, font, background, color, border, and width)
-   win without needing a specificity hack — BaseButton is a CSS Module, whose rules
-   otherwise beat equal-specificity styled-components by source order. SplitButton
-   cannot be fully migrated to fix the collision in the consumer because it renders
-   as={Dropdown.Trigger}/as={Dropdown.Content} and Dropdown is still on
-   styled-components, so :where() is the correct call for this coupled base. */
-:where(.base-button) {
+/* This base lands in the `clickui.block` cascade layer. Higher click-ui layers
+   and any unlayered consumer style override it by layer order — e.g.
+   SplitButton's `.split-button__*` element classes (clickui.elem) win over
+   these base rules — so no specificity hack is needed. */
+.base-button {
   display: flex;
   padding: var(--click-button-basic-space-y) var(--click-button-basic-space-x);
   flex-direction: row;
@@ -18,23 +14,23 @@
   cursor: pointer;
 }
 
-:where(.base-button):hover {
+.base-button:hover {
   font: var(--click-button-basic-typography-label-hover);
 }
 
-:where(.base-button):active,
-:where(.base-button):focus {
+.base-button:active,
+.base-button:focus {
   font: var(--click-button-basic-typography-label-active);
 }
 
-:where(.base-button):focus-visible {
+.base-button:focus-visible {
   outline: 2px solid var(--click-global-color-outline-default);
   outline-offset: 2px;
 }
 
-:where(.base-button):disabled,
-:where(.base-button):disabled:hover,
-:where(.base-button):disabled:active {
+.base-button:disabled,
+.base-button:disabled:hover,
+.base-button:disabled:active {
   font: var(--click-button-basic-typography-label-disabled);
   cursor: not-allowed;
 }

--- a/src/components/CardHorizontal/CardHorizontal.module.css
+++ b/src/components/CardHorizontal/CardHorizontal.module.css
@@ -1,3 +1,7 @@
+/* Renders as a <Container>; max-width and gap override the Container base
+   (a clickui.block rule) on the same node — @clickui-layer override wins by
+   layer order. */
+/* @clickui-layer override */
 .header {
   max-width: 100%;
   gap: inherit;

--- a/src/components/CardPrimary/CardPrimary.module.css
+++ b/src/components/CardPrimary/CardPrimary.module.css
@@ -126,7 +126,12 @@
   height: var(--click-card-primary-size-icon-sm-all);
 }
 
-.header.header h3 {
+/* The h3 is a <Title>, whose default color (`.title_color_default`) is a
+   clickui.mod rule. Placing this in clickui.mod lets its descendant specificity
+   (0,1,1) beat Title's (0,1,0), while `.header_disabled h3` below still
+   overrides it. */
+/* @clickui-layer mod */
+.header h3 {
   color: var(--click-global-color-text-default);
 }
 

--- a/src/components/Checkbox/Checkbox.module.css
+++ b/src/components/Checkbox/Checkbox.module.css
@@ -1,9 +1,6 @@
-/* The wrapper class is applied alongside FormRoot's styled-components class.
-   The .wrapper.wrapper double-class boost matches the specificity behavior of
-   the original `styled(FormRoot)` chain so these overrides reliably beat
-   FormRoot's `align-items: flex-start` regardless of stylesheet insertion
-   order between CSS Modules and the runtime-injected styled-components. */
-.wrapper.wrapper {
+/* Checkbox wrapper. Lands in `clickui.block`, so an unlayered consumer
+   override wins regardless of source order — no specificity hack needed. */
+.wrapper {
   /* stylelint-disable-next-line plugin/no-unsupported-browser-features -- `fit-content`
      keyword on `max-width` is widely supported on evergreen browsers; the original
      styled-components rule used the same value. */

--- a/src/components/CodeBlock/CodeBlock.module.css
+++ b/src/components/CodeBlock/CodeBlock.module.css
@@ -13,11 +13,11 @@
 }
 
 /* This class is applied alongside the IconButton module classes on the same
-   <button>. `color`, `padding`, and `border` are set by both; the
-   styled-components original won them via source order. Double the class so
-   those three win regardless of CSS-module bundle order, matching the
-   pre-migration rendering. */
-.codeblock__button.codeblock__button {
+   <button>; `color`, `padding`, and `border` are set by both. The color
+   competitor is IconButton's `.iconbutton_type_primary` (a clickui.mod rule),
+   so @clickui-layer override makes all three win by layer order. */
+/* @clickui-layer override */
+.codeblock__button {
   /* Reset so a copied/error state on one button can't inherit into another via
      the custom property (custom properties inherit by default). The copied/error
      colors are set inline per state via --codeblock-button, matching the

--- a/src/components/Container/Container.module.css
+++ b/src/components/Container/Container.module.css
@@ -1,8 +1,8 @@
-/* Kept at zero specificity via :where() so that modifier classes (e.g.
-   .container_padding_md) and downstream styled-components overrides on a
-   styled(Container) both win without needing a specificity hack — Container is
-   a CSS Module, whose rules otherwise beat equal-specificity styled-components. */
-:where(.container) {
+/* This base rule lands in the `clickui.block` cascade layer, so modifier
+   classes (in `clickui.mod`, e.g. .container_padding_md) win by layer order and
+   any unlayered styled(Container) override wins regardless of source order — no
+   specificity hack needed. */
+.container {
   /* These props are only emitted as inline custom properties when the
      matching Container prop is set (grow, shrink, fillHeight, minHeight,
      maxHeight, overflow). Custom properties inherit by default, so without

--- a/src/components/CrossButton/CrossButton.module.css
+++ b/src/components/CrossButton/CrossButton.module.css
@@ -1,5 +1,9 @@
 /* stylelint-disable custom-property-pattern -- design tokens use camelCase (e.g. iconButton) */
 
+/* Renders as an <EmptyButton>; padding and background override the EmptyButton
+   base (a clickui.block rule) on the same node. @clickui-layer override wins by
+   layer order (both rules share the layer, so :hover still beats the base). */
+/* @clickui-layer override */
 .cross-button {
   padding: var(--click-button-iconButton-sm-space-y)
     var(--click-button-iconButton-sm-space-x);
@@ -7,6 +11,7 @@
   background: var(--click-button-iconButton-color-primary-background-default);
 }
 
+/* @clickui-layer override */
 .cross-button:hover {
   background: var(--click-button-iconButton-color-primary-background-hover);
 }

--- a/src/components/DatePicker/Common.module.css
+++ b/src/components/DatePicker/Common.module.css
@@ -157,27 +157,27 @@
   gap: calc(var(--click-datePicker-space-gap) * 2);
 }
 
-/* HighlightedInputWrapper = styled(InputWrapper). The doubled class beats the
-   InputWrapper base `.wrapper` (0,1,0) for the width override and the active
-   border. The resting default border and the error border are identical to
-   what the InputWrapper base / `.wrapper_error` already render, so they are not
-   re-declared here. */
-.highlighted-input-wrapper.highlighted-input-wrapper {
+/* HighlightedInputWrapper wraps an InputWrapper. The base width override must
+   beat InputWrapper's base `.wrapper` (a clickui.block rule) yet still be
+   overridable by this component's own `_fill-width` modifier, so it goes in
+   clickui.mod (above the InputWrapper block base) alongside the modifiers,
+   which win over the base by source order. */
+/* @clickui-layer mod */
+.highlighted-input-wrapper {
   width: 250px;
 }
 
-.highlighted-input-wrapper_active.highlighted-input-wrapper_active {
+.highlighted-input-wrapper_active {
   border-color: var(--click-datePicker-dateOption-color-stroke-active);
 }
 
-/* Base `.wrapper:hover` (0,1,1) loses to the doubled active class, so re-assert
-   the hover border for the active (non-error) input to preserve the original
-   hover-over-active behavior. */
-.highlighted-input-wrapper_active.highlighted-input-wrapper_active:hover {
+/* Re-assert the hover border for the active (non-error) input so hover still
+   wins over the active border (both in clickui.mod; :hover wins on specificity). */
+.highlighted-input-wrapper_active:hover {
   border-color: var(--click-field-color-stroke-hover);
 }
 
-.highlighted-input-wrapper_fill-width.highlighted-input-wrapper_fill-width {
+.highlighted-input-wrapper_fill-width {
   /* stylelint-disable-next-line plugin/no-unsupported-browser-features -- the original styled-components used this width; preserved for byte-for-byte parity. */
   width: max-content;
   min-width: 250px;
@@ -188,19 +188,21 @@
   grid-template-rows: repeat(3, 1fr);
 }
 
-/* PickerNavControl = styled(IconButton) with `&&`. The IconButton ghost focus
-   rule is `.iconbutton_type_ghost:not([disabled]):focus` (0,3,0), so the focus
-   override needs (0,4,0) — a tripled class plus the pseudo — to win. */
-.picker-nav-control.picker-nav-control.picker-nav-control:focus,
-.picker-nav-control.picker-nav-control.picker-nav-control:focus-visible {
+/* PickerNavControl wraps an IconButton and overrides its ghost focus rule
+   (`.iconbutton_type_ghost:not([disabled]):focus`, a clickui.mod rule) on the
+   same node. @clickui-layer override wins by layer order instead of specificity. */
+/* @clickui-layer override */
+.picker-nav-control:focus,
+.picker-nav-control:focus-visible {
   border: var(--click-datePicker-dateOption-stroke) solid
     var(--click-datePicker-dateOption-color-stroke-hover);
   outline: none;
 }
 
-/* StyledDropdownItem = styled(Dropdown.Item). Doubled to beat the
-   `.dropdown-menu-item` base min-height (0,1,0). */
-.styled-dropdown-item.styled-dropdown-item {
+/* StyledDropdownItem wraps a Dropdown.Item and overrides its `.dropdown-menu-item`
+   base min-height (a clickui.block rule) on the same node. */
+/* @clickui-layer override */
+.styled-dropdown-item {
   box-sizing: content-box;
   min-height: 24px;
 }

--- a/src/components/DatePicker/DateRangePicker.module.css
+++ b/src/components/DatePicker/DateRangePicker.module.css
@@ -22,28 +22,36 @@
   left: 276px;
 }
 
-/* DateRangeTableCell = styled(DateTableCell). Doubled to beat DateTableCell's
-   base border/border-radius and `.date-table-cell_present` background (0,1,0). */
-.date-range-table-cell_indicator.date-range-table-cell_indicator {
+/* DateRangeTableCell wraps a DateTableCell and overrides its base border/radius
+   (clickui.block) and its `.date-table-cell_present` background (clickui.mod)
+   on the same node — @clickui-layer override wins over both by layer order. */
+/* @clickui-layer override */
+.date-range-table-cell_indicator {
   border: var(--click-datePicker-dateOption-stroke) solid
     var(--click-datePicker-dateOption-color-background-range);
   border-radius: 0;
   background: var(--click-datePicker-dateOption-color-background-range);
 }
 
-/* PredefinedCalendarContainer = styled(Panel). Doubled to beat the Panel
-   `.panel_align-items_center` / `.panel_color_default` default modifiers (0,1,0). */
-.predefined-calendar-container.predefined-calendar-container {
+/* PredefinedCalendarContainer wraps a Panel and overrides its default
+   `.panel_align-items_center` / `.panel_color_default` modifiers (clickui.mod)
+   on the same node — @clickui-layer override wins by layer order. */
+/* @clickui-layer override */
+.predefined-calendar-container {
   align-items: start;
   background: var(--click-panel-color-background-muted);
 }
 
-/* styled(Container) — Container's base is `:where(.container)` (0,0,0), so a
-   single class wins. */
+/* Wraps a Container and overrides its base `width` on the same node.
+   @clickui-layer override wins over Container's clickui.block base by layer order. */
+/* @clickui-layer override */
 .predefined-dates-container {
   width: 275px;
 }
 
+/* Renders as a <Container>; max-height/overflow override the Container base
+   (a clickui.block rule) on the same node. */
+/* @clickui-layer override */
 .scrollable-container {
   max-height: 210px;
   overflow-y: auto;

--- a/src/components/DatePicker/DateTimeRangePicker.module.css
+++ b/src/components/DatePicker/DateTimeRangePicker.module.css
@@ -27,32 +27,44 @@
   left: 259px;
 }
 
-/* DateRangeTableCell = styled(DateTableCell). Doubled to beat DateTableCell's
-   base border/border-radius and `.date-table-cell_present` background (0,1,0). */
-.date-range-table-cell_indicator.date-range-table-cell_indicator {
+/* DateRangeTableCell wraps a DateTableCell and overrides its base border/radius
+   (clickui.block) and its `.date-table-cell_present` background (clickui.mod)
+   on the same node — @clickui-layer override wins over both by layer order. */
+/* @clickui-layer override */
+.date-range-table-cell_indicator {
   border: var(--click-datePicker-dateOption-stroke) solid
     var(--click-datePicker-dateOption-color-background-range);
   border-radius: 0;
   background: var(--click-datePicker-dateOption-color-background-range);
 }
 
-/* NoOverflowDropdownContent = styled(Dropdown.Content). Doubled to beat the
-   `.dropdown-menu-content` base `overflow-y: auto` (0,1,0). */
-.no-overflow-dropdown-content.no-overflow-dropdown-content {
+/* NoOverflowDropdownContent wraps a Dropdown.Content and overrides its
+   `.dropdown-menu-content` base `overflow-y: auto` (clickui.block) on the same
+   node. */
+/* @clickui-layer override */
+.no-overflow-dropdown-content {
   overflow-y: hidden;
 }
 
-/* PredefinedCalendarContainer = styled(Panel). Doubled to beat the Panel
-   `.panel_align-items_center` / `.panel_color_default` default modifiers (0,1,0). */
-.predefined-calendar-container.predefined-calendar-container {
+/* PredefinedCalendarContainer wraps a Panel and overrides its default
+   `.panel_align-items_center` / `.panel_color_default` modifiers (clickui.mod)
+   on the same node — @clickui-layer override wins by layer order. */
+/* @clickui-layer override */
+.predefined-calendar-container {
   align-items: start;
   background: var(--click-panel-color-background-muted);
 }
 
+/* Renders as a <Container>; overrides the Container base `width`
+   (a clickui.block rule) on the same node. */
+/* @clickui-layer override */
 .predefined-times-container {
   width: 258px;
 }
 
+/* Renders as a <Container>; max-height/overflow override the Container base
+   (a clickui.block rule) on the same node. */
+/* @clickui-layer override */
 .scrollable-container {
   max-height: 210px;
   overflow-y: auto;

--- a/src/components/EmptyButton/EmptyButton.module.css
+++ b/src/components/EmptyButton/EmptyButton.module.css
@@ -1,9 +1,9 @@
-/* Kept at zero specificity via :where() so that downstream styled-components
-   overrides on a styled(EmptyButton) (e.g. CrossButton overriding background and
-   padding, the Popover/CodeBlock close/copy buttons overriding color and padding)
-   win without needing a specificity hack — EmptyButton is a CSS Module, whose
-   rules otherwise beat equal-specificity styled-components by source order. */
-:where(.empty-button) {
+/* This base lands in the `clickui.block` cascade layer. Higher click-ui layers
+   and any unlayered consumer style override it by layer order — e.g.
+   CrossButton's `.cross-button` (clickui.override) and the Collapsible trigger's
+   `.collapsible__trigger` (clickui.elem) win over these base rules — so no
+   specificity hack is needed. */
+.empty-button {
   padding: 0;
   border: 0;
   background: transparent;
@@ -13,9 +13,6 @@
   cursor: pointer;
 }
 
-/* Also scoped with :where() so the disabled cursor stays at zero specificity
-   and a downstream styled(EmptyButton) `&:disabled` override wins naturally,
-   rather than tying on specificity and losing to the CSS Module by source order. */
-:where(.empty-button):disabled {
+.empty-button:disabled {
   cursor: not-allowed;
 }

--- a/src/components/Flyout/Flyout.module.css
+++ b/src/components/Flyout/Flyout.module.css
@@ -119,16 +119,15 @@
   /* stylelint-enable plugin/no-unsupported-browser-features, declaration-property-value-no-unknown */
 }
 
-/* Doubled class: this element renders as a <Container>, whose base class also
-   sets `padding`/`gap`. Doubling outranks the single-class Container base so the
-   Flyout override wins regardless of CSS-module bundle order (matches the
-   styled(Container) override semantics). */
-.element_type_default.element_type_default {
+/* These elements render as a <Container> whose base also sets `padding`/`gap`.
+   The `_type_` modifier classes land in `clickui.mod`, so they win over
+   Container's `clickui.block` base by layer order. */
+.element_type_default {
   padding: 0 var(--click-flyout-space-default-content-x);
   gap: var(--click-flyout-space-default-gap);
 }
 
-.element_type_inline.element_type_inline {
+.element_type_inline {
   padding: 0 var(--click-flyout-space-inline-content-x);
   gap: var(--click-flyout-space-inline-gap);
 }
@@ -137,14 +136,14 @@
 .header {
 }
 
-.header_type_default.header_type_default {
+.header_type_default {
   padding: var(--click-flyout-space-default-y) var(--click-flyout-space-default-y)
     0 var(--click-flyout-space-default-y);
   gap: var(--click-flyout-space-default-content-row-gap)
     var(--click-flyout-space-default-content-column-gap);
 }
 
-.header_type_inline.header_type_inline {
+.header_type_inline {
   padding: var(--click-flyout-space-inline-y) var(--click-flyout-space-inline-y) 0
     var(--click-flyout-space-inline-y);
   gap: var(--click-flyout-space-inline-content-row-gap)
@@ -179,22 +178,24 @@
   font: var(--click-flyout-typography-inline-description-default);
 }
 
-/* Doubled class: renders as a <Container> whose base sets `width`. */
-.body.body {
+/* Renders as a <Container> whose base sets `width`; override that composed base. */
+/* @clickui-layer override */
+.body {
   width: var(--flyout-width);
   max-width: 100%;
 }
 
-.body_align_default.body_align_default {
+.body_align_default {
   margin-top: 0;
 }
 
-.body_align_top.body_align_top {
+.body_align_top {
   margin-top: -1rem;
 }
 
-/* Doubled class: renders as a <Container> whose base sets `width`. */
-.footer-container.footer-container {
+/* Renders as a <Container> whose base sets `width`; override that composed base. */
+/* @clickui-layer override */
+.footer-container {
   width: var(--flyout-width);
   max-width: 100%;
 }
@@ -203,13 +204,13 @@
 .footer {
 }
 
-.footer_type_default.footer_type_default {
+.footer_type_default {
   padding: var(--click-flyout-space-default-y) var(--click-flyout-space-default-content-x);
   gap: var(--click-flyout-space-default-content-row-gap)
     var(--click-flyout-space-default-content-column-gap);
 }
 
-.footer_type_inline.footer_type_inline {
+.footer_type_inline {
   padding: var(--click-flyout-space-inline-y) var(--click-flyout-space-inline-content-x);
   gap: var(--click-flyout-space-inline-content-row-gap)
     var(--click-flyout-space-inline-content-column-gap);

--- a/src/components/Label/Label.module.css
+++ b/src/components/Label/Label.module.css
@@ -3,20 +3,19 @@
   font: var(--click-field-typography-label-default);
 }
 
-/* Hover/focus rules only apply when neither disabled nor error is set, matching
-   the original styled-components behavior (which simply didn't emit them in
-   those states). The :not() chain also raises specificity above 0-1-0 so these
-   rules win over InputWrapper's `labelColor` override (a 0-1-0 single-class
-   styled-components selector injected later in the cascade). The .label_error
-   and .label_disabled modifiers below stay at 0-1-0 on purpose, so labelColor
-   continues to override them. */
-.label:not(.label_error, .label_disabled):hover {
+/* Hover/focus land in `clickui.block`; the .label_error / .label_disabled
+   modifiers land in `clickui.mod`. So in an error or disabled state the
+   modifier wins by layer order and the hover/focus styling does not apply —
+   the exclusion the original :not() chain expressed, now from layer order.
+   (InputWrapper's optional `labelColor` is an inline style, so it overrides
+   `color` in every state regardless.) */
+.label:hover {
   color: var(--click-field-color-label-hover);
   font: var(--click-field-typography-label-hover);
 }
 
-.label:not(.label_error, .label_disabled):focus,
-.label:not(.label_error, .label_disabled):focus-within {
+.label:focus,
+.label:focus-within {
   color: var(--click-field-color-label-active);
   font: var(--click-field-typography-label-active);
 }

--- a/src/components/Pagination/Pagination.module.css
+++ b/src/components/Pagination/Pagination.module.css
@@ -1,7 +1,7 @@
-/* Doubled class raises specificity to (0,2,0) so this width wins over the
-   Select root's own `width: 100%` rule, which styled() injects into <head>
-   at runtime (after the bundled CSS). The previous styled() wrapper relied
-   on runtime injection order for the same effect. */
-.custom-select.custom-select {
+/* Pagination composes a <Select> and fixes the page-size trigger's width,
+   overriding the Select trigger's own `width: 100%`. @clickui-layer override
+   makes this win over Select's rule by layer order — no specificity hack. */
+/* @clickui-layer override */
+.custom-select {
   width: 150px;
 }

--- a/src/components/RadioGroup/RadioGroup.module.css
+++ b/src/components/RadioGroup/RadioGroup.module.css
@@ -16,12 +16,9 @@
   color: var(--click-field-color-label-error);
 }
 
-/* The item class is applied alongside FormRoot's styled-components class.
-   The .item.item double-class boost matches the specificity behavior of the
-   original `styled(FormRoot)` chain so these overrides reliably beat FormRoot's
-   own declarations regardless of stylesheet insertion order between CSS Modules
-   and the runtime-injected styled-components. */
-.item.item {
+/* RadioGroup item. Lands in `clickui.block`, so an unlayered consumer override
+   wins regardless of source order — no specificity hack needed. */
+.item {
   display: flex;
   width: auto;
   padding: var(--click-checkbox-space-all);

--- a/src/components/SidebarNavigationTitle/SidebarNavigationTitle.module.css
+++ b/src/components/SidebarNavigationTitle/SidebarNavigationTitle.module.css
@@ -1,5 +1,11 @@
 /* stylelint-disable custom-property-pattern -- design tokens use camelCase (e.g. sqlSidebar) */
+
+/* SidebarCollapsibleTitle renders this wrapper `as={Collapsible.Trigger}`, so
+   the element also carries `.collapsible__trigger`. The cross-component cascade
+   between these two rules is now governed by layer order rather than the old
+   doubled-class specificity boost. */
 .wrapper {
+  display: inline-flex;
   /* stylelint-disable plugin/no-unsupported-browser-features, declaration-property-value-no-unknown -- the original styled rule used this
    same width fallback chain (100% → -webkit-fill-available → fill-available →
    stretch) so the title fills the available inline space. */
@@ -11,41 +17,27 @@
   padding: 0;
   padding-left: var(--title-pad-left);
   overflow: hidden;
+  align-items: center;
   border: none;
   background: transparent;
+  color: var(--title-color-default);
+  font: var(--click-sidebar-navigation-title-typography-default);
   white-space: nowrap;
+  cursor: pointer;
 
   /* Not collapsible by default: reserve the icon-column width on the left.
-     The single-class modifiers below override this; keep these defaults at
-     single-class specificity so they can. */
+     The `collapsible` modifier overrides this. */
   --title-pad-left: var(--click-image-sm-size-width);
 }
 
-/* Doubled class → specificity (0,2,0). SidebarCollapsibleTitle renders this
-   wrapper `as={Collapsible.Trigger}`, so the element also carries
-   `.collapsible__trigger`, whose `display/align-items/color/font/cursor`
-   resets would otherwise win on CSS-module bundle order and strip the title's
-   own typography. The original styled-components cascade resolved in the
-   title's favour; the doubled class makes that deterministic. Only the
-   properties that actually conflict with the trigger live here — box metrics
-   and the `--title-*` custom properties stay single-class above/below so the
-   `type`/`collapsible` modifiers still override them. */
-.wrapper.wrapper {
-  display: inline-flex;
-  align-items: center;
-  color: var(--title-color-default);
-  font: var(--click-sidebar-navigation-title-typography-default);
-  cursor: pointer;
-}
-
-.wrapper.wrapper:hover {
+.wrapper:hover {
   color: var(--title-color-hover);
   font: var(--click-sidebar-navigation-title-typography-hover);
 }
 
-.wrapper.wrapper:active,
-.wrapper.wrapper[data-state='open'],
-.wrapper.wrapper[data-selected='true'] {
+.wrapper:active,
+.wrapper[data-state='open'],
+.wrapper[data-selected='true'] {
   color: var(--title-color-active);
   font: var(--click-sidebar-navigation-title-typography-active);
 }

--- a/src/components/Switch/Switch.module.css
+++ b/src/components/Switch/Switch.module.css
@@ -1,9 +1,6 @@
-/* The wrapper class is applied alongside FormRoot's styled-components class.
-   The .wrapper.wrapper double-class boost matches the specificity behavior of
-   the original `styled(FormRoot)` chain so these overrides reliably beat
-   FormRoot's `align-items: flex-start` regardless of stylesheet insertion
-   order between CSS Modules and the runtime-injected styled-components. */
-.wrapper.wrapper {
+/* Switch wrapper. Lands in `clickui.block`, so an unlayered consumer override
+   wins regardless of source order — no specificity hack needed. */
+.wrapper {
   /* stylelint-disable-next-line plugin/no-unsupported-browser-features -- `fit-content`
      keyword on `max-width` is widely supported on evergreen browsers; the original
      styled-components rule used the same value. */

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -113,6 +113,10 @@ export default {
     // TODO: Maybe create an utility or test to make sure
     // its computed correctly
     // NOTE: BEM naming convention (block-name__elem-name_mod-name_mod-val) per naming convention https://en.bem.info/methodology/naming-convention
+    // This also backs the cascade-layer classifier in
+    // plugins/css-colocate/postcss-clickui-layers.ts, which routes rules to the
+    // clickui.block/elem/mod layers by BEM role: it relies on `_` being ONLY a
+    // modifier separator and `__` ONLY an element separator (words use `-`).
     'selector-class-pattern': [
       '^[a-z][a-z0-9]*(-[a-z0-9]+)*(__[a-z][a-z0-9]*(-[a-z0-9]+)*)?(_[a-z][a-z0-9]*(-[a-z0-9]+)*)?(_[a-z][a-z0-9]*(-[a-z0-9]+)*)?$',
       {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,7 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 import { visualizer } from 'rollup-plugin-visualizer';
 import { cssColocatePlugin } from './plugins/css-colocate';
 import { generateScopedName } from './plugins/css-colocate/utils';
+import { wrapInClickuiLayers } from './plugins/css-colocate/postcss-clickui-layers';
 
 const srcDir = path.resolve(__dirname, 'src').replace(/\\/g, '/');
 
@@ -82,6 +83,17 @@ const viteConfig = defineConfig({
       // Generate predictable class names for debugging in dev
       generateScopedName,
     },
+    // Wrap component CSS in the `clickui` cascade layers. Runs in Vite's native
+    // CSS pipeline (before its modules transform, so it sees original BEM
+    // names) — this covers dev, Storybook, the visual-regression suite, and the
+    // combined dist `click-ui.css`, keeping their cascade identical to what the
+    // per-component dist files get from css-preprocess.ts.
+    postcss: {
+      // Cast: Vite bundles its own `postcss` install, structurally identical
+      // to the repo's top-level `postcss` but a distinct nominal type. The
+      // plugin is runtime-compatible with both.
+      plugins: [wrapInClickuiLayers() as unknown as never],
+    },
   },
   plugins: [
     react({
@@ -149,7 +161,7 @@ const vitestConfig = defineVitestConfig({
     environment: 'jsdom',
     // TODO: Note that currently, the pw visual regression tests
     // are kept separate, see ./tests
-    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'plugins/**/*.{test,spec}.{ts,tsx}'],
     exclude: ['node_modules', 'dist', 'build', 'storybook-static', '.storybook'],
     globals: true,
     watch: false,


### PR DESCRIPTION
## What

Wraps all click-ui component CSS in a nested set of cascade layers under a single top-level `clickui` layer, so overrides become predictable without specificity hacks — and removes every internal specificity hack this makes redundant.

Layer order: `clickui.block → clickui.elem → clickui.mod → clickui.override`. Cascade-layer precedence is `unlayered > last-declared > … > first-declared`, and specificity only matters *within* a layer. This buys two guarantees:

1. **A modifier always beats the block/element it modifies** — from layer order, not specificity.
2. **Any unlayered consumer style beats every click-ui layer** — a plain rule, a CSS Module class, or a `styled(...)` override wins regardless of stylesheet order or specificity, with zero config.

## How

A small PostCSS plugin (`plugins/css-colocate/postcss-clickui-layers.ts`) wraps each rule by BEM role (single `_` → modifier, `__` → element, else block). It runs in the **shared** CSS pipeline — `css.postcss` in `vite.config.ts` (dev, Storybook, the visual-regression suite, and the combined `dist/click-ui.css`) and in `css-preprocess.ts` (per-component `dist` CSS) — so the cascade that ships is exactly the one the visual-regression suite validates. That parity is what makes removing the hacks safe.

Then, library-wide, the now-redundant hacks are removed:
- `:where()` zero-specificity bases → normal single-class selectors (Container, BaseButton, EmptyButton)
- doubled/tripled-class boosts → single class (Checkbox, Switch, RadioGroup, SidebarNavigationTitle, Flyout, Badge, CardPrimary, CodeBlock, Pagination, DatePicker)
- Label's `:not()` state-exclusion chains → plain `.label:hover/:focus` (error/disabled modifiers in the mod layer beat them automatically)

### ⚠️ Design note — a fourth `clickui.override` sub-layer

The `block/elem/mod` order handles precedence *within* a component. It cannot express a **cross-component override** — one component that composes another (via `as=`/`styled()`) and must override the composed component's own block/elem/mod rules **on the same node** (e.g. `Flyout.Body` overriding `Container`'s width; DatePicker overriding a `Panel` default modifier; Badge overriding `Icon`'s size modifier). Several of these previously relied on doubled classes or on a `:where()` base being zero-specificity.

To resolve these by layer order rather than reintroducing specificity hacks, this adds a fourth, highest **internal** sub-layer `clickui.override`, opted into per-rule with a `/* @clickui-layer override */` comment. It still sits **below** any unlayered consumer style, so consumer overrides keep winning. Used by: Pagination↔Select, Flyout↔Container, Badge↔Icon, CodeBlock↔IconButton, CardHorizontal↔Container, CrossButton↔EmptyButton, and DatePicker↔Panel/Dropdown/IconButton/InputWrapper.

The public contract stays "just the `clickui` layer" — the sub-layer names are an internal detail.

## Consumer impact

Consumer overrides that previously tied with a component class (both at `(0,1,0)`) and won/lost by CSS bundle order now **always win** (unlayered beats any layer). Control-plane can drop its override workarounds; this is coordinated separately and does not block this PR.

Requires a browser with `@layer` support (Chrome/Edge 99+, Firefox 97+, Safari 15.4+). Verified the library's browserslist resolves to Safari ≥ 15.6 / iOS ≥ 15.6 — no pre-15.4 gap.

## Verification

- ✅ Full visual-regression suite (1234 snapshots) passes **unchanged** after both the layering commit and the hack-removal commit — layering and the removals alter zero pixels.
- ✅ New unit tests for the PostCSS plugin (role routing, grouped-selector split, `@media` split, keyframes left unlayered, `override` annotation, idempotency).
- ✅ `yarn build` emits the layer-order declaration and correctly-wrapped rules in both `dist/**/click-ui.css` and the per-component `dist/**/*.css`.
- ✅ typecheck, stylelint, eslint, prettier all pass.

## Commits

1. Add the layer transform + wire into both pipelines (no rendering change)
2. Remove the specificity hacks library-wide (+ the `override` layer)
3. Docs: the `clickui`-layer override contract + stylelint note

🤖 Generated with [Claude Code](https://claude.com/claude-code)