### PR TITLE
fix(release): Update package json augmentation during release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,8 +32,9 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: |
           echo "GITHUB_TAG=${{ github.event.inputs.tag }}" >> "$GITHUB_ENV"
-          # Check if input is a semantic version (e.g., 0.0.242) or a tag name (e.g., beta, scss-deprecation)
-          if [[ "${{ github.event.inputs.tag }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
+          # Check if input is a semantic version (e.g., 0.0.242 or v0.0.242) or a
+          # tag name (e.g., beta, dev).
+          if [[ "${{ github.event.inputs.tag }}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
             echo "IS_VERSION_INPUT=true" >> "$GITHUB_ENV"
           else
             echo "IS_VERSION_INPUT=false" >> "$GITHUB_ENV"
@@ -64,7 +65,8 @@ jobs:
       - name: Bump package version (for version inputs)
         if: ${{ env.IS_VERSION_INPUT == 'true' }}
         run: |
-          npm pkg set version=$GITHUB_TAG
+          # Tags are "vX.Y.Z" but package.json versions must not carry the "v".
+          npm pkg set version="${GITHUB_TAG#v}"
       - name: Generate prerelease version (for tag inputs)
         if: ${{ env.IS_VERSION_INPUT == 'false' }}
         run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickhouse/click-ui",
-  "version": "v0.10.0",
+  "version": "0.10.0",
   "description": "Official ClickHouse design system react library",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Description

- fixes the `v`-prefix handling in the npm publish workflow\
- repairs package.json, which the last release left with `"version": "v0.10.0"`.

## Notes

- first round of release scripts/workflows updates
- next step: fix and update storybook release(s)
- no changes on npm side needed