### PR TITLE
feat(Checkbox): add var7 red color variant to CheckboxMultiSelect

### DIFF
--- a/.changeset/feat-checkbox-var7-variant.md
+++ b/.changeset/feat-checkbox-var7-variant.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': minor
+---
+
+Add `var7` (red) color variant to `Checkbox` and `CheckboxMultiSelect`

--- a/src/components/Checkbox/Checkbox.module.css
+++ b/src/components/Checkbox/Checkbox.module.css
@@ -80,6 +80,14 @@
   --checkbox-stroke-active: var(--click-checkbox-color-variations-var6-stroke-active);
 }
 
+.checkinput_variant_var7 {
+  --checkbox-bg-default: var(--click-checkbox-color-variations-var7-background-default);
+  --checkbox-bg-hover: var(--click-checkbox-color-variations-var7-background-hover);
+  --checkbox-bg-active: var(--click-checkbox-color-variations-var7-background-active);
+  --checkbox-stroke-default: var(--click-checkbox-color-variations-var7-stroke-default);
+  --checkbox-stroke-active: var(--click-checkbox-color-variations-var7-stroke-active);
+}
+
 .checkinput:hover {
   background: var(--checkbox-bg-hover);
 }

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -126,6 +126,14 @@ export const Var6Checked: Story = {
   },
 };
 
