### PR TITLE
fix(Select): snapshot searchable text when a search begins

### DIFF
--- a/.changeset/select-search-refresh.md
+++ b/.changeset/select-search-refresh.md
@@ -1,0 +1,5 @@
+---
+"@clickhouse/click-ui": patch
+---
+
+Select/MultiSelect/CheckboxMultiSelect now snapshot each item's searchable text from the DOM when a search begins, instead of capturing it up front. Search therefore matches text an item changed after the menu opened (e.g. a row that renders from its own state), and the internal capture no longer needs to re-key on the option set.

--- a/src/components/Select/Select.search.test.tsx
+++ b/src/components/Select/Select.search.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent } from '@testing-library/react';
-import { ReactNode } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import { Select } from '@/components/Select';
 import { renderCUI } from '@/utils/test-utils';
 
@@ -12,6 +12,14 @@ import { renderCUI } from '@/utils/test-utils';
 
 // A row whose visible text comes from a prop, not from string children.
 const ServiceRow = ({ name }: { name: string }) => <span>{name}</span>;
+
+// A row that renders one text on mount and settles on another via its own
+// state — i.e. its text changes after the menu has already opened.
+const LateRow = () => {
+  const [text, setText] = useState('Loading');
+  useEffect(() => setText('Analytics'), []);
+  return <span>{text}</span>;
+};
 
 const open = (getByTestId: (id: string) => HTMLElement) =>
   fireEvent.click(getByTestId('select-trigger'));
@@ -100,6 +108,22 @@ describe('InternalSelect search', () => {
       type(getByTestId, 'bill');
       expect(queryByText('Billing')).toBeVisible();
       expect(queryByText('Analytics')).not.toBeVisible();
+    });
+
+    it('matches text a row settled on after the menu opened', () => {
+      const { getByTestId, queryByText } = renderChildren(
+        <>
+          <Select.Item value="a">
+            <LateRow />
+          </Select.Item>
+          <Select.Item value="b">Billing</Select.Item>
+        </>
+      );
+      open(getByTestId);
+      // LateRow now reads "Analytics"; the snapshot is taken on this keystroke.
+      type(getByTestId, 'analyt');
+      expect(queryByText('Analytics')).toBeVisible();
+      expect(queryByText('Billing')).not.toBeVisible();
     });
 
     it('restores every item when the search is cleared', () => {

--- a/src/components/Select/common/InternalSelect.tsx
+++ b/src/components/Select/common/InternalSelect.tsx
@@ -234,29 +234,34 @@ export const InternalSelect = ({
     return [];
   }, [children, options, registerValueNode]);
 
-  // Radix mounts the popover content a commit after `open` flips, so the item
-  // text is read once the list node itself commits.
-  const listRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      if (!node) {
+  const listNode = useRef<HTMLDivElement | null>(null);
+
+  const captureSearchSource = useCallback(() => {
+    const root = listNode.current;
+    if (!root) {
+      return;
+    }
+    const next = new Map<string, string>();
+    root.querySelectorAll<HTMLElement>('[cui-select-item][data-value]').forEach(el => {
+      const value = el.getAttribute('data-value');
+      if (value === null) {
         return;
       }
-      const next = new Map<string, string>();
-      node.querySelectorAll<HTMLElement>('[cui-select-item][data-value]').forEach(el => {
-        const value = el.getAttribute('data-value');
-        if (value === null) {
-          return;
-        }
-        const group = el.closest('[cui-select-group]');
-        const heading =
-          group?.querySelector('[cui-select-group-name]')?.textContent ?? '';
-        next.set(value, `${el.textContent ?? ''} ${heading}`.toLowerCase());
-      });
-      setSearchSource(next);
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- depend on normalizedOptions to re-read DOM if options change
-    [normalizedOptions]
-  );
+      const group = el.closest('[cui-select-group]');
+      const heading = group?.querySelector('[cui-select-group-name]')?.textContent ?? '';
+      next.set(value, `${el.textContent ?? ''} ${heading}`.toLowerCase());
+    });
+    setSearchSource(next);
+  }, []);
+
+  const onSearchChange = (next: string) => {
+    if (search === '' && next !== '') {
+      // recapture searchable text from DOM when a new search begins
+      // to make sure it's not stale (e.g. an item changed its contents for any reason)
+      captureSearchSource();
+    }
+    setSearch(next);
+  };
 
   const matchedOptions = useMemo(() => {
     if (search === '') {
@@ -442,7 +447,7 @@ export const InternalSelect = ({
                   <SearchBar
                     ref={inputRef}
                     value={search}
-                    onChange={e => setSearch(e.target.value)}
+                    onChange={e => onSearchChange(e.target.value)}
                     data-testid="select-search-input"
                     onKeyDown={onKeyDown}
                     $showSearch={showSearch}
@@ -460,7 +465,7 @@ export const InternalSelect = ({
                   />
                 </SearchBarContainer>
                 <SelectListContent
-                  ref={listRef}
+                  ref={listNode}
                   $maxHeight={maxHeight}
                 >
                   <OptionContext.Provider value={optionContextValue}>


### PR DESCRIPTION
## What

Follow-up to #1154. `Select` / `MultiSelect` / `CheckboxMultiSelect` now snapshot each item's rendered text from the DOM **when a search begins**, instead of capturing it up front.

## Why

#1154 read item text into `searchSource` at mount, via a callback ref re-keyed on the option set. That snapshot went stale if an item's text changed after the menu opened *without the option set changing* — e.g. a row that renders from its own state and settles on its label after mount. It also needed an `eslint-disable` for the intentional ref dependency.

## How

- `onSearchChange` takes the snapshot on the first keystroke of a search (`'' → non-empty`), then filters.
- Filtered items stay mounted (hidden, from #1154), so reading the DOM at that moment is complete and current.
- Removes the option-set-keyed callback ref and its `eslint-disable`; visibility, navigation, and highlight stay derived.

## Tradeoff

Options that arrive *while a query is already active* aren't re-snapshotted until the search is cleared and restarted. Niche — a consumer feeding options from a server as you type generally doesn't want click-ui's client-side filter running on top.

## Testing

Added a case for text a row settles on after the menu opened; existing Select-family search suites unchanged. 83 tests green; `tsc` and ESLint clean (no suppressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)