### PR TITLE
fix(DatePicker): fix off-by-one error in DateRangePicker and DateTimeRangePicker

### DIFF
--- a/.changeset/fix-max-range-length-off-by-one.md
+++ b/.changeset/fix-max-range-length-off-by-one.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': patch
+---
+
+Fix `maxRangeLength` off-by-one error in `DateRangePicker` and `DateTimeRangePicker`. `maxRangeLength={31}` now only allows a 31 day range instead of 32. `DateTimeRangePicker` now measures the range in calendar days, so a start date's time of day prevents an off-by-two error.

--- a/src/components/DatePicker/DateRangePicker.test.tsx
+++ b/src/components/DatePicker/DateRangePicker.test.tsx
@@ -319,6 +319,27 @@ describe('DateRangePicker', () => {
 
       expect(handleSelectDate).not.toHaveBeenCalled();
     });
+
+    it('counts the start date towards the max range length', async () => {
+      const startDate = new Date('07-04-2020');
+      const handleSelectDate = vi.fn();
+
+      const { getByTestId, findByText } = renderCUI(
+        <DateRangePicker
+          startDate={startDate}
+          onSelectDateRange={handleSelectDate}
+          maxRangeLength={5}
+        />
+      );
+
+      await userEvent.click(getByTestId('daterangepicker-input'));
+      // Jul 9 would make Jul 4 – Jul 9 a 6 day range.
+      await userEvent.click(await findByText('9'));
+      expect(handleSelectDate).not.toHaveBeenCalled();
+
+      await userEvent.click(await findByText('8'));
+      expect(handleSelectDate).toHaveBeenCalledWith(startDate, new Date('07-08-2020'));
+    });
   });
 
   describe('predefined date ranges', () => {

--- a/src/components/DatePicker/DateTimeRangePicker.test.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.test.tsx
@@ -452,6 +452,29 @@ describe('DateTimeRangePicker', () => {
       expect(handleSelectDate).toHaveBeenCalled();
     });
 
+    it('measures the max range length in calendar days, ignoring the time of day', async () => {
+      const startDate = new Date('07-04-2020 11:30');
+      const handleSelectDate = vi.fn();
+
+      const { getByTestId, getByText } = renderCUI(
+        <DateTimeRangePicker
+          startDate={startDate}
+          onSelectDateRange={handleSelectDate}
+          maxRangeLength={15}
+        />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+      await userEvent.click(getByText('End date'));
+
+      // Jul 19 would make Jul 4 – Jul 19 a 16 day range.
+      await userEvent.click(getByText('19'));
+      expect(handleSelectDate).not.toHaveBeenCalled();
+
+      await userEvent.click(getByText('18'));
+      expect(handleSelectDate).toHaveBeenCalled();
+    });
+
     it('allows picking an end date before the start date when an end date is already set', async () => {
       const handleSelectDate = vi.fn();
       const startDate = new Date('07-10-2020 12:00');

--- a/src/components/DatePicker/utils.test.ts
+++ b/src/components/DatePicker/utils.test.ts
@@ -26,11 +26,22 @@ describe('DatePicker utils', () => {
       expect(datesAreWithinMaxRange(startDate, endDate, 15)).toBeFalsy();
     });
 
-    it('is inclusive with dates', () => {
+    it('counts both endpoints towards the range', () => {
       const startDate = new Date('07-01-2025');
-      const endDate = new Date('07-16-2025');
 
-      expect(datesAreWithinMaxRange(startDate, endDate, 15)).toBeTruthy();
+      expect(datesAreWithinMaxRange(startDate, new Date('07-15-2025'), 15)).toBeTruthy();
+      expect(datesAreWithinMaxRange(startDate, new Date('07-16-2025'), 15)).toBeFalsy();
+    });
+
+    it('ignores the time of day', () => {
+      const startDate = new Date('07-01-2025 12:00');
+
+      expect(
+        datesAreWithinMaxRange(startDate, new Date('07-15-2025 00:00'), 15)
+      ).toBeTruthy();
+      expect(
+        datesAreWithinMaxRange(startDate, new Date('07-16-2025 00:00'), 15)
+      ).toBeFalsy();
     });
   });
 

--- a/src/components/DatePicker/utils.ts
+++ b/src/components/DatePicker/utils.ts
@@ -194,9 +194,12 @@ export const datesAreWithinMaxRange = (
   endDate: Date,
   maxRangeLength: number
 ): boolean => {
-  const daysDifference = Math.abs(dayjs(startDate).diff(dayjs(endDate), 'days'));
+  // Compare calendar days; dayjs would otherwise drop a partial day from the diff.
+  const daysDifference = Math.abs(
+    dayjs(startDate).startOf('day').diff(dayjs(endDate).startOf('day'), 'days')
+  );
 
-  return daysDifference <= maxRangeLength;
+  return daysDifference < maxRangeLength;
 };
 
 export const isDateRangeTheWholeMonth = (


### PR DESCRIPTION
## Why?

- `datesAreWithinMaxRange` would check `<=` instead of `<` which would allow `maxRangeLength + 1` in certain cases, and with certain time combinations in `DateTimeRangePicker`, would allow `maxRangeLength + 2`.

## How?

- Change `<=` to `<` and check based on the start of day.