### PR TITLE
repro(Container): demonstration of responsive form layout limits

### DIFF
--- a/src/components/Container/ResponsiveFormLayout.stories.tsx
+++ b/src/components/Container/ResponsiveFormLayout.stories.tsx
@@ -1,0 +1,686 @@
+import { Meta, StoryObj } from '@storybook/react-vite';
+import { CSSProperties, ReactNode } from 'react';
+import { Container } from '@/components/Container';
+import { GridContainer } from '@/components/GridContainer';
+import { TextField } from '@/components/TextField';
+import { Select } from '@/components/Select';
+import { Switch } from '@/components/Switch';
+import { Separator } from '@/components/Separator';
+import { Button } from '@/components/Button';
+import { Title } from '@/components/Title';
+import { Text } from '@/components/Text';
+
+/**
+ * Reference layout: the "Billing information" onboarding step.
+ *
+ *   Billing address        <- full width
+ *   [ Address line 1     ] <- full width
+ *   [ Address line 2     ] <- full width
+ *   City        Zip        <- 2-up, must stack when narrow
+ *   Country     State      <- 2-up, must stack when narrow
+ *   (o) Shipping same...   <- switch + label, must NEVER stack
+ *   ---------------------
+ *   [Back]        [Next]   <- space-between, must NEVER stack
+ *
+ * Every approach below renders exactly this. The interesting question is not
+ * "can it render at one width" — they all can — but what happens as the
+ * *container* gets narrower, which is what actually happens in a dialog,
+ * a side panel, or a split pane.
+ */
+
+const noop = () => undefined;
+
+// ---------------------------------------------------------------------------
+// shared leaf content (identical across all four approaches)
+// ---------------------------------------------------------------------------
+
+const Dots = () => (
+  <div
+    data-demo="dots"
+    style={{ display: 'flex', gap: '8px', justifyContent: 'center', width: '100%' }}
+  >
+    {[0, 1, 2].map(i => (
+      <span
+        key={i}
+        style={{
+          width: '10px',
+          height: '10px',
+          borderRadius: '50%',
+          background: i === 0 ? '#1f1f1f' : '#dcdcdc',
+        }}
+      />
+    ))}
+  </div>
+);
+
+const AddressLine1 = () => (
+  <TextField
+    label="Billing address"
+    placeholder="Address line 1"
+    value=""
+    onChange={noop}
+  />
+);
+const AddressLine2 = () => (
+  <TextField
+    placeholder="Address line 2 (optional)"
+    value=""
+    onChange={noop}
+  />
+);
+const City = () => (
+  <TextField
+    label="City"
+    value=""
+    onChange={noop}
+  />
+);
+const Zip = () => (
+  <TextField
+    label="Zip or postal code"
+    value=""
+    onChange={noop}
+  />
+);
+const Country = () => (
+  <Select
+    label="Country"
+    value=""
+    onSelect={noop}
+  >
+    <Select.Item value="us">United States</Select.Item>
+    <Select.Item value="uk">United Kingdom</Select.Item>
+  </Select>
+);
+const StateProvince = () => (
+  <Select
+    label="State / County / Province"
+    value=""
+    onSelect={noop}
+  >
+    <Select.Item value="ca">California</Select.Item>
+    <Select.Item value="ny">New York</Select.Item>
+  </Select>
+);
+const ShippingToggle = () => (
+  <Switch
+    label="Shipping address same as billing address"
+    dir="end"
+    checked
+  />
+);
+const BackButton = () => (
+  <Button
+    type="secondary"
+    iconLeft="chevron-left"
+  >
+    Back
+  </Button>
+);
+const NextButton = () => (
+  <Button
+    type="primary"
+    iconRight="arrow-right"
+  >
+    Account details
+  </Button>
+);
+const Heading = () => <Title type="h2">Billing information</Title>;
+
+// ---------------------------------------------------------------------------
+// A. Nested <Container>s, library defaults (isResponsive is ON by default)
+//    This is the most direct translation of the Figma AutoLayout stack.
+// ---------------------------------------------------------------------------
+
+const ApproachA = () => (
+  <Container
+    orientation="vertical"
+    gap="md"
+    padding="lg"
+    alignItems="stretch"
+  >
+    <Heading />
+    <Dots />
+    <Container
+      orientation="vertical"
+      gap="xs"
+      alignItems="stretch"
+    >
+      <AddressLine1 />
+      <AddressLine2 />
+    </Container>
+
+    <Container
+      data-demo="pair-1"
+      orientation="horizontal"
+      gap="md"
+      alignItems="start"
+    >
+      <City />
+      <Zip />
+    </Container>
+
+    <Container
+      data-demo="pair-2"
+      orientation="horizontal"
+      gap="md"
+      alignItems="start"
+    >
+      <Country />
+      <StateProvince />
+    </Container>
+
+    <Container
+      data-demo="toggle-row"
+      orientation="horizontal"
+      gap="sm"
+      alignItems="center"
+    >
+      <ShippingToggle />
+    </Container>
+
+    <Separator size="sm" />
+
+    <Container
+      data-demo="footer"
+      orientation="horizontal"
+      justifyContent="space-between"
+      alignItems="center"
+    >
+      <BackButton />
+      <NextButton />
+    </Container>
+  </Container>
+);
+
+// ---------------------------------------------------------------------------
+// B. Nested <Container>s, isResponsive turned OFF, using intrinsic flex wrap
+//    (wrap + grow + minWidth) so the pairs stack on *container* width.
+// ---------------------------------------------------------------------------
+
+const ApproachB = () => (
+  <Container
+    orientation="vertical"
+    gap="md"
+    padding="lg"
+    alignItems="stretch"
+    isResponsive={false}
+  >
+    <Heading />
+    <Dots />
+    <Container
+      orientation="vertical"
+      gap="xs"
+      alignItems="stretch"
+      isResponsive={false}
+    >
+      <AddressLine1 />
+      <AddressLine2 />
+    </Container>
+
+    <Container
+      data-demo="pair-1"
+      orientation="horizontal"
+      gap="md"
+      alignItems="start"
+      wrap="wrap"
+      isResponsive={false}
+    >
+      <Container
+        orientation="vertical"
+        grow="1"
+        minWidth="200px"
+        isResponsive={false}
+      >
+        <City />
+      </Container>
+      <Container
+        orientation="vertical"
+        grow="1"
+        minWidth="200px"
+        isResponsive={false}
+      >
+        <Zip />
+      </Container>
+    </Container>
+
+    <Container
+      data-demo="pair-2"
+      orientation="horizontal"
+      gap="md"
+      alignItems="start"
+      wrap="wrap"
+      isResponsive={false}
+    >
+      <Container
+        orientation="vertical"
+        grow="1"
+        minWidth="200px"
+        isResponsive={false}
+      >
+        <Country />
+      </Container>
+      <Container
+        orientation="vertical"
+        grow="1"
+        minWidth="200px"
+        isResponsive={false}
+      >
+        <StateProvince />
+      </Container>
+    </Container>
+
+    <Container
+      data-demo="toggle-row"
+      orientation="horizontal"
+      gap="sm"
+      alignItems="center"
+      isResponsive={false}
+    >
+      <ShippingToggle />
+    </Container>
+
+    <Separator size="sm" />
+
+    <Container
+      data-demo="footer"
+      orientation="horizontal"
+      justifyContent="space-between"
+      alignItems="center"
+      isResponsive={false}
+    >
+      <BackButton />
+      <NextButton />
+    </Container>
+  </Container>
+);
+
+// ---------------------------------------------------------------------------
+// C. One <GridContainer> with a fixed 2-column template + isResponsive ON.
+//    Full-width rows need `gridColumn` spans, for which there is no prop —
+//    so they go through inline style, escaping the design system.
+// ---------------------------------------------------------------------------
+
+const span2: CSSProperties = { gridColumn: 'span 2' };
+
+const ApproachC = () => (
+  <GridContainer
+    gridTemplateColumns="1fr 1fr"
+    gap="md"
+    alignItems="start"
+    style={{ padding: '24px' }}
+  >
+    <div style={span2}>
+      <Heading />
+    </div>
+    <div style={span2}>
+      <Dots />
+    </div>
+    <div style={span2}>
+      <AddressLine1 />
+    </div>
+    <div style={span2}>
+      <AddressLine2 />
+    </div>
+
+    <div data-demo="cell-city">
+      <City />
+    </div>
+    <div data-demo="cell-zip">
+      <Zip />
+    </div>
+    <div data-demo="cell-country">
+      <Country />
+    </div>
+    <div data-demo="cell-state">
+      <StateProvince />
+    </div>
+
+    <div
+      data-demo="toggle-row"
+      style={span2}
+    >
+      <ShippingToggle />
+    </div>
+    <div style={span2}>
+      <Separator size="sm" />
+    </div>
+    <div style={span2}>
+      <Container
+        data-demo="footer"
+        orientation="horizontal"
+        justifyContent="space-between"
+        alignItems="center"
+        isResponsive={false}
+      >
+        <BackButton />
+        <NextButton />
+      </Container>
+    </div>
+  </GridContainer>
+);
+
+// ---------------------------------------------------------------------------
+// D. One <GridContainer>, isResponsive OFF, with an intrinsic auto-fit track
+//    list. This is the only approach that reflows on container width.
+// ---------------------------------------------------------------------------
+
+const spanAll: CSSProperties = { gridColumn: '1 / -1' };
+
+const ApproachD = () => (
+  <GridContainer
+    isResponsive={false}
+    gridTemplateColumns="repeat(auto-fit, minmax(200px, 1fr))"
+    gap="md"
+    alignItems="start"
+    style={{ padding: '24px' }}
+  >
+    <div style={spanAll}>
+      <Heading />
+    </div>
+    <div style={spanAll}>
+      <Dots />
+    </div>
+    <div style={spanAll}>
+      <AddressLine1 />
+    </div>
+    <div style={spanAll}>
+      <AddressLine2 />
+    </div>
+
+    <div data-demo="cell-city">
+      <City />
+    </div>
+    <div data-demo="cell-zip">
+      <Zip />
+    </div>
+    <div data-demo="cell-country">
+      <Country />
+    </div>
+    <div data-demo="cell-state">
+      <StateProvince />
+    </div>
+
+    <div
+      data-demo="toggle-row"
+      style={spanAll}
+    >
+      <ShippingToggle />
+    </div>
+    <div style={spanAll}>
+      <Separator size="sm" />
+    </div>
+    <div style={spanAll}>
+      <Container
+        data-demo="footer"
+        orientation="horizontal"
+        justifyContent="space-between"
+        alignItems="center"
+        isResponsive={false}
+      >
+        <BackButton />
+        <NextButton />
+      </Container>
+    </div>
+  </GridContainer>
+);
+
+// ---------------------------------------------------------------------------
+// harness
+// ---------------------------------------------------------------------------
+
+const APPROACHES = {
+  a: {
+    render: ApproachA,
+    title: 'A — nested <Container>, library defaults',
+    blurb:
+      'isResponsive defaults to true, so every row flips to column at viewport ≤768px.',
+  },
+  b: {
+    render: ApproachB,
+    title: 'B — nested <Container>, isResponsive={false} + wrap/grow/minWidth',
+    blurb:
+      'Reflows on container width. Needs 4 extra wrapper Containers and isResponsive off everywhere.',
+  },
+  c: {
+    render: ApproachC,
+    title: 'C — one <GridContainer>, "1fr 1fr" + isResponsive',
+    blurb:
+      'Spans need inline gridColumn. Collapses on viewport ≤768px, never on container width.',
+  },
+  d: {
+    render: ApproachD,
+    title: 'D — one <GridContainer>, isResponsive={false} + auto-fit',
+    blurb:
+      'Reflows on container width. Requires turning isResponsive off and hand-written CSS strings.',
+  },
+} as const;
+
+type ApproachKey = keyof typeof APPROACHES;
+
+const Card = ({ width, children }: { width: string; children: ReactNode }) => (
+  <div
+    data-demo="card"
+    style={{
+      width,
+      flex: '0 0 auto',
+      border: '1px solid #e0e0e0',
+      borderRadius: '12px',
+      background: '#fff',
+      boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
+      overflow: 'hidden',
+    }}
+  >
+    {children}
+  </div>
+);
+
+const Panel = ({ approach, width }: { approach: ApproachKey; width: string }) => {
+  const { render: Render, title, blurb } = APPROACHES[approach];
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+      <div>
+        <Text
+          weight="semibold"
+          size="md"
+        >
+          {title}
+        </Text>
+        <Text
+          size="sm"
+          color="muted"
+        >
+          {blurb}
+        </Text>
+      </div>
+      <Card width={width}>
+        <Render />
+      </Card>
+    </div>
+  );
+};
+
+const meta: Meta = {
+  title: 'Layout/Responsive Form Layout',
+  parameters: { layout: 'fullscreen' },
+};
+export default meta;
+
+type Story = StoryObj<{ containerWidth: string; approach: ApproachKey }>;
+
+/**
+ * All four approaches at one container width, so they can be compared directly.
+ * Change `containerWidth` to simulate a dialog / side panel / split pane, and
+ * separately resize the browser window to change the *viewport*. The point of
+ * the demo is that those two are not the same thing.
+ */
+export const CompareAll: Story = {
+  args: { containerWidth: '420px' },
+  argTypes: {
+    containerWidth: {
+      control: 'select',
+      options: ['320px', '360px', '420px', '520px', '720px', '100%'],
+    },
+  },
+  render: ({ containerWidth }) => (
+    <div
+      style={{
+        display: 'flex',
+        gap: '32px',
+        alignItems: 'flex-start',
+        padding: '24px',
+        background: '#fafafa',
+        overflowX: 'auto',
+      }}
+    >
+      {(Object.keys(APPROACHES) as ApproachKey[]).map(key => (
+        <Panel
+          key={key}
+          approach={key}
+          width={containerWidth}
+        />
+      ))}
+    </div>
+  ),
+};
+
+/** Single-approach stories, addressable individually for measurement. */
+const single = (approach: ApproachKey): Story => ({
+  args: { approach, containerWidth: '420px' },
+  argTypes: {
+    containerWidth: {
+      control: 'select',
+      options: ['320px', '360px', '420px', '520px', '720px', '100%'],
+    },
+  },
+  render: ({ containerWidth }) => (
+    <div style={{ padding: '24px', background: '#fafafa' }}>
+      <Panel
+        approach={approach}
+        width={containerWidth}
+      />
+    </div>
+  ),
+});
+
+export const ApproachAContainerDefaults = single('a');
+export const ApproachBContainerIntrinsic = single('b');
+export const ApproachCGridResponsive = single('c');
+export const ApproachDGridAutoFit = single('d');
+
+// ---------------------------------------------------------------------------
+// Isolated diagnostics for the three primitive-level defects the comparison
+// above runs into. Each is a minimal repro, independent of the billing form.
+// ---------------------------------------------------------------------------
+
+const Ruler = ({ label, children }: { label: string; children: ReactNode }) => (
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+    <Text
+      size="sm"
+      weight="semibold"
+    >
+      {label}
+    </Text>
+    {children}
+  </div>
+);
+
+/** Parent is exactly 360px and outlined in red. Anything crossing the red line
+ *  is overflow. `Container` has no `box-sizing: border-box` and click-ui ships
+ *  no global reset, so `fillWidth` (width:100%) + `padding` = width + padding. */
+export const DefectPaddingOverflowsParent: StoryObj = {
+  name: 'Defect 1 — padding overflows the parent',
+  render: () => (
+    <div
+      style={{ display: 'flex', flexDirection: 'column', gap: '32px', padding: '32px' }}
+    >
+      {(['none', 'sm', 'md', 'lg', 'xl'] as const).map(p => (
+        <Ruler
+          key={p}
+          label={`<Container padding="${p}" />  inside a 360px parent`}
+        >
+          <div
+            style={{
+              width: '360px',
+              outline: '2px solid #e5484d',
+              outlineOffset: '0px',
+            }}
+          >
+            <Container
+              padding={p}
+              orientation="vertical"
+              isResponsive={false}
+            >
+              <div style={{ background: '#cfe8ff', height: '32px', width: '100%' }} />
+            </Container>
+          </div>
+        </Ruler>
+      ))}
+    </div>
+  ),
+};
+
+/** `isResponsive` (default true) sets `max-width: none` below 768px viewport,
+ *  so a form card's own maxWidth is discarded exactly when space runs out.
+ *  Resize the browser across 768px to watch the blue box jump to full width. */
+export const DefectMaxWidthDroppedBelowBreakpoint: StoryObj = {
+  name: 'Defect 2 — maxWidth is discarded below 768px',
+  render: () => (
+    <div
+      style={{ display: 'flex', flexDirection: 'column', gap: '24px', padding: '32px' }}
+    >
+      <Text size="sm">
+        Both boxes ask for maxWidth=&quot;480px&quot; inside a 900px parent. Resize the
+        window across 768px.
+      </Text>
+      <div style={{ width: '900px', outline: '2px solid #e5484d' }}>
+        <Ruler label="isResponsive (default) — maxWidth honoured only above 768px">
+          <Container
+            maxWidth="480px"
+            padding="none"
+          >
+            <div style={{ background: '#cfe8ff', height: '32px', width: '100%' }} />
+          </Container>
+        </Ruler>
+      </div>
+      <div style={{ width: '900px', outline: '2px solid #30a46c' }}>
+        <Ruler label="isResponsive={false} — maxWidth honoured, but now nothing stacks">
+          <Container
+            maxWidth="480px"
+            padding="none"
+            isResponsive={false}
+          >
+            <div style={{ background: '#cfe8ff', height: '32px', width: '100%' }} />
+          </Container>
+        </Ruler>
+      </div>
+    </div>
+  ),
+};
+
+/** Same container width, different viewport. `isResponsive` keys off the
+ *  viewport, so neither box knows it is only 360px wide. */
+export const DefectViewportIsNotContainer: StoryObj = {
+  name: 'Defect 3 — isResponsive keys off viewport, not container',
+  render: () => (
+    <div
+      style={{ padding: '32px', display: 'flex', flexDirection: 'column', gap: '16px' }}
+    >
+      <Text size="sm">
+        Both cards are 360px wide. Resize the window across 768px: the layout changes even
+        though the cards never do. In a dialog or side panel the card width is what
+        matters, and neither primitive can see it.
+      </Text>
+      <div style={{ display: 'flex', gap: '32px', alignItems: 'flex-start' }}>
+        <Panel
+          approach="a"
+          width="360px"
+        />
+        <Panel
+          approach="c"
+          width="360px"
+        />
+      </div>
+    </div>
+  ),
+};


