### PR TITLE
fix(Tooltip): render above the overlay tier so tooltips aren't occluded

### DIFF
--- a/src/components/Tooltip/Tooltip.module.css
+++ b/src/components/Tooltip/Tooltip.module.css
@@ -2,6 +2,9 @@
   --tooltip-max-width: initial;
 
   display: flex;
+  /* Sit above the z-index:1 overlay tier (Dropdown, Menu, ContextMenu, DatePicker)
+     so a tooltip triggered from inside one of them isn't occluded by it. */
+  z-index: 2;
   max-width: var(--tooltip-max-width);
   padding: var(--click-tooltip-space-y) var(--click-tooltip-space-x);
   align-items: flex-start;


### PR DESCRIPTION
## Problem

`Tooltip` content has no `z-index`, while `Dropdown`, `Menu`, `ContextMenu` and `DatePicker` all set `z-index: 1`. When a tooltip's trigger sits inside one of those overlays, the tooltip portals into the same stacking context with an effective `z-index: auto` (0) and renders **behind** the overlay.

<img width="428" height="255" alt="image" src="https://github.com/user-attachments/assets/7b1d8e88-9150-4886-a8c9-8607ab21c3ac" />

This is now easy to hit because `EllipsisContent` shows a real `Tooltip` on overflow: an `EllipsisContent` placed inside a `Dropdown` (e.g. a truncated label in a menu item) shows its tooltip clipped behind the menu.

## Fix

Give tooltip content `z-index: 2` so it sits just above the `z-index: 1` overlay tier. `Toast` remains at the top (`2147483647`).

```css
.content {
  /* Sit above the z-index:1 overlay tier (Dropdown, Menu, ContextMenu, DatePicker)
     so a tooltip triggered from inside one of them isn't occluded by it. */
  z-index: 2;
  ...
}
```

## Verification

Render an `EllipsisContent` with overflowing text inside an open `Dropdown` and hover the trigger — the tooltip now paints above the menu instead of behind it. Existing Tooltip/EllipsisContent stories and visual-regression baselines cover the rendering.