### PR TITLE
fix(DateTimeRangePicker): loosen up check on whether selected date ranges match predefined dates

### DIFF
--- a/.changeset/fix-datetimerangepicker-predefined-selection.md
+++ b/.changeset/fix-datetimerangepicker-predefined-selection.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': patch
+---
+
+`DateTimeRangePicker`'s check on whether a user selected range matches a predefined range has been made a little looser so that the selected checkmark on a predefined date should be active more often

--- a/src/components/DatePicker/Common.tsx
+++ b/src/components/DatePicker/Common.tsx
@@ -19,14 +19,14 @@ import { Text } from '@/components/Text';
 import { cn, cva } from '@/lib/cva';
 import styles from './Common.module.css';
 import {
-  dateRangeIsValid,
+  Timezone,
   formatDateHeader,
   formatSelectedDate,
   formatSelectedDateTime,
   formatSelectedDateTimeWithSeconds,
   formatWeekday,
+  isDateRangeValid,
   shiftToTimezone,
-  Timezone,
 } from './utils';
 import { getMonthNames, DAYS, MONTHS, YEARS, DAYS_IN_WEEK } from '@/utils/date';
 import { Dropdown } from '@/components/Dropdown';
@@ -328,7 +328,7 @@ export const DateTimeRangePickerInput = ({
   const startDateIsAfterEndDate =
     selectedStartDate &&
     selectedEndDate &&
-    !dateRangeIsValid({
+    !isDateRangeValid({
       startDate: selectedStartDate,
       endDate: selectedEndDate,
     });

--- a/src/components/DatePicker/DateRangePicker.tsx
+++ b/src/components/DatePicker/DateRangePicker.tsx
@@ -29,13 +29,13 @@ import { cn, cva } from '@/lib/cva';
 import styles from './DateRangePicker.module.css';
 import {
   DateRange,
-  datesAreWithinMaxRange,
+  Timezone,
+  areDatesWithinMaxRange,
   formatDateHeader,
   formatSelectedDate,
-  shiftFromTimezone,
   isDateNotInAllowList,
   isDateRangeTheWholeMonth,
-  Timezone,
+  shiftFromTimezone,
   shiftToTimezone,
 } from './utils';
 
@@ -233,7 +233,7 @@ const Calendar = ({
           if (
             maxRangeLength > 1 &&
             shiftedStart &&
-            !datesAreWithinMaxRange(shiftedStart, fullDate, maxRangeLength) &&
+            !areDatesWithinMaxRange(shiftedStart, fullDate, maxRangeLength) &&
             fullDate > shiftedStart
           ) {
             isDisabled = true;

--- a/src/components/DatePicker/DateTimeRangePicker.test.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.test.tsx
@@ -1244,9 +1244,103 @@ describe('DateTimeRangePicker', () => {
       );
       expect(selected).toHaveLength(1);
     });
+
+    it('marks a multi-day predefined range as selected when the dates were picked by hand', async () => {
+      const predefinedTimesList = getPredefinedTimePeriodsForDateTimePicker();
+      const pastMonth = predefinedTimesList.find(item => item.label === 'Past month');
+      if (!pastMonth) {
+        throw new Error('expected a "Past month" predefined range');
+      }
+
+      const { getByTestId } = renderCUI(
+        <DateTimeRangePicker
+          onSelectDateRange={vi.fn()}
+          predefinedTimesList={predefinedTimesList}
+          startDate={new Date('June 04 2020 12:00')}
+          endDate={new Date('July 04 2020 12:00')}
+        />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+
+      expect(getByTestId('Past month')).toHaveAttribute('data-selected', 'true');
+
+      const selected = document.querySelectorAll(
+        '[data-testid="predefined-times-list"] [data-selected="true"]'
+      );
+      expect(selected).toHaveLength(1);
+    });
+
+    it('keeps a predefined range selected when the list is rebuilt on a later render', async () => {
+      const pastHour = getPredefinedTimePeriodsForDateTimePicker().find(
+        item => item.label === 'Past hour'
+      );
+      if (!pastHour) {
+        throw new Error('expected a "Past hour" predefined range');
+      }
+
+      const { getByTestId, rerender } = renderCUI(
+        <DateTimeRangePicker
+          onSelectDateRange={vi.fn()}
+          predefinedTimesList={getPredefinedTimePeriodsForDateTimePicker()}
+          startDate={new Date(pastHour.dateRange.startDate)}
+          endDate={new Date(pastHour.dateRange.endDate)}
+        />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+
+      vi.setSystemTime(new Date('07-04-2020 11:30:20 AM'));
+
+      rerender(
+        <DateTimeRangePicker
+          onSelectDateRange={vi.fn()}
+          predefinedTimesList={getPredefinedTimePeriodsForDateTimePicker()}
+          startDate={new Date(pastHour.dateRange.startDate)}
+          endDate={new Date(pastHour.dateRange.endDate)}
+        />
+      );
+
+      expect(getByTestId('Past hour')).toHaveAttribute('data-selected', 'true');
+    });
   });
 
   describe('when configured for the UTC timezone', () => {
+    it('checks the predefined range covering the same UTC days as the selection', async () => {
+      const predefinedTimesList = [
+        {
+          dateRange: {
+            startDate: new Date('2026-04-24T02:00:00Z'),
+            endDate: new Date('2026-05-01T02:00:00Z'),
+          },
+          label: 'Past week',
+        },
+        {
+          dateRange: {
+            startDate: new Date('2026-04-17T02:00:00Z'),
+            endDate: new Date('2026-05-01T02:00:00Z'),
+          },
+          label: 'Past 2 weeks',
+        },
+      ];
+
+      // The same UTC days as "Past week", at a time that falls on a different local day.
+      const { getByTestId } = renderCUI(
+        <DateTimeRangePicker
+          endDate={new Date('2026-05-01T22:00:00Z')}
+          onSelectDateRange={vi.fn()}
+          predefinedTimesList={predefinedTimesList}
+          startDate={new Date('2026-04-24T22:00:00Z')}
+          timezone="UTC"
+        />
+      );
+
+      await userEvent.click(getByTestId('datetimepicker-input'));
+
+      expect(getByTestId('Past week')).toHaveAttribute('data-selected', 'true');
+      expect(getByTestId('Past 2 weeks')).toHaveAttribute('data-selected', 'false');
+    });
+
     it('renders both endpoints from their UTC date and time fields', () => {
       const startDate = new Date('2026-04-30T08:00:00Z');
       const endDate = new Date('2026-04-30T14:30:00Z');

--- a/src/components/DatePicker/DateTimeRangePicker.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.tsx
@@ -26,13 +26,13 @@ import { Panel } from '../Panel/Panel';
 import { Icon } from '../Icon/Icon';
 import {
   DateRangeListItem,
-  dateRangeMatchesPredefinedRange,
-  datesAreWithinMaxRange,
-  shiftFromTimezone,
   Meridiem,
   Timezone,
+  areDatesWithinMaxRange,
+  isDateRangeValid,
+  isDateRangeWithinRange,
+  shiftFromTimezone,
   shiftToTimezone,
-  dateRangeIsValid,
 } from './utils';
 import { dayjs, Dayjs } from '@/utils/date';
 import { Tabs } from '../Tabs/Tabs';
@@ -302,7 +302,7 @@ const Calendar = ({
           if (
             maxRangeLength > 1 &&
             shiftedStart &&
-            !datesAreWithinMaxRange(shiftedStart, fullDate, maxRangeLength)
+            !areDatesWithinMaxRange(shiftedStart, fullDate, maxRangeLength)
           ) {
             isDisabled = true;
           }
@@ -469,7 +469,7 @@ const PredefinedTimes = ({
 
           const rangeIsSelected =
             selectedRange !== undefined &&
-            dateRangeMatchesPredefinedRange(selectedRange, dateRange, timezone);
+            isDateRangeWithinRange(selectedRange, dateRange, timezone);
 
           return (
             <StyledDropdownItem
@@ -814,7 +814,7 @@ const TabbedCalendar = ({
   }
 
   const startDateIsAfterEndDate =
-    startDate && endDate && !dateRangeIsValid({ startDate, endDate });
+    startDate && endDate && !isDateRangeValid({ startDate, endDate });
 
   return (
     <BottomPaddingTabs
@@ -1041,7 +1041,7 @@ export const DateTimeRangePicker = ({
         if (selectedEndDate) {
           if (
             !shouldFireIfInvalid &&
-            !dateRangeIsValid({ startDate: selectedDate, endDate: selectedEndDate })
+            !isDateRangeValid({ startDate: selectedDate, endDate: selectedEndDate })
           ) {
             return;
           }
@@ -1060,7 +1060,7 @@ export const DateTimeRangePicker = ({
         if (selectedStartDate) {
           if (
             !shouldFireIfInvalid &&
-            !dateRangeIsValid({ startDate: selectedStartDate, endDate: selectedDate })
+            !isDateRangeValid({ startDate: selectedStartDate, endDate: selectedDate })
           ) {
             return;
           }

--- a/src/components/DatePicker/DateTimeRangePicker.tsx
+++ b/src/components/DatePicker/DateTimeRangePicker.tsx
@@ -26,6 +26,7 @@ import { Panel } from '../Panel/Panel';
 import { Icon } from '../Icon/Icon';
 import {
   DateRangeListItem,
+  dateRangeMatchesPredefinedRange,
   datesAreWithinMaxRange,
   shiftFromTimezone,
   Meridiem,
@@ -426,6 +427,7 @@ interface PredefinedTimesProps {
   setStartDate: Dispatch<SetStateAction<Date | undefined>>;
   shouldShowCustomRange: boolean;
   showCustomDateRange: Dispatch<SetStateAction<boolean>>;
+  timezone: Timezone;
 }
 
 const PredefinedTimes = ({
@@ -437,6 +439,7 @@ const PredefinedTimes = ({
   setStartDate,
   shouldShowCustomRange,
   showCustomDateRange,
+  timezone,
 }: PredefinedTimesProps) => {
   const handleCustomTimePeriodClick = (event: MouseEvent) => {
     event.preventDefault();
@@ -450,18 +453,23 @@ const PredefinedTimes = ({
       orientation="vertical"
     >
       <ScrollableContainer orientation="vertical">
-        {predefinedTimesList.map(({ dateRange: { startDate, endDate }, label }) => {
+        {predefinedTimesList.map(({ dateRange, label }) => {
+          const { startDate, endDate } = dateRange;
+
           const handleItemClick = () => {
             setStartDate(startDate);
             setEndDate(endDate);
             onSelectDateRange(startDate, endDate, label);
           };
 
+          const selectedRange =
+            selectedStartDate && selectedEndDate
+              ? { startDate: selectedStartDate, endDate: selectedEndDate }
+              : undefined;
+
           const rangeIsSelected =
-            selectedEndDate &&
-            selectedEndDate.getTime() === endDate.getTime() &&
-            selectedStartDate &&
-            selectedStartDate.getTime() === startDate.getTime();
+            selectedRange !== undefined &&
+            dateRangeMatchesPredefinedRange(selectedRange, dateRange, timezone);
 
           return (
             <StyledDropdownItem
@@ -1126,6 +1134,7 @@ export const DateTimeRangePicker = ({
                 setStartDate={setSelectedStartDate}
                 shouldShowCustomRange={shouldShowCustomRange}
                 showCustomDateRange={setShouldShowCustomRange}
+                timezone={timezone}
               />
 
               {shouldShowCustomRange && (

--- a/src/components/DatePicker/utils.test.ts
+++ b/src/components/DatePicker/utils.test.ts
@@ -1,6 +1,7 @@
 import {
   DateRange,
   dateRangeIsValid,
+  dateRangeMatchesPredefinedRange,
   datesAreWithinMaxRange,
   formatSelectedDate,
   formatSelectedDateTime,
@@ -42,6 +43,105 @@ describe('DatePicker utils', () => {
       expect(
         datesAreWithinMaxRange(startDate, new Date('07-16-2025 00:00'), 15)
       ).toBeFalsy();
+    });
+  });
+
+  describe('matching a selected range against a predefined range', () => {
+    const pastWeek: DateRange = {
+      startDate: new Date('July 28 2025 14:30'),
+      endDate: new Date('August 04 2025 14:30'),
+    };
+
+    it('matches a multi-day range picked by hand on the same dates', () => {
+      const handPicked: DateRange = {
+        startDate: new Date('July 28 2025 12:00'),
+        endDate: new Date('August 04 2025 12:00'),
+      };
+
+      expect(dateRangeMatchesPredefinedRange(handPicked, pastWeek)).toBeTruthy();
+    });
+
+    it('does not match a multi-day range on different dates', () => {
+      const handPicked: DateRange = {
+        startDate: new Date('July 27 2025 12:00'),
+        endDate: new Date('August 04 2025 12:00'),
+      };
+
+      expect(dateRangeMatchesPredefinedRange(handPicked, pastWeek)).toBeFalsy();
+    });
+
+    it('tolerates the drift of a predefined list rebuilt a moment later', () => {
+      const rebuilt: DateRange = {
+        startDate: new Date('July 28 2025 14:30:02'),
+        endDate: new Date('August 04 2025 14:30:02'),
+      };
+
+      expect(dateRangeMatchesPredefinedRange(rebuilt, pastWeek)).toBeTruthy();
+    });
+
+    describe('when configured for the UTC timezone', () => {
+      it('matches on UTC calendar days, not local ones', () => {
+        // Same UTC days at both ends, but times that land on a different local day.
+        const predefinedRange: DateRange = {
+          startDate: new Date('2025-08-04T02:00:00Z'),
+          endDate: new Date('2025-08-11T02:00:00Z'),
+        };
+        const middleOfTheUtcDay: DateRange = {
+          startDate: new Date('2025-08-04T12:00:00Z'),
+          endDate: new Date('2025-08-11T12:00:00Z'),
+        };
+        const endOfTheUtcDay: DateRange = {
+          startDate: new Date('2025-08-04T22:00:00Z'),
+          endDate: new Date('2025-08-11T22:00:00Z'),
+        };
+
+        expect(
+          dateRangeMatchesPredefinedRange(middleOfTheUtcDay, predefinedRange, 'UTC')
+        ).toBeTruthy();
+        expect(
+          dateRangeMatchesPredefinedRange(endOfTheUtcDay, predefinedRange, 'UTC')
+        ).toBeTruthy();
+      });
+
+      it('does not match a range on a different UTC day', () => {
+        const predefinedRange: DateRange = {
+          startDate: new Date('2025-08-04T02:00:00Z'),
+          endDate: new Date('2025-08-11T02:00:00Z'),
+        };
+        const aDayLate: DateRange = {
+          startDate: new Date('2025-08-05T02:00:00Z'),
+          endDate: new Date('2025-08-11T02:00:00Z'),
+        };
+
+        expect(
+          dateRangeMatchesPredefinedRange(aDayLate, predefinedRange, 'UTC')
+        ).toBeFalsy();
+      });
+    });
+
+    describe('for ranges shorter than a day', () => {
+      const pastHour: DateRange = {
+        startDate: new Date('August 04 2025 13:30'),
+        endDate: new Date('August 04 2025 14:30'),
+      };
+
+      it('matches on time, within a minute of drift', () => {
+        const rebuilt: DateRange = {
+          startDate: new Date('August 04 2025 13:30:20'),
+          endDate: new Date('August 04 2025 14:30:20'),
+        };
+
+        expect(dateRangeMatchesPredefinedRange(rebuilt, pastHour)).toBeTruthy();
+      });
+
+      it('does not match another range on the same dates', () => {
+        const pastSixHours: DateRange = {
+          startDate: new Date('August 04 2025 08:30'),
+          endDate: new Date('August 04 2025 14:30'),
+        };
+
+        expect(dateRangeMatchesPredefinedRange(pastSixHours, pastHour)).toBeFalsy();
+      });
     });
   });
 

--- a/src/components/DatePicker/utils.test.ts
+++ b/src/components/DatePicker/utils.test.ts
@@ -1,13 +1,13 @@
 import {
   DateRange,
-  dateRangeIsValid,
-  dateRangeMatchesPredefinedRange,
-  datesAreWithinMaxRange,
+  areDatesWithinMaxRange,
   formatSelectedDate,
   formatSelectedDateTime,
-  shiftFromTimezone,
   isDateNotInAllowList,
   isDateRangeTheWholeMonth,
+  isDateRangeValid,
+  isDateRangeWithinRange,
+  shiftFromTimezone,
   shiftToTimezone,
 } from './utils';
 
@@ -17,31 +17,31 @@ describe('DatePicker utils', () => {
       const startDate = new Date('07-01-2025');
       const endDate = new Date('07-08-2025');
 
-      expect(datesAreWithinMaxRange(startDate, endDate, 15)).toBeTruthy();
+      expect(areDatesWithinMaxRange(startDate, endDate, 15)).toBeTruthy();
     });
 
     it('returns false if the two dates are not within the range', () => {
       const startDate = new Date('07-01-2025');
       const endDate = new Date('07-31-2025');
 
-      expect(datesAreWithinMaxRange(startDate, endDate, 15)).toBeFalsy();
+      expect(areDatesWithinMaxRange(startDate, endDate, 15)).toBeFalsy();
     });
 
     it('counts both endpoints towards the range', () => {
       const startDate = new Date('07-01-2025');
 
-      expect(datesAreWithinMaxRange(startDate, new Date('07-15-2025'), 15)).toBeTruthy();
-      expect(datesAreWithinMaxRange(startDate, new Date('07-16-2025'), 15)).toBeFalsy();
+      expect(areDatesWithinMaxRange(startDate, new Date('07-15-2025'), 15)).toBeTruthy();
+      expect(areDatesWithinMaxRange(startDate, new Date('07-16-2025'), 15)).toBeFalsy();
     });
 
     it('ignores the time of day', () => {
       const startDate = new Date('07-01-2025 12:00');
 
       expect(
-        datesAreWithinMaxRange(startDate, new Date('07-15-2025 00:00'), 15)
+        areDatesWithinMaxRange(startDate, new Date('07-15-2025 00:00'), 15)
       ).toBeTruthy();
       expect(
-        datesAreWithinMaxRange(startDate, new Date('07-16-2025 00:00'), 15)
+        areDatesWithinMaxRange(startDate, new Date('07-16-2025 00:00'), 15)
       ).toBeFalsy();
     });
   });
@@ -58,7 +58,7 @@ describe('DatePicker utils', () => {
         endDate: new Date('August 04 2025 12:00'),
       };
 
-      expect(dateRangeMatchesPredefinedRange(handPicked, pastWeek)).toBeTruthy();
+      expect(isDateRangeWithinRange(handPicked, pastWeek)).toBeTruthy();
     });
 
     it('does not match a multi-day range on different dates', () => {
@@ -67,7 +67,7 @@ describe('DatePicker utils', () => {
         endDate: new Date('August 04 2025 12:00'),
       };
 
-      expect(dateRangeMatchesPredefinedRange(handPicked, pastWeek)).toBeFalsy();
+      expect(isDateRangeWithinRange(handPicked, pastWeek)).toBeFalsy();
     });
 
     it('tolerates the drift of a predefined list rebuilt a moment later', () => {
@@ -76,7 +76,7 @@ describe('DatePicker utils', () => {
         endDate: new Date('August 04 2025 14:30:02'),
       };
 
-      expect(dateRangeMatchesPredefinedRange(rebuilt, pastWeek)).toBeTruthy();
+      expect(isDateRangeWithinRange(rebuilt, pastWeek)).toBeTruthy();
     });
 
     describe('when configured for the UTC timezone', () => {
@@ -96,10 +96,10 @@ describe('DatePicker utils', () => {
         };
 
         expect(
-          dateRangeMatchesPredefinedRange(middleOfTheUtcDay, predefinedRange, 'UTC')
+          isDateRangeWithinRange(middleOfTheUtcDay, predefinedRange, 'UTC')
         ).toBeTruthy();
         expect(
-          dateRangeMatchesPredefinedRange(endOfTheUtcDay, predefinedRange, 'UTC')
+          isDateRangeWithinRange(endOfTheUtcDay, predefinedRange, 'UTC')
         ).toBeTruthy();
       });
 
@@ -113,9 +113,7 @@ describe('DatePicker utils', () => {
           endDate: new Date('2025-08-11T02:00:00Z'),
         };
 
-        expect(
-          dateRangeMatchesPredefinedRange(aDayLate, predefinedRange, 'UTC')
-        ).toBeFalsy();
+        expect(isDateRangeWithinRange(aDayLate, predefinedRange, 'UTC')).toBeFalsy();
       });
     });
 
@@ -131,7 +129,7 @@ describe('DatePicker utils', () => {
           endDate: new Date('August 04 2025 14:30:20'),
         };
 
-        expect(dateRangeMatchesPredefinedRange(rebuilt, pastHour)).toBeTruthy();
+        expect(isDateRangeWithinRange(rebuilt, pastHour)).toBeTruthy();
       });
 
       it('does not match another range on the same dates', () => {
@@ -140,7 +138,7 @@ describe('DatePicker utils', () => {
           endDate: new Date('August 04 2025 14:30'),
         };
 
-        expect(dateRangeMatchesPredefinedRange(pastSixHours, pastHour)).toBeFalsy();
+        expect(isDateRangeWithinRange(pastSixHours, pastHour)).toBeFalsy();
       });
     });
   });
@@ -245,7 +243,7 @@ describe('DatePicker utils', () => {
   describe('validating a date range', () => {
     it('rejects a range with no start date', () => {
       expect(
-        dateRangeIsValid({
+        isDateRangeValid({
           startDate: undefined as unknown as Date,
           endDate: new Date('2026-04-30'),
         })
@@ -254,7 +252,7 @@ describe('DatePicker utils', () => {
 
     it('rejects a range with no end date', () => {
       expect(
-        dateRangeIsValid({
+        isDateRangeValid({
           startDate: new Date('2026-04-01'),
           endDate: undefined as unknown as Date,
         })
@@ -262,12 +260,12 @@ describe('DatePicker utils', () => {
     });
 
     it('rejects a null date range', () => {
-      expect(dateRangeIsValid(null as unknown as DateRange)).toBe(false);
+      expect(isDateRangeValid(null as unknown as DateRange)).toBe(false);
     });
 
     it('rejects a start date that is a date-shaped string', () => {
       expect(
-        dateRangeIsValid({
+        isDateRangeValid({
           startDate: '2026-04-01' as unknown as Date,
           endDate: new Date('2026-04-30'),
         })
@@ -276,7 +274,7 @@ describe('DatePicker utils', () => {
 
     it('rejects an end date that is a date-shaped string', () => {
       expect(
-        dateRangeIsValid({
+        isDateRangeValid({
           startDate: new Date('2026-04-01'),
           endDate: '2026-04-30' as unknown as Date,
         })
@@ -285,7 +283,7 @@ describe('DatePicker utils', () => {
 
     it('rejects a start date that is a Date holding NaN', () => {
       expect(
-        dateRangeIsValid({
+        isDateRangeValid({
           startDate: new Date('not-a-date'),
           endDate: new Date('2026-04-30'),
         })
@@ -294,7 +292,7 @@ describe('DatePicker utils', () => {
 
     it('rejects an end date that is a Date holding NaN', () => {
       expect(
-        dateRangeIsValid({
+        isDateRangeValid({
           startDate: new Date('2026-04-01'),
           endDate: new Date('not-a-date'),
         })
@@ -303,7 +301,7 @@ describe('DatePicker utils', () => {
 
     it('rejects a range whose start date is after its end date', () => {
       expect(
-        dateRangeIsValid({
+        isDateRangeValid({
           startDate: new Date('2026-04-30'),
           endDate: new Date('2026-04-01'),
         })
@@ -312,7 +310,7 @@ describe('DatePicker utils', () => {
 
     it('accepts a range spanning multiple days', () => {
       expect(
-        dateRangeIsValid({
+        isDateRangeValid({
           startDate: new Date('2026-04-01'),
           endDate: new Date('2026-04-30'),
         })
@@ -322,7 +320,7 @@ describe('DatePicker utils', () => {
     it('accepts a range where start and end are the same date', () => {
       const date = new Date('2026-04-15T12:00:00Z');
       expect(
-        dateRangeIsValid({
+        isDateRangeValid({
           startDate: date,
           endDate: new Date(date.getTime()),
         })
@@ -331,7 +329,7 @@ describe('DatePicker utils', () => {
 
     it('accepts a range starting at the unix epoch', () => {
       expect(
-        dateRangeIsValid({
+        isDateRangeValid({
           startDate: new Date(0),
           endDate: new Date('2026-04-30'),
         })

--- a/src/components/DatePicker/utils.ts
+++ b/src/components/DatePicker/utils.ts
@@ -189,7 +189,7 @@ export const isDateNotInAllowList = (
   allowList.length > 0 &&
   !allowList.some(allowedDate => isSameDate(allowedDate, date));
 
-export const datesAreWithinMaxRange = (
+export const areDatesWithinMaxRange = (
   startDate: Date,
   endDate: Date,
   maxRangeLength: number
@@ -205,7 +205,7 @@ export const datesAreWithinMaxRange = (
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 const toleranceMs = 60 * 1000;
 
-export const dateRangeMatchesPredefinedRange = (
+export const isDateRangeWithinRange = (
   selectedRange: DateRange,
   predefinedRange: DateRange,
   timezone: Timezone = 'system'
@@ -248,7 +248,7 @@ export const isDateRangeTheWholeMonth = (
   return startDateIsFirstDay && endDateIsLastDay;
 };
 
-export const dateRangeIsValid = (dateRange: DateRange): boolean => {
+export const isDateRangeValid = (dateRange: DateRange): boolean => {
   if (!dateRange?.startDate || !dateRange?.endDate) {
     return false;
   }

--- a/src/components/DatePicker/utils.ts
+++ b/src/components/DatePicker/utils.ts
@@ -202,6 +202,35 @@ export const datesAreWithinMaxRange = (
   return daysDifference < maxRangeLength;
 };
 
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const toleranceMs = 60 * 1000;
+
+export const dateRangeMatchesPredefinedRange = (
+  selectedRange: DateRange,
+  predefinedRange: DateRange,
+  timezone: Timezone = 'system'
+): boolean => {
+  const { startDate, endDate } = predefinedRange;
+
+  if (endDate.getTime() - startDate.getTime() < ONE_DAY_MS) {
+    return (
+      Math.abs(selectedRange.startDate.getTime() - startDate.getTime()) <= toleranceMs &&
+      Math.abs(selectedRange.endDate.getTime() - endDate.getTime()) <= toleranceMs
+    );
+  }
+
+  // Shifted the same way the calendar is, so the check agrees with the days it marks.
+  const shiftedSelectedStart = shiftToTimezone(selectedRange.startDate, timezone);
+  const shiftedSelectedEnd = shiftToTimezone(selectedRange.endDate, timezone);
+  const shiftedStart = shiftToTimezone(startDate, timezone);
+  const shiftedEnd = shiftToTimezone(endDate, timezone);
+
+  return (
+    isSameDate(shiftedSelectedStart, shiftedStart) &&
+    isSameDate(shiftedSelectedEnd, shiftedEnd)
+  );
+};
+
 export const isDateRangeTheWholeMonth = (
   { startDate, endDate }: DateRange,
   timezone: Timezone = 'system'


### PR DESCRIPTION
## Why?

When selecting user-defined date ranges when predefined dates exist, if the date range matched a predefined date (e.g. last hour), the predefined date should get a selected indicator. This often didn't happen in practice due to re-renders and pad comparisons. This worked fine in storybook because the page didn't re-render at a different time. The check has been tweaked to be loosened in checks within hours, and uses `isSameDate` headless calendar's internal comparison tool

## How?

- Loosen up the check within days to check if the dates match
- Use `isSameDate` to check if calendar dates are aligned