### PR DESCRIPTION
## Why?

Responsive forms are pretty much impossible to do correctly with our current primitives. For example, the payment info form in onboarding needs a form shaped like this: full-width address lines, two rows of side-by-side fields, a toggle row, and a footer with Back on the left and the primary action on the right.

<img width="1460" height="998" alt="image" src="https://github.com/user-attachments/assets/0a1a05a9-2ad4-4da6-977e-6a5eb9c95848" />

In Figma that is a stack of auto-layouts. In a browser it also has to survive the card getting narrower, at which point the side-by-side fields need to stack.

I tried to build it with `Container` and with `GridContainer` and could not get a correct result from either without switching off the `isResponsive` prop and overriding the flex/grid properties directly.

This PR is the reproduction only. It changes no library code, so the Storybook preview shows how `main` behaves today.

## How?

One new stories file: `src/components/Container/ResponsiveFormLayout.stories.tsx`, under Layout > Responsive Form Layout.

`CompareAll` builds the same form four ways and gives each one a `containerWidth` control, so card width and window width can be varied independently. That separation is the thing to look at.

- A: nested `Container`, library defaults
- B: nested `Container`, `isResponsive={false}` with `wrap` / `grow` / `minWidth`
- C: one `GridContainer`, `gridTemplateColumns="1fr 1fr"` with `isResponsive`
- D: one `GridContainer`, `isResponsive={false}` with `repeat(auto-fit, minmax(200px, 1fr))`