+export const Var7Checked: Story = {
+  args: {
+    ...baseArgs,
+    variant: 'var7',
+    checked: true,
+  },
+};
+
 export const OrientationVerticalDirStart: Story = {
   args: {
     ...baseArgs,

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -18,6 +18,7 @@ const checkInputVariants = cva(styles.checkinput, {
       var4: styles['checkinput_variant_var4'],
       var5: styles['checkinput_variant_var5'],
       var6: styles['checkinput_variant_var6'],
+      var7: styles['checkinput_variant_var7'],
     },
   },
   defaultVariants: {

--- a/src/components/Checkbox/Checkbox.types.ts
+++ b/src/components/Checkbox/Checkbox.types.ts
@@ -8,7 +8,8 @@ export type CheckboxVariants =
   | 'var3'
   | 'var4'
   | 'var5'
-  | 'var6';
+  | 'var6'
+  | 'var7';
 
 export interface CheckboxProps extends RadixCheckbox.CheckboxProps {
   label?: ReactNode;

--- a/src/components/CheckboxMultiSelect/CheckboxMultiSelect.stories.tsx
+++ b/src/components/CheckboxMultiSelect/CheckboxMultiSelect.stories.tsx
@@ -131,6 +131,12 @@ export const CheckboxMultiSelectVariants: StoryObj<typeof CheckboxMultiSelect> =
         >
           Variant 6
         </CheckboxMultiSelect.Item>
+        <CheckboxMultiSelect.Item
+          value="variant 7"
+          variant="var7"
+        >
+          Variant 7
+        </CheckboxMultiSelect.Item>
       </CheckboxMultiSelect>
     );
   },

--- a/src/theme/styles/tokens-dark.css
+++ b/src/theme/styles/tokens-dark.css
@@ -643,7 +643,7 @@
   --click-checkbox-color-variations-var7-background-hover: rgb(17.794% 17.794% 17.794%);
   --click-checkbox-color-variations-var7-background-active: #ff2323;
   --click-checkbox-color-variations-var7-background-disabled: rgb(17.794% 17.794% 17.794%);
-  --click-checkbox-color-variations-var7-stroke-default: #c10000;
+  --click-checkbox-color-variations-var7-stroke-default: #ff2323;
   --click-checkbox-color-variations-var7-stroke-hover: #ff7575;
   --click-checkbox-color-variations-var7-stroke-active: #ff7575;
   --click-checkbox-color-variations-var7-stroke-disabled: #606060;

--- a/src/theme/styles/tokens-dark.css
+++ b/src/theme/styles/tokens-dark.css
@@ -639,6 +639,18 @@
   --click-checkbox-color-variations-var6-check-hover: #ffffff;
   --click-checkbox-color-variations-var6-check-active: #ffffff;
   --click-checkbox-color-variations-var6-check-disabled: #a0a0a0;
+  --click-checkbox-color-variations-var7-background-default: rgb(17.794% 17.794% 17.794%);
+  --click-checkbox-color-variations-var7-background-hover: rgb(17.794% 17.794% 17.794%);
+  --click-checkbox-color-variations-var7-background-active: #ff2323;
+  --click-checkbox-color-variations-var7-background-disabled: rgb(17.794% 17.794% 17.794%);
+  --click-checkbox-color-variations-var7-stroke-default: #c10000;
+  --click-checkbox-color-variations-var7-stroke-hover: #ff7575;
+  --click-checkbox-color-variations-var7-stroke-active: #ff7575;
+  --click-checkbox-color-variations-var7-stroke-disabled: #606060;
+  --click-checkbox-color-variations-var7-check-default: #ffffff;
+  --click-checkbox-color-variations-var7-check-hover: #ffffff;
+  --click-checkbox-color-variations-var7-check-active: #ffffff;
+  --click-checkbox-color-variations-var7-check-disabled: #a0a0a0;
   --click-checkbox-color-background-default: rgb(17.794% 17.794% 17.794%);
   --click-checkbox-color-background-hover: rgb(17.794% 17.794% 17.794%);
   --click-checkbox-color-background-active: #faff69;

--- a/src/theme/styles/tokens-light.css
+++ b/src/theme/styles/tokens-light.css
@@ -636,6 +636,18 @@
   --click-checkbox-color-variations-var6-check-hover: #ffffff;
   --click-checkbox-color-variations-var6-check-active: #ffffff;
   --click-checkbox-color-variations-var6-check-disabled: #a0a0a0;
+  --click-checkbox-color-variations-var7-background-default: #f6f7fa;
+  --click-checkbox-color-variations-var7-background-hover: #f6f7fa;
+  --click-checkbox-color-variations-var7-background-active: #ff2323;
+  --click-checkbox-color-variations-var7-background-disabled: #dfdfdf;
+  --click-checkbox-color-variations-var7-stroke-default: #ff5353;
+  --click-checkbox-color-variations-var7-stroke-hover: #ff5353;
+  --click-checkbox-color-variations-var7-stroke-active: #ff5353;
+  --click-checkbox-color-variations-var7-stroke-disabled: #c0c0c0;
+  --click-checkbox-color-variations-var7-check-default: #ffffff;
+  --click-checkbox-color-variations-var7-check-hover: #ffffff;
+  --click-checkbox-color-variations-var7-check-active: #ffffff;
+  --click-checkbox-color-variations-var7-check-disabled: #a0a0a0;
   --click-checkbox-color-check-default: #ffffff;
   --click-checkbox-color-check-hover: #ffffff;
   --click-checkbox-color-check-active: #ffffff;

--- a/src/theme/tokens/variables.dark.ts
+++ b/src/theme/tokens/variables.dark.ts
@@ -1388,7 +1388,7 @@ const theme = {
               disabled: 'rgb(17.794% 17.794% 17.794%)',
             },
             stroke: {
-              default: '#c10000',
+              default: '#ff2323',
               hover: '#ff7575',
               active: '#ff7575',
               disabled: '#606060',

--- a/src/theme/tokens/variables.dark.ts
+++ b/src/theme/tokens/variables.dark.ts
@@ -1380,6 +1380,26 @@ const theme = {
               disabled: '#a0a0a0',
             },
           },
+          var7: {
+            background: {
+              default: 'rgb(17.794% 17.794% 17.794%)',
+              hover: 'rgb(17.794% 17.794% 17.794%)',
+              active: '#ff2323',
+              disabled: 'rgb(17.794% 17.794% 17.794%)',
+            },
+            stroke: {
+              default: '#c10000',
+              hover: '#ff7575',
+              active: '#ff7575',
+              disabled: '#606060',
+            },
+            check: {
+              default: '#ffffff',
+              hover: '#ffffff',
+              active: '#ffffff',
+              disabled: '#a0a0a0',
+            },
+          },
         },
         background: {
           default: 'rgb(17.794% 17.794% 17.794%)',

--- a/src/theme/tokens/variables.light.ts
+++ b/src/theme/tokens/variables.light.ts
@@ -1374,6 +1374,26 @@ const theme = {
               disabled: '#a0a0a0',
             },
           },
+          var7: {
+            background: {
+              default: '#f6f7fa',
+              hover: '#f6f7fa',
+              active: '#ff2323',
+              disabled: '#dfdfdf',
+            },
+            stroke: {
+              default: '#ff5353',
+              hover: '#ff5353',
+              active: '#ff5353',
+              disabled: '#c0c0c0',
+            },
+            check: {
+              default: '#ffffff',
+              hover: '#ffffff',
+              active: '#ffffff',
+              disabled: '#a0a0a0',
+            },
+          },
         },
         check: {
           default: '#ffffff',

--- a/tokens/themes/dark.json
+++ b/tokens/themes/dark.json
@@ -2219,6 +2219,62 @@
                 "type": "color"
               }
             }
