### PR TITLE
fix(Dropdown): narrow tooltipProps, default item tooltips right, unstale exported types

### DIFF
--- a/.changeset/ellipsis-content-tooltip-props.md
+++ b/.changeset/ellipsis-content-tooltip-props.md
@@ -8,8 +8,8 @@
 
 ```tsx
 <EllipsisContent tooltipProps={{ side: 'right' }}>{organization.name}</EllipsisContent>
-
-<Dropdown.Item tooltipProps={{ side: 'right' }}>{organization.name}</Dropdown.Item>
 ```
 
-`tooltipProps` is positioning only — `side`, `align` and `sideOffset`. `TooltipContentProps` and `EllipsisContentProps` are now exported for typing wrappers around it. Omitting `tooltipProps` keeps today's behavior.
+`tooltipProps` is positioning only — `side`, `align` and `sideOffset`. `TooltipContentProps` and `EllipsisContentProps` are now exported for typing wrappers around it. On `EllipsisContent` and `IconWrapper`, omitting it keeps today's behavior.
+
+`Dropdown.Item` and `Dropdown.Trigger sub` are the exception: they now default their truncation tooltip to `side: 'right'` rather than inheriting `side="top"`. A tooltip covering the item above the hovered one is wrong in any menu, so the good default belongs here instead of in every caller. Pass `tooltipProps` to override it. When the menu sits at the edge of the viewport, Radix's collision handling flips the tooltip to `left`, never back to `top`.

