### PR TITLE
fix(CI): Unblock contributions code checks

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,8 +1,14 @@
 name: Code quality checks
 
 on:
-  push:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+      # Maintenance branches for stable/rc releases
+      - 'chore/v*'
+  # Runs for fork PRs as well (a `push` event only fires in the fork).
+  pull_request:
 
 env:
   HUSKY: 0

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,8 +1,14 @@
 name: Unit tests
 
 on:
-  push:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+      # Maintenance branches for stable/rc releases
+      - 'chore/v*'
+  # Runs for fork PRs as well (a `push` event only fires in the fork).
+  pull_request:
 
 env:
   HUSKY: 0


### PR DESCRIPTION
## Description

Current external contribution PRs cannot run necessary code checks.
This adjustments resolves it.

Note: previous adjustment fixed similar issue with errors on the fork checks, this is a follow up in a way.

No regressions expected

Examples of PRs:
- https://github.com/ClickHouse/click-ui/pull/1165
- https://github.com/ClickHouse/click-ui/pull/1158
- https://github.com/ClickHouse/click-ui/pull/1140