+          },
+          "var7": {
+            "background": {
+              "default": {
+                "value": "{click.field.color.background.default}",
+                "type": "color"
+              },
+              "hover": {
+                "value": "{click.checkbox.color.variations.default.background.default}",
+                "type": "color"
+              },
+              "active": {
+                "value": "{palette.danger.400}",
+                "type": "color"
+              },
+              "disabled": {
+                "value": "{click.checkbox.color.variations.default.background.default}",
+                "type": "color"
+              }
+            },
+            "stroke": {
+              "default": {
+                "value": "{palette.danger.600}",
+                "type": "color"
+              },
+              "hover": {
+                "value": "{palette.danger.300}",
+                "type": "color"
+              },
+              "active": {
+                "value": "{click.checkbox.color.variations.var7.stroke.hover}",
+                "type": "color"
+              },
+              "disabled": {
+                "value": "{click.checkbox.color.variations.default.stroke.disabled}",
+                "type": "color"
+              }
+            },
+            "check": {
+              "default": {
+                "value": "{palette.neutral.0}",
+                "type": "color"
+              },
+              "hover": {
+                "value": "{click.checkbox.color.variations.default.check.default}",
+                "type": "color"
+              },
+              "active": {
+                "value": "{palette.neutral.0}",
+                "type": "color"
+              },
+              "disabled": {
+                "value": "{palette.neutral.400}",
+                "type": "color"
+              }
+            }
           }
         },
         "background": {

--- a/tokens/themes/dark.json
+++ b/tokens/themes/dark.json
@@ -2241,7 +2241,7 @@
             },
             "stroke": {
               "default": {
-                "value": "{palette.danger.600}",
+                "value": "{palette.danger.400}",
                 "type": "color"
               },
               "hover": {

--- a/tokens/themes/light.json
+++ b/tokens/themes/light.json
@@ -2648,6 +2648,62 @@
                 "type": "color"
               }
             }
