### PR TITLE
feat(EllipsisContent): let callers position the truncation tooltip

### DIFF
--- a/.changeset/ellipsis-content-tooltip-props.md
+++ b/.changeset/ellipsis-content-tooltip-props.md
@@ -1,0 +1,15 @@
+---
+'@clickhouse/click-ui': minor
+---
+
+`EllipsisContent` now accepts `tooltipProps`, forwarded to the `Tooltip.Content` it renders when its text is truncated. The tooltip previously always used the default `side="top"`, which inside a menu covers the items above the hovered one. `IconWrapper`, `Dropdown.Item` and `Dropdown.Trigger sub` forward the same prop, so menu labels can move their truncation tooltip out of the way.
+
+**How to use?**
+
+```tsx
+<EllipsisContent tooltipProps={{ side: 'right' }}>{organization.name}</EllipsisContent>
+
+<Dropdown.Item tooltipProps={{ side: 'right' }}>{organization.name}</Dropdown.Item>
+```
+
+`tooltipProps` takes any `Tooltip.Content` prop (`side`, `align`, `sideOffset`, `maxWidth`, `showArrow`, …). `TooltipContentProps` and `EllipsisContentProps` are now exported for typing wrappers around it. Omitting `tooltipProps` keeps today's behavior.

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -218,3 +218,33 @@ export const TriggerStandalone: Story = {
     </div>
   ),
 };
+
+// A menu whose item labels are too long for the panel: the truncation tooltip is
+// moved to the right so it does not cover the items above the hovered one.
+export const TruncatedItemsTooltipOnRight: Story = {
+  render: () => (
+    <div
+      data-testid="dropdown-harness"
+      style={{ padding: '2rem', paddingBottom: '6rem', minHeight: 240 }}
+    >
+      <Dropdown
+        open
+        modal={false}
+      >
+        <Dropdown.Trigger>Dropdown Trigger</Dropdown.Trigger>
+        <Dropdown.Content
+          side="bottom"
+          avoidCollisions={false}
+          style={{ width: 180 }}
+        >
+          <Dropdown.Item tooltipProps={{ side: 'right' }}>
+            A menu item label far too long for this panel
+          </Dropdown.Item>
+          <Dropdown.Item tooltipProps={{ side: 'right' }}>
+            Another menu item label far too long for this panel
+          </Dropdown.Item>
+        </Dropdown.Content>
+      </Dropdown>
+    </div>
+  ),
+};

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -11,6 +11,7 @@ import { cn } from '@/lib/cva';
 import { useInputModality } from '@/hooks/internal';
 import Popover_Arrow from '@/components/Assets/Icons/Popover-Arrow';
 import { IconWrapper } from '@/components/IconWrapper';
+import type { IconWrapperProps } from '@/components/IconWrapper';
 import { Icon } from '@/components/Icon';
 import type { IconName } from '@/components/Icon';
 import type { HorizontalDirection } from '@/types';
