### PR TITLE
fix(IconButton): keep xs size at 16px with the border

### DIFF
--- a/src/components/IconButton/IconButton.module.css
+++ b/src/components/IconButton/IconButton.module.css
@@ -1,6 +1,7 @@
 /* stylelint-disable custom-property-pattern -- design tokens use camelCase (e.g. iconButton) */
 
 .iconbutton {
+  box-sizing: border-box;
   padding: var(--click-button-iconButton-default-space-y)
     var(--click-button-iconButton-default-space-x);
   border: var(--click-button-stroke) solid;
@@ -19,8 +20,9 @@
 }
 
 .iconbutton_size_xs {
-  padding: var(--click-button-iconButton-xs-space-y)
-    var(--click-button-iconButton-xs-space-x);
+  /* Border adds 2px; drop 1px padding per side so xs stays 16×16. */
+  padding: calc(var(--click-button-iconButton-xs-space-y) - 1px)
+    calc(var(--click-button-iconButton-xs-space-x) - 1px);
 }
 
 .iconbutton_type_primary {


### PR DESCRIPTION
xs IconButton is supposed to be 16×16. The 1px stroke sat outside the padding box. Use border-box sizing and drop 1px of xs padding per side.

Fixes #539