City and Zip field widths, measured in Chromium:

| approach | vp 1400 / card 360 | vp 1400 / card 720 | vp 760 / card 720 |
| --- | --- | --- | --- |
| A | 172px, side by side | 352px | 720px, footer stacked |
| B | 360px, stacked | 352px | 352px |
| C | 172px, side by side | 352px | 512px / 192px |
| D | 360px, stacked | 229px across 3 columns | 229px across 3 columns |

Three more stories isolate the primitive-level defects behind those numbers.

`isResponsive` is keyed to the viewport and never to the container. At a 360px card on a 1400px window, A and C leave the fields side by side at 172px and clip the primary button. Inside a dialog or a side panel the card width is the only thing that matters. Because the prop also defaults to `true`, at 768px every `Container` flips to `flex-direction: column`, so approach A stacks Back on top of the primary button and drops the toggle label below the switch, with 720px of room available.

`Container` padding overflows its parent. `.container` sets `width: 100%` and `padding` with no `box-sizing: border-box`, and the library ships no global reset (`global.css` is a single `body` color rule). `<Container fillWidth padding="lg">` inside a 360px parent measures 408px. The overflow equals the padding, and it is invisible in any app that ships its own reset, which is probably why it has survived.

`isResponsive` discards `maxWidth`. `.container_responsive` sets `max-width: none` below 768px. A `Container` asking for `maxWidth="480px"` inside a 900px parent measures 482px at a 1000px viewport and 902px at 700px.

