### PR TITLE
fix: use a box-drawing-capable monospace font for the mono typography token

### DIFF
--- a/.changeset/mono-font-box-drawing.md
+++ b/.changeset/mono-font-box-drawing.md
@@ -1,0 +1,5 @@
+---
+"@clickhouse/click-ui": minor
+---
+
+Use a box-drawing-capable monospace font stack (DejaVu Sans Mono, Liberation Mono, MonoLisa, Consolas) for the `mono` typography token, and `line-height: normal` for the mono text styles, so box-drawing characters (U+2500–U+259F) used by ClickHouse Pretty* output formats render as seamless frames.

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,12 +1,8 @@
 <link rel="preconnect" href="https://rsms.me/">
 <link rel="stylesheet" href="https://rsms.me/inter/inter.css">
 
-<!-- Mono font used by the `mono` typography token ("Inconsolata"). Loaded here so
-     story canvases (and visual-regression screenshots) render the real font instead
-     of a host-dependent monospace fallback. -->
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inconsolata:wght@200..900&display=swap">
+<!-- The `mono` typography token resolves to system fonts (DejaVu Sans Mono /
+     Liberation Mono / MonoLisa / Consolas), so no mono webfont is loaded here. -->
 
 <style>
 	.sbdocs-preview, .docs-story, .docs-story > div:first-child {

--- a/.storybook/theme.ts
+++ b/.storybook/theme.ts
@@ -13,5 +13,5 @@ export default create({
   fontBase:  `"Inter", "SF Pro Display", -apple-system,
   BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
   "Open Sans", "Helvetica Neue", sans-serif;`,
-  fontCode: `"Inconsolata", "SFMono Regular", monospace;`,
+  fontCode: `"DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace;`,
 });

--- a/src/theme/styles/tokens-dark.css
+++ b/src/theme/styles/tokens-dark.css
@@ -672,7 +672,7 @@
   --click-codeblock-space-gap: 1.5rem;
   --click-codeblock-radii-all: 0.25rem;
   --click-codeblock-stroke: 1px;
-  --click-codeblock-typography-text-default: 500 0.875rem/1.7 "Inconsolata", Consolas, "SFMono Regular", monospace;
+  --click-codeblock-typography-text-default: 500 0.875rem/normal "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace;
   --click-codeblock-numbers-size-width: 1.5rem;
   --click-codeblock-darkMode-color-background-default: #282828;
   --click-codeblock-darkMode-color-text-default: #ffffff;
@@ -692,7 +692,7 @@
   --click-codeblock-monacoTheme-parameter-background: rgb(62.745% 62.745% 62.745% / 0.2);
   --click-codeInline-space-x: 0.25rem;
   --click-codeInline-stroke: 1px;
-  --click-codeInline-typography-text-default: 500 0.875rem/1.7 "Inconsolata", Consolas, "SFMono Regular", monospace;
+  --click-codeInline-typography-text-default: 500 0.875rem/normal "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace;
   --click-codeInline-radii-all: 0.25rem;
   --click-codeInline-color-background-default: #282828;
   --click-codeInline-color-text-default: #ffffff;
@@ -998,7 +998,7 @@
   --click-grid-body-cell-color-text-default: lch(100 0 none);
   --click-grid-body-cell-color-text-selectIndirect: #ffffff;
   --click-grid-body-cell-color-text-selectDirect: #ffffff;
-  --click-grid-cell-text-default: 500 0.875rem/1.5 "Inconsolata", Consolas, "SFMono Regular", monospace;
+  --click-grid-cell-text-default: 500 0.875rem/1.5 "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace;
   --click-grid-radii-none: 0;
   --click-grid-radii-sm: 0.25rem;
   --click-grid-radii-md: 0.5rem;
@@ -1686,7 +1686,7 @@
   --sizes-10: 2.5rem;
   --sizes-11: 4rem;
   --typography-font-families-regular: "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
-  --typography-font-families-mono: "Inconsolata", Consolas, "SFMono Regular", monospace;
+  --typography-font-families-mono: "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace;
   --typography-font-families-display: 'Basier Square', "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   --typography-font-weights-1: 400;
   --typography-font-weights-2: 500;
@@ -1722,10 +1722,10 @@
   --typography-styles-product-text-semibold-sm: 600 0.75rem/1.5 "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   --typography-styles-product-text-semibold-md: 600 0.875rem/1.5 "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   --typography-styles-product-text-semibold-lg: 600 1rem/1.5 "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
-  --typography-styles-product-text-mono-xs: 500 0.625rem/1.6 "Inconsolata", Consolas, "SFMono Regular", monospace;
-  --typography-styles-product-text-mono-sm: 500 0.75rem/1.6 "Inconsolata", Consolas, "SFMono Regular", monospace;
-  --typography-styles-product-text-mono-md: 500 0.875rem/1.7 "Inconsolata", Consolas, "SFMono Regular", monospace;
-  --typography-styles-product-text-mono-lg: 500 1rem/1.6 "Inconsolata", Consolas, "SFMono Regular", monospace;
+  --typography-styles-product-text-mono-xs: 500 0.625rem/normal "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace;
+  --typography-styles-product-text-mono-sm: 500 0.75rem/normal "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace;
+  --typography-styles-product-text-mono-md: 500 0.875rem/normal "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace;
+  --typography-styles-product-text-mono-lg: 500 1rem/normal "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace;
   --typography-styles-product-text-bold-xs: 700 0.625rem/1.5 "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   --typography-styles-product-text-bold-sm: 700 0.75rem/1.5 "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   --typography-styles-product-text-bold-md: 700 0.875rem/1.5 "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;

--- a/src/theme/styles/tokens-light.css
+++ b/src/theme/styles/tokens-light.css
@@ -665,7 +665,7 @@
   --click-codeblock-space-gap: 1.5rem;
   --click-codeblock-radii-all: 0.25rem;
   --click-codeblock-stroke: 1px;
-  --click-codeblock-typography-text-default: 500 0.875rem/1.7 "Inconsolata", Consolas, "SFMono Regular", monospace;
+  --click-codeblock-typography-text-default: 500 0.875rem/normal "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace;
   --click-codeblock-numbers-size-width: 1.5rem;
   --click-codeblock-darkMode-color-background-default: #282828;
   --click-codeblock-darkMode-color-text-default: #ffffff;
@@ -685,7 +685,7 @@
   --click-codeblock-monacoTheme-parameter-background: rgb(41.176% 43.137% 47.451% / 0.1);
   --click-codeInline-space-x: 0.25rem;
   --click-codeInline-stroke: 1px;
-  --click-codeInline-typography-text-default: 500 0.875rem/1.7 "Inconsolata", Consolas, "SFMono Regular", monospace;
+  --click-codeInline-typography-text-default: 500 0.875rem/normal "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace;
   --click-codeInline-radii-all: 0.25rem;
   --click-codeInline-color-background-default: #f6f7fa;
   --click-codeInline-color-text-default: #161517;
@@ -989,7 +989,7 @@
   --click-grid-body-cell-color-text-default: lch(7.1704 1.4351 305.43);
   --click-grid-body-cell-color-text-selectIndirect: #161517;
   --click-grid-body-cell-color-text-selectDirect: #161517;
-  --click-grid-cell-text-default: 500 0.875rem/1.5 "Inconsolata", Consolas, "SFMono Regular", monospace;
+  --click-grid-cell-text-default: 500 0.875rem/1.5 "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace;
   --click-grid-radii-none: 0;
   --click-grid-radii-sm: 0.25rem;
   --click-grid-radii-md: 0.5rem;
@@ -1676,7 +1676,7 @@
   --sizes-10: 2.5rem;
   --sizes-11: 4rem;
   --typography-font-families-regular: "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
-  --typography-font-families-mono: "Inconsolata", Consolas, "SFMono Regular", monospace;
+  --typography-font-families-mono: "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace;
   --typography-font-families-display: 'Basier Square', "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   --typography-font-weights-1: 400;
   --typography-font-weights-2: 500;
@@ -1712,10 +1712,10 @@
   --typography-styles-product-text-semibold-sm: 600 0.75rem/1.5 "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   --typography-styles-product-text-semibold-md: 600 0.875rem/1.5 "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   --typography-styles-product-text-semibold-lg: 600 1rem/1.5 "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
-  --typography-styles-product-text-mono-xs: 500 0.625rem/1.6 "Inconsolata", Consolas, "SFMono Regular", monospace;
-  --typography-styles-product-text-mono-sm: 500 0.75rem/1.6 "Inconsolata", Consolas, "SFMono Regular", monospace;
-  --typography-styles-product-text-mono-md: 500 0.875rem/1.7 "Inconsolata", Consolas, "SFMono Regular", monospace;
-  --typography-styles-product-text-mono-lg: 500 1rem/1.6 "Inconsolata", Consolas, "SFMono Regular", monospace;
+  --typography-styles-product-text-mono-xs: 500 0.625rem/normal "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace;
+  --typography-styles-product-text-mono-sm: 500 0.75rem/normal "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace;
+  --typography-styles-product-text-mono-md: 500 0.875rem/normal "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace;
+  --typography-styles-product-text-mono-lg: 500 1rem/normal "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace;
   --typography-styles-product-text-bold-xs: 700 0.625rem/1.5 "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   --typography-styles-product-text-bold-sm: 700 0.75rem/1.5 "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
   --typography-styles-product-text-bold-md: 700 0.875rem/1.5 "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;

--- a/src/theme/tokens/variables.dark.ts
+++ b/src/theme/tokens/variables.dark.ts
@@ -1440,7 +1440,7 @@ const theme = {
       typography: {
         text: {
           default:
-            '500 0.875rem/1.7 "Inconsolata", Consolas, "SFMono Regular", monospace',
+            '500 0.875rem/normal "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace',
         },
       },
       numbers: {
@@ -1513,7 +1513,7 @@ const theme = {
       typography: {
         text: {
           default:
-            '500 0.875rem/1.7 "Inconsolata", Consolas, "SFMono Regular", monospace',
+            '500 0.875rem/normal "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace',
         },
       },
       radii: {
@@ -2289,7 +2289,7 @@ const theme = {
       cell: {
         text: {
           default:
-            '500 0.875rem/1.5 "Inconsolata", Consolas, "SFMono Regular", monospace',
+            '500 0.875rem/1.5 "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace',
         },
       },
       radii: {
@@ -3821,7 +3821,7 @@ const theme = {
       families: {
         regular:
           '"Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;',
-        mono: '"Inconsolata", Consolas, "SFMono Regular", monospace',
+        mono: '"DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace',
         display:
           '\'Basier Square\', "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;',
       },
@@ -3879,10 +3879,10 @@ const theme = {
             lg: '600 1rem/1.5 "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;',
           },
           mono: {
-            xs: '500 0.625rem/1.6 "Inconsolata", Consolas, "SFMono Regular", monospace',
-            sm: '500 0.75rem/1.6 "Inconsolata", Consolas, "SFMono Regular", monospace',
-            md: '500 0.875rem/1.7 "Inconsolata", Consolas, "SFMono Regular", monospace',
-            lg: '500 1rem/1.6 "Inconsolata", Consolas, "SFMono Regular", monospace',
+            xs: '500 0.625rem/normal "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace',
+            sm: '500 0.75rem/normal "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace',
+            md: '500 0.875rem/normal "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace',
+            lg: '500 1rem/normal "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace',
           },
           bold: {
             xs: '700 0.625rem/1.5 "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;',

--- a/src/theme/tokens/variables.light.ts
+++ b/src/theme/tokens/variables.light.ts
@@ -1428,7 +1428,7 @@ const theme = {
       typography: {
         text: {
           default:
-            '500 0.875rem/1.7 "Inconsolata", Consolas, "SFMono Regular", monospace',
+            '500 0.875rem/normal "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace',
         },
       },
       numbers: {
@@ -1501,7 +1501,7 @@ const theme = {
       typography: {
         text: {
           default:
-            '500 0.875rem/1.7 "Inconsolata", Consolas, "SFMono Regular", monospace',
+            '500 0.875rem/normal "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace',
         },
       },
       radii: {
@@ -2273,7 +2273,7 @@ const theme = {
       cell: {
         text: {
           default:
-            '500 0.875rem/1.5 "Inconsolata", Consolas, "SFMono Regular", monospace',
+            '500 0.875rem/1.5 "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace',
         },
       },
       radii: {
@@ -3804,7 +3804,7 @@ const theme = {
       families: {
         regular:
           '"Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;',
-        mono: '"Inconsolata", Consolas, "SFMono Regular", monospace',
+        mono: '"DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace',
         display:
           '\'Basier Square\', "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;',
       },
@@ -3862,10 +3862,10 @@ const theme = {
             lg: '600 1rem/1.5 "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;',
           },
           mono: {
-            xs: '500 0.625rem/1.6 "Inconsolata", Consolas, "SFMono Regular", monospace',
-            sm: '500 0.75rem/1.6 "Inconsolata", Consolas, "SFMono Regular", monospace',
-            md: '500 0.875rem/1.7 "Inconsolata", Consolas, "SFMono Regular", monospace',
-            lg: '500 1rem/1.6 "Inconsolata", Consolas, "SFMono Regular", monospace',
+            xs: '500 0.625rem/normal "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace',
+            sm: '500 0.75rem/normal "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace',
+            md: '500 0.875rem/normal "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace',
+            lg: '500 1rem/normal "DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace',
           },
           bold: {
             xs: '700 0.625rem/1.5 "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;',

--- a/tokens/themes/primitives.json
+++ b/tokens/themes/primitives.json
@@ -715,7 +715,7 @@
           "type": "fontFamilies"
         },
         "mono": {
-          "value": "\"Inconsolata\",  Consolas, \"SFMono Regular\", monospace",
+          "value": "\"DejaVu Sans Mono\", \"Liberation Mono\", MonoLisa, Consolas, monospace",
           "type": "fontFamilies"
         },
         "display": {
@@ -972,7 +972,7 @@
               "value": {
                 "fontFamily": "{typography.font.families.mono}",
                 "fontWeight": "{typography.font.weights.2}",
-                "lineHeight": "{typography.font.line-height.2}",
+                "lineHeight": "normal",
                 "fontSize": "{typography.font.sizes.0}"
               },
               "type": "typography"
@@ -981,7 +981,7 @@
               "value": {
                 "fontFamily": "{typography.font.families.mono}",
                 "fontWeight": "{typography.font.weights.2}",
-                "lineHeight": "{typography.font.line-height.2}",
+                "lineHeight": "normal",
                 "fontSize": "{typography.font.sizes.1}"
               },
               "type": "typography"
@@ -990,7 +990,7 @@
               "value": {
                 "fontFamily": "{typography.font.families.mono}",
                 "fontWeight": "{typography.font.weights.2}",
-                "lineHeight": "{typography.font.line-height.3}",
+                "lineHeight": "normal",
                 "fontSize": "{typography.font.sizes.2}"
               },
               "type": "typography"
@@ -999,7 +999,7 @@
               "value": {
                 "fontFamily": "{typography.font.families.mono}",
                 "fontWeight": "{typography.font.weights.2}",
-                "lineHeight": "{typography.font.line-height.2}",
+                "lineHeight": "normal",
                 "fontSize": "{typography.font.sizes.3}"
               },
               "type": "typography"


### PR DESCRIPTION
## Problem

The `typography.font.families.mono` token was `"Inconsolata", Consolas, "SFMono Regular", monospace`. In apps that load Inconsolata from Google Fonts (as `.storybook/preview-head.html` did, and as ClickHouse Fiddle does), box-drawing characters — the frames of ClickHouse `Pretty*` output formats, U+2500–U+259F — render broken:

- The full Inconsolata font does contain box-drawing glyphs, but Google Fonts serves latin/latin-ext/vietnamese subsets whose `unicode-range` does not include U+2500–U+259F, so those characters fall through to the rest of the stack.
- `Consolas` is absent on Linux and macOS, and `SFMono Regular` is not a real family name (the PostScript name is `SFMono-Regular`, the family is `SF Mono`), so the characters land in a generic monospace whose advance width differs from Inconsolata — every frame line breaks apart horizontally.
- The mono text styles used line-height 1.6/1.7, which leaves vertical gaps between the `│` glyphs of consecutive rows even with a correct font.

This is the upstream half of ClickHouse/clickhouse-fiddle#82.

## Fix

- Change the mono stack to `"DejaVu Sans Mono", "Liberation Mono", MonoLisa, Consolas, monospace` — the same stack the ClickHouse Play UI uses. Every font in it (and the typical `monospace` defaults such as Menlo) covers box drawing.
- Set `line-height: normal` for the `product/text/mono` styles. These fonts draw box-drawing glyphs to fill exactly their normal line box (1.164 em for DejaVu Sans Mono, 1.133 em for Liberation Mono), so vertical lines touch at `normal` and break apart at anything larger — a fixed value like 1.25 measurably leaves gaps ([comparison](https://gist.githubusercontent.com/alexey-milovidov/f0dd4af10383ec6a2405664430fec655/raw/lineheight-comparison.png)).
- Regenerated token files with `yarn generate:tokens`; removed the now-unused Inconsolata webfont from the Storybook preview head.

## Before / after

The same `PrettyMonoBlock` output rendered with the old and new `--click-codeblock-typography-text-default` token values:

![before/after](https://gist.githubusercontent.com/alexey-milovidov/f0dd4af10383ec6a2405664430fec655/raw/clickui-before-after.png)

And the effect in ClickHouse Fiddle (https://fiddle.clickhouse.com/7ae4e9f7-bd3a-4638-8d98-540c90aa14bd): [before](https://gist.githubusercontent.com/alexey-milovidov/f0dd4af10383ec6a2405664430fec655/raw/before-crop.png) → [after](https://gist.githubusercontent.com/alexey-milovidov/f0dd4af10383ec6a2405664430fec655/raw/after-crop.png).

## Verification

- `yarn build` passes (including the dist health check)
- `yarn vitest run`: 544 tests in 61 files pass
- `yarn lint`: only pre-existing warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