@@ -42,6 +43,8 @@ interface SubDropdownProps {
   sub?: true;
   icon?: IconName;
   iconDir?: HorizontalDirection;
+  /** Props for the tooltip shown when the label is truncated */
+  tooltipProps?: IconWrapperProps['tooltipProps'];
 }
 
 interface MainDropdownProps {
@@ -58,7 +61,8 @@ const DropdownTrigger = ({
   ...props
 }: DropdownSubTriggerProps | DropdownTriggerProps) => {
   if (sub) {
-    const { icon, iconDir, ...menuProps } = props as DropdownSubTriggerProps;
+    const { icon, iconDir, tooltipProps, ...menuProps } =
+      props as DropdownSubTriggerProps;
     return (
       <DropdownMenuItem
         as={DropdownMenu.SubTrigger}
@@ -67,6 +71,7 @@ const DropdownTrigger = ({
         <IconWrapper
           icon={icon}
           iconDir={iconDir}
+          tooltipProps={tooltipProps}
         >
           {children}
         </IconWrapper>
@@ -202,6 +207,8 @@ interface DropdownItemProps extends DropdownMenu.DropdownMenuItemProps {
   iconDir?: HorizontalDirection;
   /** The type of the menu item */
   type?: 'default' | 'danger';
+  /** Props for the tooltip shown when the label is truncated */
+  tooltipProps?: IconWrapperProps['tooltipProps'];
 }
 
 export type { DropdownItemProps };
@@ -210,6 +217,7 @@ const DropdownItem = ({
   icon,
   iconDir,
   type = 'default',
+  tooltipProps,
   children,
   ...props
 }: DropdownItemProps) => {
@@ -222,6 +230,7 @@ const DropdownItem = ({
       <IconWrapper
         icon={icon}
         iconDir={iconDir}
+        tooltipProps={tooltipProps}
       >
         {children}
       </IconWrapper>

--- a/src/components/EllipsisContent/EllipsisContent.stories.tsx
+++ b/src/components/EllipsisContent/EllipsisContent.stories.tsx
@@ -54,6 +54,13 @@ export const AsSpan: Story = {
   },
 };
 
+export const TooltipOnRight: Story = {
+  args: {
+    children: 'This is a very long line of text whose tooltip opens to the right',
+    tooltipProps: { side: 'right' },
+  },
+};
+
 export const WithChildElement: Story = {
   args: {
     children: <span>This is a very long line of text inside a child span</span>,

--- a/src/components/EllipsisContent/EllipsisContent.tsx
+++ b/src/components/EllipsisContent/EllipsisContent.tsx
@@ -9,11 +9,8 @@ import {
 import { mergeRefs } from '@/utils/mergeRefs';
 import { cn } from '@/lib/cva';
 import { Tooltip } from '@/components/Tooltip';
+import { EllipsisContentProps } from './EllipsisContent.types';
 import styles from './EllipsisContent.module.css';
-
-export interface EllipsisContentProps<T extends ElementType = 'div'> {
-  component?: T;
-}
 
 type EllipsisPolymorphicComponent = <T extends ElementType = 'div'>(
   props: Omit<ComponentProps<T>, keyof EllipsisContentProps<T>> & EllipsisContentProps<T>
@@ -23,6 +20,7 @@ const EllipsisContentComponent = <T extends ElementType = 'div'>(
   {
     component,
     className,
+    tooltipProps,
     ...props
   }: Omit<ComponentProps<T>, keyof EllipsisContentProps<T>> &
     EllipsisContentProps<T> & { className?: string },
@@ -55,7 +53,7 @@ const EllipsisContentComponent = <T extends ElementType = 'div'>(
   return (
     <Tooltip>
       <Tooltip.Trigger asChild>{content}</Tooltip.Trigger>
-      <Tooltip.Content>{tooltipContent}</Tooltip.Content>
+      <Tooltip.Content {...tooltipProps}>{tooltipContent}</Tooltip.Content>
     </Tooltip>
   );
 };

--- a/src/components/EllipsisContent/EllipsisContent.types.ts
+++ b/src/components/EllipsisContent/EllipsisContent.types.ts
@@ -1,5 +1,11 @@
 import { ElementType } from 'react';
+import type { TooltipContentProps } from '@/components/Tooltip/Tooltip.types';
 
 export interface EllipsisContentProps<T extends ElementType = 'div'> {
   component?: T;
+  /**
+   * Props for the tooltip shown when the content is truncated, e.g.
+   * `{ side: 'right' }` to keep it clear of the content above it.
+   */
+  tooltipProps?: Omit<TooltipContentProps, 'children'>;
 }

--- a/src/components/IconWrapper/IconWrapper.tsx
+++ b/src/components/IconWrapper/IconWrapper.tsx
@@ -11,11 +11,11 @@ export const IconWrapper = ({
   height,
   children,
   ellipsisContent = true,
+  tooltipProps,
   gap = 'sm',
   isResponsive = true,
   ...props
 }: IconWrapperProps) => {
-  const TextWrapper = ellipsisContent ? EllipsisContent : 'div';
   return (
     <Container
       orientation="horizontal"
@@ -32,11 +32,16 @@ export const IconWrapper = ({
           height={height}
         />
       )}
-      <TextWrapper
-        data-testid={`${ellipsisContent ? 'ellipsed' : 'normal'}-icon-wrapper-text`}
-      >
-        {children}
-      </TextWrapper>
+      {ellipsisContent ? (
+        <EllipsisContent
+          data-testid="ellipsed-icon-wrapper-text"
+          tooltipProps={tooltipProps}
+        >
+          {children}
+        </EllipsisContent>
+      ) : (
+        <div data-testid="normal-icon-wrapper-text">{children}</div>
+      )}
       {icon && iconDir === 'end' && (
         <Icon
           name={icon}

--- a/src/components/IconWrapper/IconWrapper.types.ts
+++ b/src/components/IconWrapper/IconWrapper.types.ts
@@ -1,5 +1,6 @@
 import { HTMLAttributes, ReactNode } from 'react';
 import type { HorizontalDirection, AssetSize } from '@/types';
+import type { EllipsisContentProps } from '@/components/EllipsisContent/EllipsisContent.types';
 import type { ImageName } from '@/components/Icon/Icon.types';
 import type { GapOptions } from '@/components/Container';
 
@@ -11,6 +12,8 @@ export interface IconWrapperProps extends HTMLAttributes<HTMLDivElement> {
   height?: number | string;
   children: ReactNode;
   ellipsisContent?: boolean;
+  /** Props for the truncation tooltip. Ignored when `ellipsisContent` is `false`. */
+  tooltipProps?: EllipsisContentProps['tooltipProps'];
   gap?: GapOptions;
   isResponsive?: boolean;
 }

--- a/src/components/Tooltip/index.ts
+++ b/src/components/Tooltip/index.ts
@@ -1,2 +1,2 @@
 export { Tooltip } from './Tooltip';
-export type { TooltipProps } from './Tooltip.types';
+export type { TooltipContentProps, TooltipProps } from './Tooltip.types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,6 +129,7 @@ export { Dropdown } from './components/Dropdown';
 
 // Ellipsis Content
 export { EllipsisContent } from './components/EllipsisContent';
+export type { EllipsisContentProps } from './components/EllipsisContent';
 
 // File Upload & Tabs
 export { FileMultiUpload, FileUpload } from './components/FileUpload';
@@ -269,7 +270,7 @@ export type { CUIThemeType, UseThemeParams } from './hooks';
 
 // Tooltip
 export { Tooltip } from './components/Tooltip/Tooltip';
-export type { TooltipProps } from './components/Tooltip';
+export type { TooltipContentProps, TooltipProps } from './components/Tooltip';
 
 // Text
 export { Text } from './components/Text';

--- a/tests/display/ellipsis-content.spec.ts
+++ b/tests/display/ellipsis-content.spec.ts
@@ -139,6 +139,20 @@ describe('EllipsisContent Visual Regression', () => {
       await expect(panel).toContainText(fullText);
     });
 
+    it('opens the tooltip on the side given by tooltipProps', async ({ page }) => {
+      await page.goto(
+        getStoryUrl('display-ellipsiscontent--tooltip-on-right', 'light'),
+        {
+          waitUntil: 'networkidle',
+        }
+      );
+      const content = page.locator(`${harnessLocator} > *`).first();
+      await content.hover();
+      const panel = tooltipPanel(page);
+      await expect(panel).toBeVisible({ timeout: 10000 });
+      await expect(panel).toHaveAttribute('data-side', 'right');
+    });
+
     it('does not show a tooltip when the text fits', async ({ page }) => {
       await page.goto(getStoryUrl('display-ellipsiscontent--not-truncated', 'light'), {
         waitUntil: 'networkidle',

--- a/tests/overlays/genericmenu.spec.ts
+++ b/tests/overlays/genericmenu.spec.ts
@@ -133,6 +133,24 @@ describe('GenericMenu cluster Visual Regression', () => {
     }
   });
 
+  describe('Dropdown item truncation tooltip', () => {
+    it('opens the item tooltip on the side given by tooltipProps', async ({ page }) => {
+      await page.goto(
+        getStoryUrl('display-dropdown--truncated-items-tooltip-on-right', 'light'),
+        { waitUntil: 'domcontentloaded' }
+      );
+      const item = page.getByRole('menuitem').first();
+      await expect(item).toBeVisible({ timeout: 10000 });
+      await item.hover();
+      // data-side is only on the portaled tooltip panel, never on the trigger.
+      const panel = page.locator(
+        '[data-side][data-state="instant-open"], [data-side][data-state="delayed-open"]'
+      );
+      await expect(panel).toBeVisible({ timeout: 10000 });
+      await expect(panel).toHaveAttribute('data-side', 'right');
+    });
+  });
+
   describe('Popover content extension', () => {
     for (const theme of themes) {
       describe(`${theme} theme`, () => {


### PR DESCRIPTION
## Why?

`EllipsisContent` shows a `Tooltip` with the full text when its content is truncated, and it always uses the default `side="top"`. Inside a menu that tooltip covers the items above the hovered one — the org switcher in Cloud Console is the case that prompted this.

<img width="449" height="240" alt="image" src="https://github.com/user-attachments/assets/75d81c46-a229-41b8-ac11-2a3d944e2e31" />

Callers can't fix it today. `EllipsisContent` owns the side, and menu labels only reach it indirectly (`Dropdown.Item` → `IconWrapper` → `EllipsisContent`), so there is nowhere to pass a `side`.

## How?

- `EllipsisContent` takes `tooltipProps`, spread onto the `Tooltip.Content` it renders on overflow. Any `Tooltip.Content` prop works (`side`, `align`, `sideOffset`, `maxWidth`, `showArrow`, …). Omitting it keeps today's behavior.
- `IconWrapper`, `Dropdown.Item` and `Dropdown.Trigger sub` forward the same prop, so menu items can reach it.
- Export `TooltipContentProps` and `EllipsisContentProps` for consumers typing their own wrappers.
- Drop the duplicate `EllipsisContentProps` declaration in `EllipsisContent.tsx`; `EllipsisContent.types.ts` (the one `index.ts` already exported) is now the single source.
- Stories: `Display/EllipsisContent → TooltipOnRight`, `Display/Dropdown → TruncatedItemsTooltipOnRight`.
- Playwright coverage for the side actually reaching the portaled panel (`data-side="right"`), both directly and through `Dropdown.Item`.

```tsx
<EllipsisContent tooltipProps={{ side: 'right' }}>{organization.name}</EllipsisContent>

<Dropdown.Item tooltipProps={{ side: 'right' }}>{organization.name}</Dropdown.Item>
```

`IconWrapper` keeps identical output — the ternary that picked `EllipsisContent` vs `div` became two explicit branches so `tooltipProps` is only passed to the former.

`ContextMenu`, `Select` and `AutoComplete` also render text through `IconWrapper` and can be threaded the same way if the need shows up; left out here to keep the change small.

## Tickets?

n/a

## Contribution checklist?

- [x] You've done enough research before writing
- [x] You have reviewed the PR
- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [x] Assets or static content are linked and stored in the project
- [x] For documentation, guides or references, you've tested the commands

## Security checklist?

- [x] All user inputs are validated and sanitized
- [x] No usage of `dangerouslySetInnerHTML`
- [x] Sensitive data has been identified and is being protected properly
- [x] Build output contains no secrets or API keys

## Preview?

Verified locally: `yarn typecheck`, `yarn lint` (0 errors), `yarn test` (544 passed), `yarn build`, and the two Dockerized Playwright specs this touches — `tests/display/ellipsis-content.spec.ts` + `tests/overlays/genericmenu.spec.ts`, 36 passed including the new side assertions and all existing snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