Underneath all three sits an API problem rather than a CSS one: `GridContainer` children cannot describe their own placement, and neither component accepts any instruction about what to do at a given breakpoint. That is what the recommendations below are about.

## Recommendations, for a separate PR

The first two are API shape, the third is the mechanism both of them would need.

### 1. GridContainer gives children no way to place themselves

A child cannot say how many columns it spans. The full-width rows in this repro need `style={{ gridColumn: 'span 2' }}`, which leaves the design system entirely, and those inline spans are what create the implicit `auto` track that garbles the `isResponsive` collapse into `512px 192px`. The one prop that would fix it does not exist.

[MUI's Grid](https://mui.com/material-ui/react-grid/) puts the span on the child, and accepts breakpoint objects there:

```jsx
<Grid size={{ xs: 12, sm: 6, md: 8 }}>...</Grid>
<Grid size="grow">...</Grid>   // equal share of the remaining space
<Grid size="auto">...</Grid>   // fit to content
<Grid size={4} offset={{ xs: 3, md: 0 }}>...</Grid>
```

That would express this form directly: `size={{ xs: 12, md: 6 }}` on City and Zip, `size={12}` on the address lines, no inline styles and no `1 / -1` strings.

### 2. Neither component accepts per-breakpoint instruction

`isResponsive` is one boolean covering one hardcoded breakpoint. There is no way to say "two columns here, one column below that", so the escape hatch is a raw CSS string in `gridTemplateColumns`, which is why approach D ends up with three columns at a 720px card.

MUI takes a responsive object on every layout prop, not just child spans:

```jsx
<Grid container columns={16} spacing={{ xs: 2, md: 3 }} columnSpacing={{ xs: 1, sm: 2 }}>
<Stack direction={{ xs: 'column', sm: 'row' }} spacing={{ xs: 1, md: 4 }}>
```

`Stack` is the closest analogue to our `Container`, and `direction` taking a breakpoint object is the thing `orientation` cannot do today. A footer row would set `orientation="horizontal"` flat and never stack, instead of needing `isResponsive={false}` to opt out of a default it never wanted.

### 3. Key the reflow to the container, not the viewport

Both of the above still leave the breakpoints keyed to the window. Two references for fixing that:

[shadcn's `Field`](https://ui.shadcn.com/docs/components/base/field) has `orientation="vertical" | "horizontal" | "responsive"`, and `responsive` resolves against a container query rather than the viewport. The parent opts in by naming a containment context: `<FieldGroup className="@container/field-group ...">`. Underneath it is Tailwind v4, where `@container` marks the container and `@md:flex-row`, `@max-md:flex-col`, `@sm:@max-md:flex-col` and `@min-[475px]:flex-row` set the conditions. shadcn is copied source plus utility classes rather than a component API, so the transferable part is the mechanism and the `orientation="responsive"` naming, not the implementation.

MUI v6 added `theme.containerQueries`, mirroring the existing `theme.breakpoints` methods so the same breakpoint keys work either way:

```js
theme.containerQueries.up('sm')            // @container (min-width: 600px)
theme.containerQueries.down('md')          // @container (max-width: 900px)
theme.containerQueries('sidebar').up('500px')  // @container sidebar (min-width: 500px)
```

We already have the token half of this: `--breakpoint-sizes-sm` through `-2xl` exist and only `md` is used.

Concretely for us: `container-type: inline-size` on both components, re-key the existing `768px` rules to `@container`, and let callers name a breakpoint token instead of accepting the hardcoded one. `.browserslistrc` is not a blocker; the oldest target is Safari/iOS 16.0, and container queries shipped in Safari 16.0 and Chrome 105.

The two mechanisms compose rather than compete, which is what MUI does: responsive objects for the props, container queries for what those breakpoints resolve against. If we take both, `orientation={{ base: 'vertical', md: 'horizontal' }}` and `size={{ base: 12, md: 6 }}` would read against container width.

### Smaller fixes in the same area

`box-sizing: border-box` on both base classes. A `padding` prop on `GridContainer`, which has none. And a decision on `isResponsive` itself: defaulting to `true` is wrong for any row that should never stack, so the default and the name are both open questions.

### On the two approaches in this repro

Approach B is correct at every width I tested, and it gets there by turning `isResponsive` off on all ten `Container`s and reimplementing reflow with flex wrap. A plain `div` would do the same. Approach D reflows on container width but mis-groups: at a 720px card, `auto-fit` produces three columns and orphans State / Province, because a track list cannot express "these two fields belong together." A child-side `size` prop can.

### References

- [MUI Grid](https://mui.com/material-ui/react-grid/)
- [MUI Stack](https://mui.com/material-ui/react-stack/)
- [MUI container queries](https://mui.com/material-ui/customization/container-queries/)
- [shadcn/ui Field](https://ui.shadcn.com/docs/components/base/field)
- [Tailwind container queries](https://tailwindcss.com/docs/responsive-design)

## Tickets?

None yet. Filing follow-ups once there is agreement on the direction.

## Contribution checklist?

- [x] You've done enough research before writing
- [x] You have reviewed the PR
- [x] The commit messages are detailed
- [ ] The `build` command runs locally (not run; stories-only change, `tsc --noEmit` and eslint are clean)
- [x] Assets or static content are linked and stored in the project
- [ ] For documentation, guides or references, you've tested the commands

## Security checklist?

- [x] All user inputs are validated and sanitized
- [x] No usage of `dangerouslySetInnerHTML`
- [x] Sensitive data has been identified and is being protected properly
- [x] Build output contains no secrets or API keys

## Preview?

Storybook preview on this PR, under Layout > Responsive Form Layout. Start with `CompareAll`, then resize the window across 768px while leaving `containerWidth` alone.

Note for reviewers: these stories render deliberately broken layouts, so they will show up as new Chromatic snapshots needing approval.
