### PR TITLE
chore(docs): Display current CUI version in SB docs

### DIFF
--- a/.github/workflows/storybook-vercel.yml
+++ b/.github/workflows/storybook-vercel.yml
@@ -114,7 +114,13 @@ jobs:
         run: npm install --global vercel@41.7.3
 
       - name: Build Storybook
-        run: yarn storybook:build
+        # The version badge in the Storybook UI comes from package.json on the
+        # checked-out ref (the release tag on release events).
+        shell: bash
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "📦 Building Storybook for @clickhouse/click-ui v$VERSION (commit $GITHUB_SHA)" | tee -a "$GITHUB_STEP_SUMMARY"
+          yarn storybook:build
 
       - name: Package Storybook for Vercel
         # Static Build Output API v3, hand-built: no `vercel pull` / `vercel build`

--- a/.storybook/theme.ts
+++ b/.storybook/theme.ts
@@ -2,13 +2,18 @@
 
 import { create } from "storybook/theming/create";
 
+import { version } from "../package.json";
+
+export const brandVersion = `v${version}`;
+const brandLabel = `Click UI | ${brandVersion}`;
+
 export default create({
   base: "dark",
   colorPrimary: '#FAFF69',
   colorSecondary: '#FAFF69',
-  brandTitle: "ClickUI Storybook",
+  // renders as raw HTML inside the logo link
+  brandTitle: `<img src="/logo.svg" alt="${brandLabel}" title="${brandLabel}" style="height:40px" /><span style="margin-left:8px;font-size:12px;font-weight:400;opacity:.55;white-space:nowrap">${brandVersion}</span>`,
   brandUrl: "/",
-  brandImage: "/logo.svg",
   brandTarget: "_self",
   fontBase:  `"Inter", "SF Pro Display", -apple-system,
   BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,


### PR DESCRIPTION
## Description

Shows current version in Storybook for easy identification.

## Screenshots

Before 😢 
<img width="307" height="97" alt="image" src="https://github.com/user-attachments/assets/d5475407-7ad9-47b5-b4ac-8186bc2f74c2" />


After 🥳 
<img width="311" height="115" alt="image" src="https://github.com/user-attachments/assets/b7cc8676-108d-4107-9382-e6aff7bdc5c3" />