--- a/.changeset/ellipsis-content-tooltip-props.md
+++ b/.changeset/ellipsis-content-tooltip-props.md
@@ -12,4 +12,4 @@
 <Dropdown.Item tooltipProps={{ side: 'right' }}>{organization.name}</Dropdown.Item>
 ```
 
-`tooltipProps` takes any `Tooltip.Content` prop (`side`, `align`, `sideOffset`, `maxWidth`, `showArrow`, …). `TooltipContentProps` and `EllipsisContentProps` are now exported for typing wrappers around it. Omitting `tooltipProps` keeps today's behavior.
+`tooltipProps` is positioning only — `side`, `align` and `sideOffset`. `TooltipContentProps` and `EllipsisContentProps` are now exported for typing wrappers around it. Omitting `tooltipProps` keeps today's behavior.

--- a/.changeset/fix-dropdown-exported-item-props.md
+++ b/.changeset/fix-dropdown-exported-item-props.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': patch
+---
+
+`DropdownItemProps` exported from `@clickhouse/click-ui` and `@clickhouse/click-ui/Dropdown` now matches what `Dropdown.Item` actually accepts. The barrel was re-exporting a copy in `Dropdown.types.ts` that the component never imported, so it was missing both `type` and `tooltipProps` and typing a wrapper around `Dropdown.Item` failed to compile. `Dropdown.types.ts` is now the single declaration, as in `ContextMenu`, and `DropdownItemProps` is exported from the package root for the first time.

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -221,7 +221,8 @@ export const TriggerStandalone: Story = {
 
 // A menu whose item labels are too long for the panel. The first two items take the
 // default truncation tooltip, which opens to the right so it does not cover the items
-// above the hovered one; the third overrides it.
+// above the hovered one; the third overrides it. The sub-trigger takes the same
+// default through its own branch of Dropdown.Trigger.
 export const TruncatedItems: Story = {
   render: () => (
     <div
@@ -245,6 +246,14 @@ export const TruncatedItems: Story = {
           <Dropdown.Item tooltipProps={{ side: 'bottom' }}>
             A third label, too long again, opting out of the default
           </Dropdown.Item>
+          <Dropdown.Sub>
+            <Dropdown.Trigger sub>
+              A sub menu trigger label far too long for this panel
+            </Dropdown.Trigger>
+            <Dropdown.Content sub>
+              <Dropdown.Item>SubContent0</Dropdown.Item>
+            </Dropdown.Content>
+          </Dropdown.Sub>
         </Dropdown.Content>
       </Dropdown>
     </div>

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -219,9 +219,10 @@ export const TriggerStandalone: Story = {
   ),
 };
 
-// A menu whose item labels are too long for the panel: the truncation tooltip is
-// moved to the right so it does not cover the items above the hovered one.
-export const TruncatedItemsTooltipOnRight: Story = {
+// A menu whose item labels are too long for the panel. The first two items take the
+// default truncation tooltip, which opens to the right so it does not cover the items
+// above the hovered one; the third overrides it.
+export const TruncatedItems: Story = {
   render: () => (
     <div
       data-testid="dropdown-harness"
@@ -237,11 +238,12 @@ export const TruncatedItemsTooltipOnRight: Story = {
           avoidCollisions={false}
           style={{ width: 180 }}
         >
-          <Dropdown.Item tooltipProps={{ side: 'right' }}>
-            A menu item label far too long for this panel
-          </Dropdown.Item>
-          <Dropdown.Item tooltipProps={{ side: 'right' }}>
+          <Dropdown.Item>A menu item label far too long for this panel</Dropdown.Item>
+          <Dropdown.Item>
             Another menu item label far too long for this panel
+          </Dropdown.Item>
+          <Dropdown.Item tooltipProps={{ side: 'bottom' }}>
+            A third label, too long again, opting out of the default
           </Dropdown.Item>
         </Dropdown.Content>
       </Dropdown>

--- a/src/components/Dropdown/Dropdown.stories.tsx
+++ b/src/components/Dropdown/Dropdown.stories.tsx
@@ -6,7 +6,7 @@ import { GridCenter } from '@/components/GridCenter';
 import { Button } from '@/components/Button';
 import { Key } from 'react';
 
-import type { DropdownItemProps } from '@/components/Dropdown/Dropdown';
+import type { DropdownItemProps } from '@/components/Dropdown';
 
 interface DropdownExampleProps extends DropdownMenuProps {
   disabled?: boolean;

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -40,8 +40,14 @@ const _DropdownMenuItem = <T extends ElementType = 'div'>(
 
 const DropdownMenuItem: DropdownMenuItemComponent = forwardRef(_DropdownMenuItem);
 
-interface SubDropdownProps {
+// `sub` alone discriminates the two shapes of Trigger and Content. The label
+// fields live separately so only the sub-trigger accepts them — Content spreads
+// what it does not read straight onto the Radix element, i.e. into the DOM.
+interface SubDiscriminant {
   sub?: true;
+}
+
+interface SubTriggerFields {
   icon?: IconName;
   iconDir?: HorizontalDirection;
   /**
@@ -56,7 +62,8 @@ interface MainDropdownProps {
 }
 
 type DropdownSubTriggerProps = DropdownMenu.DropdownMenuSubTriggerProps &
-  SubDropdownProps;
+  SubDiscriminant &
+  SubTriggerFields;
 type DropdownTriggerProps = DropdownMenu.DropdownMenuTriggerProps & MainDropdownProps;
 
 const DropdownTrigger = ({
@@ -111,7 +118,7 @@ interface StyledDropdownSubContentProps extends DropdownMenu.DropdownMenuSubCont
   responsivePositioning?: boolean;
 }
 
-type DropdownContentProps = StyledDropdownContentProps & SubDropdownProps & ArrowProps;
+type DropdownContentProps = StyledDropdownContentProps & SubDiscriminant & ArrowProps;
 type DropdownSubContentProps = StyledDropdownSubContentProps &
   MainDropdownProps &
   ArrowProps;

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -16,6 +16,7 @@ import { Icon } from '@/components/Icon';
 import type { IconName } from '@/components/Icon';
 import type { HorizontalDirection } from '@/types';
 import { useResolvedPortalContainer } from '@/providers/PortalContext';
+import type { ArrowProps, DropdownItemProps } from './Dropdown.types';
 import styles from './Dropdown.module.css';
 
 export const Dropdown = (props: DropdownMenu.DropdownMenuProps) => (
@@ -97,10 +98,6 @@ const DropdownTrigger = ({
 
 DropdownTrigger.displayName = 'DropdownTrigger';
 Dropdown.Trigger = DropdownTrigger;
-
-export type ArrowProps = {
-  showArrow?: boolean;
-};
 
 interface StyledDropdownContentProps extends DropdownMenu.DropdownMenuContentProps {
   children?: ReactNode;
@@ -202,22 +199,6 @@ const DropdownSub = (props: DropdownMenu.DropdownMenuGroupProps) => {
 
 DropdownSub.displayName = 'DropdownSub';
 Dropdown.Sub = DropdownSub;
-
-interface DropdownItemProps extends DropdownMenu.DropdownMenuItemProps {
-  /** Icon to display in the menu item */
-  icon?: IconName;
-  /** The direction of the icon relative to the label */
-  iconDir?: HorizontalDirection;
-  /** The type of the menu item */
-  type?: 'default' | 'danger';
-  /**
-   * Positions the tooltip shown when the label is truncated. Defaults to
-   * `side: 'right'` so the tooltip does not cover the items above it.
-   */
-  tooltipProps?: IconWrapperProps['tooltipProps'];
-}
-
-export type { DropdownItemProps };
 
 const DropdownItem = ({
   icon,

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -43,7 +43,10 @@ interface SubDropdownProps {
   sub?: true;
   icon?: IconName;
   iconDir?: HorizontalDirection;
-  /** Props for the tooltip shown when the label is truncated */
+  /**
+   * Positions the tooltip shown when the label is truncated. Defaults to
+   * `side: 'right'` so the tooltip does not cover the items above it.
+   */
   tooltipProps?: IconWrapperProps['tooltipProps'];
 }
 
@@ -71,7 +74,7 @@ const DropdownTrigger = ({
         <IconWrapper
           icon={icon}
           iconDir={iconDir}
-          tooltipProps={tooltipProps}
+          tooltipProps={{ side: 'right', ...tooltipProps }}
         >
           {children}
         </IconWrapper>
@@ -207,7 +210,10 @@ interface DropdownItemProps extends DropdownMenu.DropdownMenuItemProps {
   iconDir?: HorizontalDirection;
   /** The type of the menu item */
   type?: 'default' | 'danger';
-  /** Props for the tooltip shown when the label is truncated */
+  /**
+   * Positions the tooltip shown when the label is truncated. Defaults to
+   * `side: 'right'` so the tooltip does not cover the items above it.
+   */
   tooltipProps?: IconWrapperProps['tooltipProps'];
 }
 
@@ -230,7 +236,7 @@ const DropdownItem = ({
       <IconWrapper
         icon={icon}
         iconDir={iconDir}
-        tooltipProps={tooltipProps}
+        tooltipProps={{ side: 'right', ...tooltipProps }}
       >
         {children}
       </IconWrapper>

--- a/src/components/Dropdown/Dropdown.types.ts
+++ b/src/components/Dropdown/Dropdown.types.ts
@@ -1,12 +1,22 @@
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 import type { HorizontalDirection } from '@/types';
 import type { IconName } from '@/components/Icon/Icon.types';
+import type { IconWrapperProps } from '@/components/IconWrapper/IconWrapper.types';
 
 export interface ArrowProps {
   showArrow?: boolean;
 }
 
 export interface DropdownItemProps extends DropdownMenu.DropdownMenuItemProps {
+  /** Icon to display in the menu item */
   icon?: IconName;
+  /** The direction of the icon relative to the label */
   iconDir?: HorizontalDirection;
+  /** The type of the menu item */
+  type?: 'default' | 'danger';
+  /**
+   * Positions the tooltip shown when the label is truncated. Defaults to
+   * `side: 'right'` so the tooltip does not cover the items above it.
+   */
+  tooltipProps?: IconWrapperProps['tooltipProps'];
 }

--- a/src/components/EllipsisContent/EllipsisContent.types.ts
+++ b/src/components/EllipsisContent/EllipsisContent.types.ts
@@ -4,8 +4,8 @@ import type { TooltipContentProps } from '@/components/Tooltip/Tooltip.types';
 export interface EllipsisContentProps<T extends ElementType = 'div'> {
   component?: T;
   /**
-   * Props for the tooltip shown when the content is truncated, e.g.
+   * Positions the tooltip shown when the content is truncated, e.g.
    * `{ side: 'right' }` to keep it clear of the content above it.
    */
-  tooltipProps?: Omit<TooltipContentProps, 'children'>;
+  tooltipProps?: Pick<TooltipContentProps, 'side' | 'align' | 'sideOffset'>;
 }

--- a/src/components/IconWrapper/IconWrapper.types.ts
+++ b/src/components/IconWrapper/IconWrapper.types.ts
@@ -12,7 +12,7 @@ export interface IconWrapperProps extends HTMLAttributes<HTMLDivElement> {
   height?: number | string;
   children: ReactNode;
   ellipsisContent?: boolean;
-  /** Props for the truncation tooltip. Ignored when `ellipsisContent` is `false`. */
+  /** Positions the truncation tooltip. Ignored when `ellipsisContent` is `false`. */
   tooltipProps?: EllipsisContentProps['tooltipProps'];
   gap?: GapOptions;
   isResponsive?: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,6 +126,7 @@ export type {
 
 // Dropdown
 export { Dropdown } from './components/Dropdown';
+export type { DropdownItemProps } from './components/Dropdown';
 
 // Ellipsis Content
 export { EllipsisContent } from './components/EllipsisContent';

--- a/tests/overlays/genericmenu.spec.ts
+++ b/tests/overlays/genericmenu.spec.ts
@@ -134,20 +134,32 @@ describe('GenericMenu cluster Visual Regression', () => {
   });
 
   describe('Dropdown item truncation tooltip', () => {
-    it('opens the item tooltip on the side given by tooltipProps', async ({ page }) => {
-      await page.goto(
-        getStoryUrl('display-dropdown--truncated-items-tooltip-on-right', 'light'),
-        { waitUntil: 'domcontentloaded' }
-      );
-      const item = page.getByRole('menuitem').first();
-      await expect(item).toBeVisible({ timeout: 10000 });
-      await item.hover();
-      // data-side is only on the portaled tooltip panel, never on the trigger.
-      const panel = page.locator(
+    // data-side is only on the portaled tooltip panel, never on the trigger.
+    const tooltipPanel = (page: import('@playwright/test').Page) =>
+      page.locator(
         '[data-side][data-state="instant-open"], [data-side][data-state="delayed-open"]'
       );
+
+    const hoverItem = async (page: import('@playwright/test').Page, index: number) => {
+      await page.goto(getStoryUrl('display-dropdown--truncated-items', 'light'), {
+        waitUntil: 'domcontentloaded',
+      });
+      const item = page.getByRole('menuitem').nth(index);
+      await expect(item).toBeVisible({ timeout: 10000 });
+      await item.hover();
+      const panel = tooltipPanel(page);
       await expect(panel).toBeVisible({ timeout: 10000 });
-      await expect(panel).toHaveAttribute('data-side', 'right');
+      return panel;
+    };
+
+    it('opens the item tooltip on the right by default', async ({ page }) => {
+      // No tooltipProps on the item: the default has to reach EllipsisContent
+      // through Dropdown.Item -> IconWrapper.
+      await expect(await hoverItem(page, 0)).toHaveAttribute('data-side', 'right');
+    });
+
+    it('lets the item override the default side', async ({ page }) => {
+      await expect(await hoverItem(page, 2)).toHaveAttribute('data-side', 'bottom');
     });
   });
 

--- a/tests/overlays/genericmenu.spec.ts
+++ b/tests/overlays/genericmenu.spec.ts
@@ -161,6 +161,12 @@ describe('GenericMenu cluster Visual Regression', () => {
     it('lets the item override the default side', async ({ page }) => {
       await expect(await hoverItem(page, 2)).toHaveAttribute('data-side', 'bottom');
     });
+
+    it('defaults the sub-trigger tooltip to the right as well', async ({ page }) => {
+      // Dropdown.Trigger sub is its own branch, and the submenu it opens on hover
+      // reports data-state="open", so it never matches the tooltip selector.
+      await expect(await hoverItem(page, 3)).toHaveAttribute('data-side', 'right');
+    });
   });
 
   describe('Popover content extension', () => {


### PR DESCRIPTION
## Why?

Follow-up to #1178, which is still unreleased (pending changeset, package at `0.10.0`). Review feedback raised three things to fix before the next release, and all three are addressed here — the prop surface is narrower, menu items get the right default, and the type consumers actually import is no longer a stale copy.

## How?

Three commits, one per point.

**1. Narrow `tooltipProps`** — it was `Omit<TooltipContentProps, 'children'>`, which handed callers the whole Radix content surface (`asChild`, `collisionBoundary`, `onEscapeKeyDown`, `container`, …) when the problem it solves is only *where* the tooltip opens. Now:

```ts
tooltipProps?: Pick<TooltipContentProps, 'side' | 'align' | 'sideOffset'>;
```

`IconWrapper` and `Dropdown` reach it through indexed access, so they narrow with it — that chain is why this is a one-line change.

**2. Default menu items to `side: 'right'`** — a truncated label's tooltip inherited `Tooltip.Content`'s `side="top"`, which puts it directly over the item above the hovered one. That's wrong in any menu, not just the org switcher that prompted #1178, so `Dropdown.Item` and `Dropdown.Trigger sub` now pass `{ side: 'right', ...tooltipProps }`. Caller props spread last, so an explicit `side` still wins.

On the "what if the menu is at the right edge" question: verified against `@radix-ui/react-popper@1.2.1` and then empirically. `avoidCollisions` defaults to `true`, `flip()` runs with default options so `right` has exactly one fallback — `left`, never back to `top` (that would need `fallbackAxisSideDirection`, which Radix doesn't set) — and `shift({ mainAxis: true, crossAxis: false })` only slides vertically for a left/right placement. A throwaway spec at a 320px viewport confirms the flipped panel reports `data-side="left"`. Both sides keep the tooltip clear of the sibling items, which is the property that matters; the degraded case overlays page content beside the menu instead of the menu's own items.

**3. `Dropdown.types.ts` is now the single source** — `Dropdown/index.ts` re-exported `ArrowProps` and `DropdownItemProps` from `Dropdown.types.ts`, but `Dropdown.tsx` declared its own copies and nothing ever imported the types file. It was born stale in #832: the barrel was rewired to it while the component was left alone, so every later addition (`type: 'default' | 'danger'`, then `tooltipProps`) landed only in `Dropdown.tsx`. The exported type was a two-field subset of the real one, so typing a wrapper around `Dropdown.Item` against the public API didn't compile — both `@clickhouse/click-ui/Dropdown` and the package root were affected, and the root exported no Dropdown types at all.

The two interfaces moved into `Dropdown.types.ts` and `Dropdown.tsx` imports them, matching `ContextMenu`. `DropdownItemProps` is now exported from the package root; `ArrowProps` deliberately isn't — `ContextMenu` declares one too and the name is too generic there, which is the precedent `src/index.ts` already sets.

Eight other components have the same two-source structure (`RadioGroup`, `FileUpload`, `Pagination`, `FileTabs`, `Link`, `GridContainer`, `HoverCard`, `MultiAccordion`). Dropdown is the only one confirmed to have drifted; the rest need a per-component diff, so that's tracked separately for a follow-up.

`Display/Dropdown → TruncatedItemsTooltipOnRight` was an opt-in demo and is now a story about the default, so it's renamed `TruncatedItems`, with a third item that overrides the side and a Playwright assertion for each half.

The alternative flat `tooltipSide` prop is left out, per the review.

## Tickets?

n/a

## Contribution checklist?

- [x] You've done enough research before writing
- [x] You have reviewed the PR
- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [x] Assets or static content are linked and stored in the project
- [x] For documentation, guides or references, you've tested the commands

## Security checklist?

- [x] All user inputs are validated and sanitized
- [x] No usage of `dangerouslySetInnerHTML`
- [x] Sensitive data has been identified and is being protected properly
- [x] Build output contains no secrets or API keys

## Preview?

Local: `yarn typecheck`, `yarn lint` (0 errors, 14 pre-existing warnings, none in touched files), `yarn lint:css`, `yarn format`, `yarn test` (544 passed), `yarn circular-dependency:check`, `yarn build`, `yarn changeset:verify`.

Dockerized Playwright — `tests/display/ellipsis-content.spec.ts` + `tests/overlays/genericmenu.spec.ts`, **37 passed**, every existing snapshot unchanged. The two new assertions cover the default reaching `EllipsisContent` through `Dropdown.Item` → `IconWrapper` (`data-side="right"` with no prop passed) and the override winning (`data-side="bottom"`).

Type-level checks, confirmed then reverted:

- `<EllipsisContent tooltipProps={{ maxWidth: '20rem' }}>` now errors; `{ side, align, sideOffset }` compiles.
- A wrapper typed `(props: DropdownItemProps) => …` from the barrel accepts `tooltipProps`, `type="danger"`, `icon` and `iconDir` — the reviewer's actual blocker.
- `dist/types/components/Dropdown/Dropdown.types.d.ts` carries all four members after `yarn build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
