### PR TITLE
fix(deploy): storybook deploy matrix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,8 @@ env:
 
 jobs:
   build:
+    # TEMP: safeguard for testing, can be removed after all release flows validated
+    if: ${{ !contains(github.event.release.tag_name, 'storybook-test') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write      # For git push and tagging

--- a/.github/workflows/storybook-vercel.yml
+++ b/.github/workflows/storybook-vercel.yml
@@ -1,43 +1,100 @@
 name: Publish storybook to vercel
 
+# NOTE: see .scripts/bash/storybook-deploy-channels for extra info
+
 on:
   push:
     branches:
       - main
   pull_request:
+  release:
+    types: [published]
   workflow_dispatch:
+    inputs:
+      deploy_production:
+        description: 'Deploy the release channel (production). Leave off for a build-only dry run.'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
   pull-requests: write
 
+# One group per PR (stale preview builds cancel); everything else shares one
+# group - Vercel's production alias goes to whichever deploy finishes last.
+concurrency:
+  group: storybook-vercel-${{ github.event_name == 'pull_request' && github.event.pull_request.number || 'release' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   HUSKY: 0
   STORYBOOK_BUILD_DIR: .storybook/out
-  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-  VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
 jobs:
   deploy:
-    # Fork PRs can't access repo secrets (VERCEL_TOKEN + GitHub App), so we skip
-    # the Storybook preview deploy for forks; fork contributors get a hosted
-    # Storybook via Chromatic instead.
+    # Fork PRs have no repo secrets: skip the preview deploy - forks get a
+    # hosted Storybook via Chromatic instead.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     steps:
+      # ======================================================================
+      # DECIDE - which channels does this run deploy, and why
+      # ======================================================================
+
       - name: Checkout
+        # On release events this lands on the release tag.
         uses: actions/checkout@v6
 
-      - name: Generate GitHub workflow token
-        id: gh-workflow-token
-        # NOTE: Upgrade v3 due to gh node20 deprecation
-        # at time of writing there's only "v3.0.0-beta.2"
-        # see https://github.com/actions/create-github-app-token/releases
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ secrets.WORKFLOW_AUTH_PUBLIC_APP_ID }}
-          private-key: ${{ secrets.WORKFLOW_AUTH_PUBLIC_PRIVATE_KEY }}
+      - name: Decide deploy channels
+        id: channels
+        # shell: bash enables pipefail; the implicit default shell does not,
+        # and `tee` would then mask a script failure. Releases on tags that
+        # predate this script fail here - deploy those via workflow_dispatch.
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          IS_PRERELEASE: ${{ github.event.release.prerelease }}
+          DEPLOY_PRODUCTION: ${{ inputs.deploy_production }}
+        run: |
+          COMMIT_MSG=$(git log -1 --format=%s)
+          .scripts/bash/storybook-deploy-channels \
+            "$EVENT_NAME" \
+            "$REF" \
+            "$COMMIT_MSG" \
+            "$IS_PRERELEASE" \
+            "$DEPLOY_PRODUCTION" \
+            | tee -a "$GITHUB_OUTPUT"
+
+      - name: Report deploy decisions
+        # Written before the build so the reasoning survives a build failure.
+        env:
+          SITUATION: ${{ steps.channels.outputs.situation }}
+          DESCRIPTION: ${{ steps.channels.outputs.description }}
+          CHANNELS: ${{ steps.channels.outputs.channels }}
+          DEPLOY_PREVIEW: ${{ steps.channels.outputs.deploy_preview }}
+          DEPLOY_RELEASE: ${{ steps.channels.outputs.deploy_release }}
+        run: |
+          icon() { [[ "$1" == "true" ]] && echo "✅ yes" || echo "⏭️ no"; }
+
+          {
+            echo "## Storybook deploy channels"
+            echo ""
+            echo "**Situation:** \`$SITUATION\` → deploying **$CHANNELS**"
+            echo ""
+            echo "$DESCRIPTION"
+            echo ""
+            echo "| Channel | Deploying |"
+            echo "| --- | --- |"
+            echo "| Preview | $(icon "$DEPLOY_PREVIEW") |"
+            echo "| Release | $(icon "$DEPLOY_RELEASE") |"
+            echo ""
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # ======================================================================
+      # BUILD - produce .vercel/output, identical for every channel
+      # ======================================================================
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -51,71 +108,83 @@ jobs:
         run: yarn install --immutable
 
       - name: Install Vercel CLI
-        # NOTE: Pinned to avoid broken @vercel/hono@0.2.67 dep in newer versions can revisit when Vercel publishes a fix
+        # Pinned: newer versions pull a broken @vercel/hono dep
         run: npm install --global vercel@41.7.3
 
       - name: Build Storybook
         run: yarn storybook:build
 
-      - name: Pull Vercel Environment Information
-        run: |
-          vercel pull \
-            --yes \
-            --environment=preview \
-            --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Create Vercel Build Output
+      - name: Package Storybook for Vercel
+        # Static Build Output API v3, hand-built: no `vercel pull` / `vercel build`
+        # needed. Project targeting comes from VERCEL_ORG_ID + VERCEL_PROJECT_ID.
         run: |
           mkdir -p .vercel/output/static
-          cp -r ${{ env.STORYBOOK_BUILD_DIR }}/* .vercel/output/static/
+          cp -r "$STORYBOOK_BUILD_DIR"/* .vercel/output/static/
           cat > .vercel/output/config.json << EOF
           {
             "version": 3
           }
           EOF
 
-      - name: Deploy to Vercel (Preview)
-        if: github.event_name == 'pull_request'
-        id: deploy
+      # ======================================================================
+      # DEPLOY - one step per channel. --prod is the only difference between
+      # a preview deployment and a production one.
+      # ======================================================================
+
+      - name: Deploy preview
+        if: steps.channels.outputs.deploy_preview == 'true'
+        id: preview
+        # Step-scoped on purpose: workflow-level env would expose the token
+        # to install scripts and third-party actions.
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
           DEPLOYMENT_URL=$(vercel deploy \
             --prebuilt \
             --yes \
-            --token=${{ secrets.VERCEL_TOKEN }})
-          echo "url=$DEPLOYMENT_URL" >> $GITHUB_OUTPUT
+            --token="$VERCEL_TOKEN")
+          echo "url=$DEPLOYMENT_URL" >> "$GITHUB_OUTPUT"
           echo "Preview deployed to: $DEPLOYMENT_URL"
+          echo "✅ **Preview** deployed: $DEPLOYMENT_URL" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Comment PR with Preview URL
-        if: github.event_name == 'pull_request'
+      - name: Generate GitHub workflow token
+        # Only used to post the preview-URL PR comment below.
+        if: steps.channels.outputs.deploy_preview == 'true'
+        id: gh-workflow-token
+        # TODO: bump to v3 once it leaves beta (gh node20 deprecation)
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.WORKFLOW_AUTH_PUBLIC_APP_ID }}
+          private-key: ${{ secrets.WORKFLOW_AUTH_PUBLIC_PRIVATE_KEY }}
+
+      - name: Comment PR with preview URL
+        if: steps.channels.outputs.deploy_preview == 'true'
         uses: mshick/add-pr-comment@v2
         with:
           message: |
             ## Storybook Preview Deployed
 
-            ✅ Preview URL: ${{ steps.deploy.outputs.url }}
+            ✅ Preview URL: ${{ steps.preview.outputs.url }}
 
             Built from commit: `${{ github.sha }}`
           message-id: storybook-preview
           repo-token: ${{ steps.gh-workflow-token.outputs.token }}
           refresh-message-position: true
 
-      - name: Deploy to Vercel (Production)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      - name: Deploy release channel
+        if: steps.channels.outputs.deploy_release == 'true'
+        # Step-scoped credentials - see "Deploy preview".
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          COMMIT_MSG=$(git log -1 --format=%s)
-
-          if OUTPUT=$(.scripts/bash/verify-release-commit "$COMMIT_MSG"); then
-            VERSION=$(echo "$OUTPUT" | awk '{print $1}')
-            RELEASE_TYPE=$(echo "$OUTPUT" | awk '{print $2}')
-            echo "Detected release commit for version $VERSION ($RELEASE_TYPE) will deploy..."
-          else
-            echo "Skip! Commit message does not match release format"
-            exit 0
-          fi
-
           DEPLOYMENT_URL=$(vercel deploy \
             --prebuilt \
             --yes \
             --prod \
-            --token=${{ secrets.VERCEL_TOKEN }})
-          echo "Deployed v$VERSION ($RELEASE_TYPE) to $DEPLOYMENT_URL"
+            --token="$VERCEL_TOKEN")
+          echo "Release channel deployed to: $DEPLOYMENT_URL"
+          echo "✅ **Release channel** deployed: $DEPLOYMENT_URL" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/storybook-vercel.yml
+++ b/.github/workflows/storybook-vercel.yml
@@ -21,10 +21,12 @@ permissions:
   contents: read
   pull-requests: write
 
-# One group per PR (stale preview builds cancel); everything else shares one
-# group - Vercel's production alias goes to whichever deploy finishes last.
+# One group per PR (stale preview builds cancel). Non-PR runs group by sha:
+# GitHub keeps only one pending run per group, so a shared group would let an
+# ordinary main push evict a queued release deploy. Prod-deploying runs are
+# rare pre-canary; revisit serialization when canary lands.
 concurrency:
-  group: storybook-vercel-${{ github.event_name == 'pull_request' && github.event.pull_request.number || 'release' }}
+  group: storybook-vercel-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ playwright-report
 
 .install
 .vscode
+.claude-logs/

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ playwright-report
 
 .install
 .vscode
-.claude-logs/
+.claude-logs

--- a/.scripts/bash/build_output_health_check
+++ b/.scripts/bash/build_output_health_check
@@ -8,7 +8,7 @@ echo "🚑 Build $DIST_DIR output health check..."
 
 dirExists() {
   if [[ ! -d "$1" ]]; then
-    echo "👹 Oops! Couldn't find the directory $1"
+    echo "❌ Error: Couldn't find the directory $1"
 
     if [[ "$1" != "$DIST_DIR" ]]; then
       echo "💡 Have you modified the distribution file architecture and forgot to update this checkup?"
@@ -29,7 +29,7 @@ for dir in cjs esm types; do
   file_count=$(echo "$file_count" | xargs)
 
   if [[ "$file_count" -eq 0 ]]; then
-    echo "👹 Oops! The directory $full_path has $file_count files. Is this expected?"
+    echo "❌ Error: The directory $full_path has $file_count files. Is this expected?"
 
     exit 1;
   fi
@@ -37,11 +37,11 @@ for dir in cjs esm types; do
   dir_size=$(du -sk "$full_path" | cut -f1)
 
   if [[ "$dir_size" -lt "$MIN_SIZE_KB" ]]; then
-    echo "👹 Oops! The directory $full_path size is smaller than minimum expected size of $MIN_SIZE_KB KB"
+    echo "❌ Error: The directory $full_path size is smaller than minimum expected size of $MIN_SIZE_KB KB"
 
     exit 1;
   fi
 done
 
-echo "👍 Done! Build $DIST_DIR output health check completed."
+echo "✅ Done! Build $DIST_DIR output health check completed."
 exit 0

--- a/.scripts/bash/changeset-add
+++ b/.scripts/bash/changeset-add
@@ -4,14 +4,14 @@ branch_name=$(git rev-parse --abbrev-ref HEAD)
 filename=$(echo "$branch_name" | sed 's/\//-/g' | sed 's/ /-/g' | sed 's/[^a-zA-Z0-9._-]//g' | tr '[:upper:]' '[:lower:]')
 
 if [[ -z "$filename" ]]; then
-  echo "👹 Oops! Could not generate a valid filename from branch name: $branch_name"
+  echo "❌ Error: Could not generate a valid filename from branch name: $branch_name"
   exit 1
 fi
 
 changeset_path=".changeset/${filename}.md"
 
 if ! yarn changeset; then
-  echo "👹 Oops! Failed to create changest"
+  echo "❌ Error: Failed to create changeset"
   exit 1
 fi
 
@@ -19,19 +19,19 @@ untracked_changesets=$(git ls-files --others --exclude-standard ".changeset/*.md
 untracked_count=$(echo "$untracked_changesets" | grep -c .)
 
 if [[ "$untracked_count" -gt 1 ]]; then
-  echo "⚠️Warning! Found $untracked_count untracked changeset files will proceed and use the first one!"
+  echo "⚠️ Warning: Found $untracked_count untracked changeset files will proceed and use the first one!"
 fi
 
 new_changeset=$(echo "$untracked_changesets" | head -1)
 
 if [[ ! -n "$new_changeset" ]]; then
-  echo "👹 Oops! This is embarassing but couldn't locate the expeccted generated changeset file..."
+  echo "❌ Error: This is embarrassing but couldn't locate the expected generated changeset file..."
   exit 1
 fi
 
 if ! mv "$new_changeset" "$changeset_path"; then
-  echo "👹 Oops! Failed to rename changeset filename (from $new_changeset to $changeset_path)"
+  echo "❌ Error: Failed to rename changeset filename (from $new_changeset to $changeset_path)"
   exit 1
 fi
 
-echo "👍 Done! Changeset created: $changeset_path"
+echo "✅ Done! Changeset created: $changeset_path"

--- a/.scripts/bash/changeset-verification
+++ b/.scripts/bash/changeset-verification
@@ -10,7 +10,7 @@ if [[ -n "$pendingChangesetList" ]]; then
 fi
 
 if ! echo "$pendingChangesetList" | grep -qE "$changesetArtifactsRegex"; then
-  echo "👹 Oops! Couldn't locate any changeset. Did you forget to include one?"
+  echo "❌ Error: Couldn't locate any changeset. Did you forget to include one?"
   echo "💡 Run the command yarn changeset:add"
 
   exit 1

--- a/.scripts/bash/circular-dependency-check
+++ b/.scripts/bash/circular-dependency-check
@@ -20,7 +20,7 @@ if command -v yarn &> /dev/null; then
     --ignorePattern="$IGNORE_PATTERNS" \
     --exitCodeOnCircularDependencies=1 < /dev/null > "$TEMP_OUTPUT" 2>&1 || true
 else
-  echo "👹 Oops! The package skott is missing, have you installed the project dependencies?"
+  echo "❌ Error: The package skott is missing, have you installed the project dependencies?"
 
   exit 1
 fi
@@ -38,7 +38,7 @@ elif grep -q "✓.*no circular dependencies found" "$TEMP_OUTPUT"; then
 
   exit 0
 else
-  echo "⚠️  Warning: Could not determine circular dependency status from skott output"
+  echo "⚠️ Warning: Could not determine circular dependency status from skott output"
   cat "$TEMP_OUTPUT"
 
   exit 1

--- a/.scripts/bash/extract-changelog
+++ b/.scripts/bash/extract-changelog
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ $# -lt 1 ]]; then
-  echo "👹 Oops! Usage is extract-changelog <version> [changelog_file]" >&2
+  echo "❌ Error: Usage is extract-changelog <version> [changelog_file]" >&2
   exit 1
 fi
 
@@ -9,12 +9,12 @@ VERSION="$1"
 CHANGELOG_FILE="${2:-CHANGELOG.md}"
 
 if [[ -z "$VERSION" ]]; then
-  echo "👹 Oops! Version is empty" >&2
+  echo "❌ Error: Version is empty" >&2
   exit 1
 fi
 
 if [[ ! -f "$CHANGELOG_FILE" ]]; then
-  echo "👹 Oops! Changelog file not found: $CHANGELOG_FILE" >&2
+  echo "❌ Error: Changelog file not found: $CHANGELOG_FILE" >&2
   exit 1
 fi
 

--- a/.scripts/bash/generate-release-commit-message
+++ b/.scripts/bash/generate-release-commit-message
@@ -6,7 +6,7 @@
 # Output: chore: 🤖 release v1.2.3 (latest)
 
 if [[ $# -lt 2 ]]; then
-  echo "👹 Oops! Missing arguments" >&2
+  echo "❌ Error: Missing arguments" >&2
   echo "💡 Use generate-release-commit-message <version> <release_type>, e.g. generate-release-commit-message 1.2.3 latest"
 
   exit 1
@@ -16,13 +16,13 @@ VERSION="$1"
 RELEASE_TYPE="$2"
 
 if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
-  echo "👹 Oops! Invalid version format: '$VERSION'"
+  echo "❌ Error: Invalid version format: '$VERSION'"
   echo "💡 Expected format X.Y.Z or X.Y.Z-suffix, e.g., 1.2.3 or 1.2.3-rc.1"
   exit 1
 fi
 
 if [[ ! "$RELEASE_TYPE" =~ ^(latest|rc|test|stable)$ ]]; then
-  echo "👹 Oops! Invalid release type '$RELEASE_TYPE'"
+  echo "❌ Error: Invalid release type '$RELEASE_TYPE'"
   echo "💡 Expected one of latest, rc or test"
 
   exit 1

--- a/.scripts/bash/storybook-deploy-channels
+++ b/.scripts/bash/storybook-deploy-channels
@@ -33,6 +33,12 @@ DEPLOY_PRODUCTION="$5"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+VERIFIER="$SCRIPT_DIR/verify-release-commit"
+if [[ ! -x "$VERIFIER" ]]; then
+  echo "❌ Error: $VERIFIER is missing or not executable" >&2
+  exit 1
+fi
+
 # ============================================================================
 # 1. CLASSIFY
 #
@@ -53,13 +59,14 @@ elif [[ "$EVENT_NAME" == "release" ]]; then
   SITUATION="release-published"
 
 elif [[ "$EVENT_NAME" == "push" && "$REF" == "refs/heads/main" ]] &&
-  VERIFY_OUTPUT=$("$SCRIPT_DIR/verify-release-commit" "$COMMIT_MSG" 2>&1); then
+  VERIFY_OUTPUT=$("$VERIFIER" "$COMMIT_MSG" 2>&1); then
   RELEASE_VERSION=$(echo "$VERIFY_OUTPUT" | awk '{print $1}')
   RELEASE_TYPE=$(echo "$VERIFY_OUTPUT" | awk '{print $2}')
-  if [[ "$RELEASE_TYPE" == "rc" || "$RELEASE_TYPE" == "test" ]]; then
-    SITUATION="prerelease-commit-on-main"
-  else
+  # Allowlist: only known-stable types reach prod; a new type fails closed.
+  if [[ "$RELEASE_TYPE" == "latest" || "$RELEASE_TYPE" == "stable" ]]; then
     SITUATION="release-commit-on-main"
+  else
+    SITUATION="prerelease-commit-on-main"
   fi
 
 elif [[ "$EVENT_NAME" == "push" && "$REF" == "refs/heads/main" ]]; then
@@ -109,7 +116,7 @@ case "$SITUATION" in
 
   prerelease-commit-on-main)
     CHANNELS=""
-    DESCRIPTION="A release commit for v$RELEASE_VERSION ($RELEASE_TYPE) landed on main, but rc/test content must not overwrite the stable Storybook, so nothing is deployed. The prerelease still publishes to npm."
+    DESCRIPTION="A release commit for v$RELEASE_VERSION ($RELEASE_TYPE) landed on main, but only latest/stable releases update the stable Storybook, so nothing is deployed. The release still publishes to npm."
     ;;
 
   merge-to-main)

--- a/.scripts/bash/storybook-deploy-channels
+++ b/.scripts/bash/storybook-deploy-channels
@@ -21,7 +21,7 @@
 set -uo pipefail
 
 if [[ $# -lt 5 ]]; then
-  echo "👹 Oops! Usage: storybook-deploy-channels <event_name> <ref> <commit_message> <prerelease> <deploy_production>" >&2
+  echo "❌ Error: Usage: storybook-deploy-channels <event_name> <ref> <commit_message> <prerelease> <deploy_production>" >&2
   exit 1
 fi
 
@@ -138,7 +138,7 @@ case "$SITUATION" in
     ;;
 
   *)
-    echo "👹 Oops! Situation '$SITUATION' has no row in the deploy table" >&2
+    echo "❌ Error: Situation '$SITUATION' has no row in the deploy table" >&2
     exit 1
     ;;
 esac

--- a/.scripts/bash/storybook-deploy-channels
+++ b/.scripts/bash/storybook-deploy-channels
@@ -1,0 +1,161 @@
+#!/bin/bash
+#
+# Decide which Storybook channels a workflow run should deploy to.
+#
+# Usage:
+#   storybook-deploy-channels <event_name> <ref> <commit_message> <prerelease> <deploy_production>
+#
+# Channels:
+#   preview - throwaway per-PR deployment; only the PR links to it
+#   release - the stable Storybook production URL; released code only
+#
+# Three sections, one job each:
+#   1. CLASSIFY  - sort the run into exactly one situation
+#   2. TABLE     - one row per situation: which channels, and what it means
+#   3. DERIVE    - turn the channel list into the flags the workflow reads
+#
+# Emits key=value lines on stdout, ready to append to $GITHUB_OUTPUT:
+#   situation / description / channels
+#   deploy_preview / deploy_release  -> true | false
+
+set -uo pipefail
+
+if [[ $# -lt 5 ]]; then
+  echo "👹 Oops! Usage: storybook-deploy-channels <event_name> <ref> <commit_message> <prerelease> <deploy_production>" >&2
+  exit 1
+fi
+
+EVENT_NAME="$1"
+REF="$2"
+COMMIT_MSG="$3"
+PRERELEASE="$4"
+DEPLOY_PRODUCTION="$5"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ============================================================================
+# 1. CLASSIFY
+#
+# First match wins: specific before general. The release-commit checks MUST
+# precede merge-to-main, or changesets releases stop deploying.
+# ============================================================================
+
+RELEASE_VERSION=""
+RELEASE_TYPE=""
+
+if [[ "$EVENT_NAME" == "pull_request" ]]; then
+  SITUATION="pull-request"
+
+elif [[ "$EVENT_NAME" == "release" && "$PRERELEASE" == "true" ]]; then
+  SITUATION="prerelease-published"
+
+elif [[ "$EVENT_NAME" == "release" ]]; then
+  SITUATION="release-published"
+
+elif [[ "$EVENT_NAME" == "push" && "$REF" == "refs/heads/main" ]] &&
+  VERIFY_OUTPUT=$("$SCRIPT_DIR/verify-release-commit" "$COMMIT_MSG" 2>&1); then
+  RELEASE_VERSION=$(echo "$VERIFY_OUTPUT" | awk '{print $1}')
+  RELEASE_TYPE=$(echo "$VERIFY_OUTPUT" | awk '{print $2}')
+  if [[ "$RELEASE_TYPE" == "rc" || "$RELEASE_TYPE" == "test" ]]; then
+    SITUATION="prerelease-commit-on-main"
+  else
+    SITUATION="release-commit-on-main"
+  fi
+
+elif [[ "$EVENT_NAME" == "push" && "$REF" == "refs/heads/main" ]]; then
+  SITUATION="merge-to-main"
+
+elif [[ "$EVENT_NAME" == "push" ]]; then
+  SITUATION="push-to-other-branch"
+
+elif [[ "$EVENT_NAME" == "workflow_dispatch" && "$DEPLOY_PRODUCTION" == "true" ]]; then
+  SITUATION="manual-deploy"
+
+elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+  SITUATION="manual-dry-run"
+
+else
+  SITUATION="unrecognised-event"
+fi
+
+# ============================================================================
+# 2. TABLE
+#
+# Every row sets CHANNELS (space-separated, "" = deploy nothing) and
+# DESCRIPTION. No defaults on purpose: set -u turns a forgotten assignment
+# into a hard error instead of a silent "deploy nothing".
+# ============================================================================
+
+case "$SITUATION" in
+  pull-request)
+    CHANNELS="preview"
+    DESCRIPTION="A pull request from a branch in this repo. Deploying a preview URL for reviewers."
+    ;;
+
+  release-published)
+    CHANNELS="release"
+    DESCRIPTION="A GitHub Release was published and is not marked as a prerelease. Checkout lands on the release tag, so the stable Storybook serves exactly the released code."
+    ;;
+
+  prerelease-published)
+    CHANNELS=""
+    DESCRIPTION="A GitHub Release was published but is marked as a prerelease (an rc). rc content must not overwrite the stable Storybook, so nothing is deployed. The rc still publishes to npm."
+    ;;
+
+  release-commit-on-main)
+    CHANNELS="release"
+    DESCRIPTION="A release commit for v$RELEASE_VERSION ($RELEASE_TYPE) landed on main. The changesets chain creates its GitHub Release with a bot token, which emits no release: event, so this commit message is the only signal."
+    ;;
+
+  prerelease-commit-on-main)
+    CHANNELS=""
+    DESCRIPTION="A release commit for v$RELEASE_VERSION ($RELEASE_TYPE) landed on main, but rc/test content must not overwrite the stable Storybook, so nothing is deployed. The prerelease still publishes to npm."
+    ;;
+
+  merge-to-main)
+    CHANNELS=""
+    DESCRIPTION="An ordinary merge to main. Nothing is deployed - publishing a GitHub Release is what updates the stable Storybook."
+    ;;
+
+  push-to-other-branch)
+    CHANNELS=""
+    DESCRIPTION="A push to '$REF', which is not main. Nothing is deployed."
+    ;;
+
+  manual-deploy)
+    CHANNELS="release"
+    DESCRIPTION="Manually dispatched with deploy_production=true. Deploying the release channel from whichever ref was dispatched."
+    ;;
+
+  manual-dry-run)
+    CHANNELS=""
+    DESCRIPTION="Manually dispatched with deploy_production=false. Storybook is built but nothing is deployed. Re-run with deploy_production=true to deploy."
+    ;;
+
+  unrecognised-event)
+    CHANNELS=""
+    DESCRIPTION="Event '$EVENT_NAME' on ref '$REF' matches no known situation, so nothing is deployed. If it should deploy something, add it to CLASSIFY and give it a row in TABLE."
+    ;;
+
+  *)
+    echo "👹 Oops! Situation '$SITUATION' has no row in the deploy table" >&2
+    exit 1
+    ;;
+esac
+
+# ============================================================================
+# 3. DERIVE
+# ============================================================================
+
+deploy_preview=false
+deploy_release=false
+[[ " $CHANNELS " == *" preview "* ]] && deploy_preview=true
+[[ " $CHANNELS " == *" release "* ]] && deploy_release=true
+
+echo "situation=$SITUATION"
+echo "description=$DESCRIPTION"
+echo "channels=${CHANNELS:-nothing}"
+echo "deploy_preview=$deploy_preview"
+echo "deploy_release=$deploy_release"
+
+exit 0

--- a/.scripts/bash/verify-release-commit
+++ b/.scripts/bash/verify-release-commit
@@ -7,7 +7,7 @@
 # On failure: outputs error messages to stderr only
 
 if [[ $# -lt 1 ]]; then
-  echo "👹 Oops! Missing argument..."
+  echo "❌ Error: Missing argument..."
   exit 1
 fi
 
@@ -16,37 +16,37 @@ COMMIT_MSG="$1"
 RELEASE_PATTERN='^chore: 🤖 release v([0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?) \((latest|rc|test|stable)\)( \(#[0-9]+\)| #[0-9]+)?$'
 
 if [[ -z "$COMMIT_MSG" ]]; then
-  echo "👹 Oops! Commit message is empty"
+  echo "❌ Error: Commit message is empty"
   exit 1
 fi
 
 if [[ ! "$COMMIT_MSG" =~ ^chore: ]]; then
-  echo "🦖 Skip! Commit message does not start with 'chore:'"
+  echo "⏩ Skipped: Commit message does not start with 'chore:'"
   exit 1
 fi
 
 if [[ ! "$COMMIT_MSG" =~ 🤖 ]]; then
-  echo "🦖 Skip! Commit message is missing the 🤖 emoji"
+  echo "⏩ Skipped: Commit message is missing the 🤖 emoji"
   exit 1
 fi
 
 if [[ ! "$COMMIT_MSG" =~ release ]]; then
-  echo "🦖 Skip! Commit message does not contain 'release'"
+  echo "⏩ Skipped: Commit message does not contain 'release'"
   exit 1
 fi
 
 if [[ ! "$COMMIT_MSG" =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-  echo "🦖 Skip! Commit message does not contain a valid version number"
+  echo "⏩ Skipped: Commit message does not contain a valid version number"
   exit 1
 fi
 
 if [[ ! "$COMMIT_MSG" =~ \((latest|rc|test|stable)\) ]]; then
-  echo "🦖 Skip! Commit message does not contain a valid release type"
+  echo "⏩ Skipped: Commit message does not contain a valid release type"
   exit 1
 fi
 
 if [[ ! "$COMMIT_MSG" =~ $RELEASE_PATTERN ]]; then
-  echo "🦖 Skip! Commit message format is invalid"
+  echo "⏩ Skipped: Commit message format is invalid"
   exit 1
 fi
 
@@ -54,7 +54,7 @@ if [[ "$COMMIT_MSG" =~ ^chore:\ 🤖\ release\ v([0-9.a-zA-Z-]+)\ \((latest|rc|t
   VERSION="${BASH_REMATCH[1]}"
   RELEASE_TYPE="${BASH_REMATCH[2]}"
 else
-  echo "🦖 Skip! Failed to extract version and release type"
+  echo "⏩ Skipped: Failed to extract version and release type"
   exit 1
 fi
 

--- a/.scripts/js/convert-svg-to-react-component
+++ b/.scripts/js/convert-svg-to-react-component
@@ -63,7 +63,7 @@ const getAssetType = (args) => {
   const type = typeFlag.replace('--type=', '');
 
   if (typeof ASSET_TYPES[type] === 'undefined') {
-    console.error(`👹 Oops! Unknown type: ${type}. Use logos, icons, or flags`);
+    console.error(`❌ Error: Unknown type: ${type}. Use logos, icons, or flags`);
     process.exit(1);
   }
 
@@ -167,7 +167,7 @@ const normalizeSvg = (svgPath, tempPath, idPrefix) => {
     console.log('✅ SVG normalized successfully');
     return tempPath;
   } catch (error) {
-    console.error('👹 Oops! SVG normalization failed:', error.message);
+    console.error('❌ Error: SVG normalization failed:', error.message);
     throw error;
   }
 };
@@ -207,7 +207,7 @@ export default \${variables.componentName};
   try {
     output = execSync(cmd, { encoding: 'utf8' });
   } catch (error) {
-    console.error(`👹 Oops! Failed to convert ${svgPath}:`, error.message);
+    console.error(`❌ Error: Failed to convert ${svgPath}:`, error.message);
     process.exit(1);
   }
 
@@ -262,7 +262,7 @@ const cleanUp = (files) => {
     const prettierCmd = `npx prettier --write --config .prettierrc ${files.join(' ')}`;
     execSync(prettierCmd, { encoding: 'utf8', stdio: 'inherit' });
   } catch (error) {
-    console.warn('⚠️Code format fix failed due to:', error.message);
+    console.warn('⚠️ Code format fix failed due to:', error.message);
     countErrors++;
   }
 
@@ -331,7 +331,7 @@ if (isRegenerate) {
 }
 
 if (args.length < 1) {
-  console.error('👹 Oops! The SVG file path is required');
+  console.error('❌ Error: The SVG file path is required');
   console.error('💡 Usage: convert-svg-to-react-component <svg-path> [component-name] [--type=logos|icons|flags] [--skip-normalize]');
   console.error('💡 Or use: convert-svg-to-react-component --regenerate [--type=logos|icons|flags|payments]');
   console.error('💡 Note: SVGs are automatically normalized before conversion. Use --skip-normalize to disable.');
@@ -349,7 +349,7 @@ if (!componentName) {
 }
 
 if (!componentName.match(/^[A-Z][a-zA-Z0-9_-]*$/)) {
-  console.error('👹 Oops! The component name must start with uppercase and use only letters, numbers, hyphens, or underscores.');
+  console.error('❌ Error: The component name must start with uppercase and use only letters, numbers, hyphens, or underscores.');
   process.exit(1);
 }
 
@@ -358,7 +358,7 @@ if (type === 'icons' && componentName.length > 1) {
   const isCamelCase = componentName.match(/[a-z][A-Z]/);
 
   if (isCamelCase && !hasMultipleWords) {
-    console.error(`👹 Icon name "${componentName}" must use dashes to separate words, e.g., Arrow-Down not ArrowDown.`);
+    console.error(`❌ Error: Icon name "${componentName}" must use dashes to separate words, e.g., Arrow-Down not ArrowDown.`);
     console.log(`💡 This ensures consistent kebab-case registry keys, e.g., 'arrow-down').`);
     process.exit(1);
   }
@@ -409,5 +409,5 @@ regenerateAssetRegistry(config);
 console.log(`🧹 Cleaning ${componentName}...\n`);
 cleanUp([outputPath, typesPath, lightFile, darkFile]);
 
-console.log(`\n👍 Done! Created ${componentName}`);
+console.log(`\n✅ Done! Created ${componentName}`);
 console.log('💡 Test it! When happy, remember to commit your changes');

--- a/.scripts/js/generate-exports
+++ b/.scripts/js/generate-exports
@@ -94,7 +94,7 @@ try {
 
   process.exit(0);
 } catch (err) {
-  console.error('\n👹 Oops! Failed to generate exports:\n');
+  console.error('\n❌ Error: Failed to generate exports:\n');
 
   console.error(err.message);
   process.exit(1);


### PR DESCRIPTION
## Description

storybook deployment to prod doesn't work due to commit message hiccup.
what is fixed and improved
- fixed bug - storybook prod deployments are not blocked
- added step for identifying nature of required deployment and updated logic

## Notes

- This is not final. The follow-up will be focusing on split of prod and canary deployments.
- `storybook-test` condition is only needed for testing, will be resolved in the follow up
- docs updates - in the follow up as well

## What works and how

| trigger | deploys |
| --- | --- |
| pull request | preview - throwaway URL, posted as a PR comment |
| merge to main | nothing (YET - canary in the follow up) |
| release commit on main - `latest` / `stable` | prod |
| release commit on main - `rc` / `test` | nothing - prereleases must not overwrite prod |
| GitHub release published manually (non-prerelease) | prod |
| manual dispatch with `deploy_production=true` | prod, from the dispatched ref |
| manual dispatch (default) | nothing - build-only dry run |

Validated on this PR: preview deploy + PR comment (https://click-ek618xty7-clickhouse.vercel.app/), manual dry run (deploys nothing, gated steps skipped), and the full 13-case decision matrix locally.