+          },
+          "var7": {
+            "background": {
+              "default": {
+                "value": "{palette.slate.50}",
+                "type": "color"
+              },
+              "hover": {
+                "value": "{click.checkbox.color.variations.default.background.default}",
+                "type": "color"
+              },
+              "active": {
+                "value": "{palette.danger.400}",
+                "type": "color"
+              },
+              "disabled": {
+                "value": "{palette.neutral.200}",
+                "type": "color"
+              }
+            },
+            "stroke": {
+              "default": {
+                "value": "{palette.danger.base}",
+                "type": "color"
+              },
+              "hover": {
+                "value": "{palette.danger.base}",
+                "type": "color"
+              },
+              "active": {
+                "value": "{click.checkbox.color.variations.var7.stroke.hover}",
+                "type": "color"
+              },
+              "disabled": {
+                "value": "{palette.neutral.300}",
+                "type": "color"
+              }
+            },
+            "check": {
+              "default": {
+                "value": "{palette.neutral.0}",
+                "type": "color"
+              },
+              "hover": {
+                "value": "{click.checkbox.color.variations.default.check.default}",
+                "type": "color"
+              },
+              "active": {
+                "value": "{palette.neutral.0}",
+                "type": "color"
+              },
+              "disabled": {
+                "value": "{palette.neutral.400}",
+                "type": "color"
+              }
+            }
           }
         },
         "check": {


### PR DESCRIPTION
## Why?

We needed a **red** checkbox color option for use inside `CheckboxMultiSelect` (and `Checkbox` directly). The component already ships six color variants (`var1`–`var6`), but none of them is red, so consumers had no token-backed way to render a red checkbox.

This adds a new `var7` variant wired to the existing **danger** palette — the checked fill resolves to `#ff2323` (= `palette.danger.400`), the same red already used elsewhere in the design system. The change is purely **additive**: no existing variant, token, or color is modified, so it is non-breaking.

## How?

The `variant` prop flows straight through `CheckboxMultiSelect.Item` → `MultiSelectCheckboxItem` → `Checkbox`, so `CheckboxMultiSelect` itself needed **no code change**. `var7` was added at the same four layers every other variant lives in:

1. **Design tokens** (`tokens/themes/dark.json`, `light.json`) — new `var7` entry under `click.checkbox.color.variations`, modeled on `var1` but referencing `{palette.danger.*}` instead of `{palette.success.*}` / chart green. The active fill points at `{palette.danger.400}` (#ff2323).
2. **Regenerated token output** — ran `yarn generate:tokens`, which emits `--click-checkbox-color-variations-var7-*` into `tokens-{dark,light}.css` and `variables.{dark,light}.ts`. These files are generated, not hand-edited.
3. **Variant class** (`Checkbox.module.css`) — new `.checkinput_variant_var7` block mapping those tokens onto the component's `--checkbox-*` CSS custom properties (identical shape to `var1`–`var6`).
4. **Type + class map** — `'var7'` added to the `CheckboxVariants` union (`Checkbox.types.ts`) and to the `cva` variant map (`Checkbox.tsx`).

Because `var7` reuses existing palette primitives, both light and dark themes are covered:

- Dark: checked fill `#ff2323`, stroke `#c10000` → `#ff7575` on hover/active
- Light: checked fill `#ff2323`, stroke `#ff5353`

### Why reuse the danger palette instead of a new color?

`#ff2323` already exists as `palette.danger.400`. Referencing it (rather than hardcoding a hex or introducing a new primitive) keeps the variant in sync with the rest of the danger scale and follows exactly how `var1`–`var6` reference their palette families.

## Tickets?

N/A

## Contribution checklist?

- [x] You've done enough research before writing
- [x] You have reviewed the PR
- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [x] Assets or static content are linked and stored in the project
- [x] For documentation, guides or references, you've tested the commands

## Security checklist?

- [x] All user inputs are validated and sanitized
- [x] No usage of `dangerouslySetInnerHTML`
- [x] Sensitive data has been identified and is being protected properly
- [x] Build output contains no secrets or API keys

## Preview?

Verified in Storybook:

- **Forms → CheckboxMultiSelect → Checkbox Multi Select Variants** — new **Variant 7** row renders a red checkbox when selected.
- **Forms → Checkbox → Var7 Checked** — the red checkbox in isolation.

```tsx
<CheckboxMultiSelect onSelect={handleSelect} placeholder={label}>
  <CheckboxMultiSelect.Item value="variant 7" variant="var7">
    Variant 7
  </CheckboxMultiSelect.Item>
</CheckboxMultiSelect>

// or directly
<Checkbox variant="var7" checked />
```

Validation run locally (all green):

- `tsc --noEmit` — no type errors
- `eslint` on the changed files — clean
- `vitest run` — Checkbox (2) + CheckboxMultiSelect (17) suites pass
- `yarn generate:tokens` — regenerates cleanly; diff is additive-only

### Changed files

- `tokens/themes/dark.json`, `tokens/themes/light.json` — new `var7` token entry referencing `{palette.danger.*}`
- `src/theme/styles/tokens-dark.css`, `src/theme/styles/tokens-light.css` — generated `--click-checkbox-color-variations-var7-*` vars
- `src/theme/tokens/variables.dark.ts`, `src/theme/tokens/variables.light.ts` — generated TS token entries
- `src/components/Checkbox/Checkbox.types.ts` — `'var7'` added to `CheckboxVariants`
- `src/components/Checkbox/Checkbox.tsx` — `var7` added to the `cva` variant map
- `src/components/Checkbox/Checkbox.module.css` — `.checkinput_variant_var7` class
- `src/components/Checkbox/Checkbox.stories.tsx` — `Var7Checked` story
- `src/components/CheckboxMultiSelect/CheckboxMultiSelect.stories.tsx` — "Variant 7" item in the variants story
- `.changeset/feat-checkbox-var7-variant.md` — minor bump


# Screenshots

Light Theme

<img width="743" height="232" alt="image" src="https://github.com/user-attachments/assets/591a524a-bff4-46bc-88dc-66bc3425798b" />
<img width="318" height="229" alt="image" src="https://github.com/user-attachments/assets/d6bc38a5-a5eb-4492-b3bb-25728b5c1d60" />


Dark Theme
<img width="297" height="245" alt="image" src="https://github.com/user-attachments/assets/0d688ecb-f946-45eb-90d8-373c340c1b96" />
<img width="384" height="243" alt="image" src="https://github.com/user-attachments/assets/5b4a5dda-31d2-49b8-8f45-3d1df594d708" />
