### PR TITLE
ci(publish): run publish workflows on Node 24, drop npm@latest upgrade

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,14 +78,10 @@ jobs:
           npm pkg set version=$NEW_VERSION --no-git-tag-version
       - uses: actions/setup-node@v6
         with:
-          node-version: '23.x'
-          # registry-url is required for OIDC trusted publishing. Avoid `npm install -g npm@latest`
-          # on hosted runners — it can leave npm broken (e.g. MODULE_NOT_FOUND / promise-retry).
+          # Node 24.x bundles npm >= 11.5.1, which supports OIDC trusted publishing,
+          # so no global npm upgrade is needed. registry-url is required for OIDC.
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
-      - name: Upgrade npm for OIDC support
-        run: |
-          npm install -g npm@latest
-          echo "npm version: $(npm --version)"
       - name: Enable Corepack
         run: corepack enable
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,8 +78,8 @@ jobs:
           npm pkg set version=$NEW_VERSION --no-git-tag-version
       - uses: actions/setup-node@v6
         with:
-          # Node 24.x bundles npm >= 11.5.1, which supports OIDC trusted publishing,
-          # so no global npm upgrade is needed. registry-url is required for OIDC.
+          # Node 24.x bundles npm >= 11.5.1, which supports OIDC trusted publishing.
+          # registry-url is required for OIDC.
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
       - name: Enable Corepack

--- a/.github/workflows/release-publisher.yml
+++ b/.github/workflows/release-publisher.yml
@@ -102,8 +102,8 @@ jobs:
         if: steps.verify-merge.outputs.is_release == 'true'
         uses: actions/setup-node@v6
         with:
-          # Node 24.x bundles npm >= 11.5.1, which supports OIDC trusted publishing,
-          # so no global npm upgrade is needed. registry-url is required for OIDC.
+          # Node 24.x bundles npm >= 11.5.1, which supports OIDC trusted publishing.
+          # registry-url is required for OIDC.
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
 

--- a/.github/workflows/release-publisher.yml
+++ b/.github/workflows/release-publisher.yml
@@ -102,14 +102,10 @@ jobs:
         if: steps.verify-merge.outputs.is_release == 'true'
         uses: actions/setup-node@v6
         with:
-          node-version: '23.x'
+          # Node 24.x bundles npm >= 11.5.1, which supports OIDC trusted publishing,
+          # so no global npm upgrade is needed. registry-url is required for OIDC.
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Upgrade npm for OIDC support
-        if: steps.verify-merge.outputs.is_release == 'true'
-        run: |
-          npm install -g npm@latest
-          echo "npm version: $(npm --version)"
 
       - name: Enable Corepack
         if: steps.verify-merge.outputs.is_release == 'true'


### PR DESCRIPTION
## Problem

The `v1.0.0-rc1` publish run failed at the **Upgrade npm for OIDC support** step and never published:

```
npm error code EBADENGINE
npm error engine Not compatible with your version of node/npm: npm@12.0.1
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.9.2","node":"v23.11.1"}
```

`npm install -g npm@latest` now resolves to **npm 12**, which dropped support for Node 23 (an odd-numbered, now-EOL line). Both publish workflows pinned `node-version: '23.x'`, so the step hard-failed with exit code 1 — three steps before `npm publish` ever ran.

## Fix

Bump both publish workflows to **Node 24.x** and remove the global npm upgrade step:

- `setup-node@v6` with `node-version: '24.x'` fetches Node 24.18.0, which bundles **npm 11.16.0** — well past the **npm 11.5.1** threshold for OIDC trusted publishing (first shipped in Node 24.5.0). So the upgrade step is no longer needed, and pinning to the LTS line avoids future `npm@latest` engine surprises.

Files:
- `.github/workflows/publish.yml`
- `.github/workflows/release-publisher.yml`

Verified locally with Node 24.11.1: `yarn test` and `yarn build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)