### PR TITLE
fix(EllipsisContent): hide tooltip on cursor leaving the trigger

### DIFF
--- a/.changeset/hide-ellipsis-content-tooltip.md
+++ b/.changeset/hide-ellipsis-content-tooltip.md
@@ -2,7 +2,7 @@
 "@clickhouse/click-ui": patch
 ---
 
-Hides Tooltip when cursor levaes the trigger in ElipsisContent.
+Hides Tooltip when cursor leaves the trigger in ElipsisContent.
 
 Default Tooltip behavior can obscure interaction with neighbouring elements by remaining on screen when you move your cursor from the trigger to the tooltip.
 For EllipsisContent, it should always hide in these situations. Its purpose is to reveal the full content, never to be interacted with.

--- a/.changeset/hide-ellipsis-content-tooltip.md
+++ b/.changeset/hide-ellipsis-content-tooltip.md
@@ -1,0 +1,9 @@
+---
+"@clickhouse/click-ui": patch
+---
+
+Hides Tooltip when cursor levaes the trigger in ElipsisContent.
+
+Default Tooltip behavior can obscure interaction with neighbouring elements by remaining on screen when you move your cursor from the trigger to the tooltip.
+For EllipsisContent, it should always hide in these situations. Its purpose is to reveal the full content, never to be interacted with.
+If you need to interact with tooltip content, you need another component.

--- a/src/components/EllipsisContent/EllipsisContent.tsx
+++ b/src/components/EllipsisContent/EllipsisContent.tsx
@@ -51,7 +51,7 @@ const EllipsisContentComponent = <T extends ElementType = 'div'>(
   }
 
   return (
-    <Tooltip>
+    <Tooltip disableHoverableContent>
       <Tooltip.Trigger asChild>{content}</Tooltip.Trigger>
       <Tooltip.Content {...tooltipProps}>{tooltipContent}</Tooltip.Content>
     </Tooltip>


### PR DESCRIPTION
Default Tooltip behavior can obscure interaction with neighbouring elements by remaining on screen when you move your cursor from the trigger to the tooltip. For `EllipsisContent`, it should always hide in these situations. Its purpose is to reveal the full content, never to be interacted with. If you need to interact with tooltip content, you need another component.