### PR TITLE
fix(CardHorizontal): prevent duplicate button clicks

### DIFF
--- a/.changeset/fix-card-horizontal-button-bubbling.md
+++ b/.changeset/fix-card-horizontal-button-bubbling.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': patch
+---
+
+Prevent CardHorizontal button clicks from triggering the card handler twice.

--- a/src/components/CardHorizontal/CardHorizontal.test.tsx
+++ b/src/components/CardHorizontal/CardHorizontal.test.tsx
@@ -1,4 +1,5 @@
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { CardHorizontal, CardHorizontalProps } from '@/components/CardHorizontal';
 import { renderCUI } from '@/utils/test-utils';
 
@@ -204,6 +205,33 @@ describe('CardHorizontal Component', () => {
     wrapper.click();
 
     expect(windowOpenSpy).not.toHaveBeenCalled();
+    windowOpenSpy.mockRestore();
+  });
+
+  it('should call onButtonClick only once when the inner button is clicked', async () => {
+    const onButtonClick = vitest.fn();
+    const { getByRole } = renderCard({
+      title: 'Test Card',
+      infoText: 'Click me',
+      onButtonClick,
+    });
+
+    await userEvent.click(getByRole('button'));
+
+    expect(onButtonClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should open infoUrl only once when the inner button is clicked', async () => {
+    const windowOpenSpy = vitest.spyOn(window, 'open').mockImplementation(() => null);
+    const { getByRole } = renderCard({
+      title: 'Test Card',
+      infoText: 'Click me',
+      infoUrl: 'https://example.com',
+    });
+
+    await userEvent.click(getByRole('button'));
+
+    expect(windowOpenSpy).toHaveBeenCalledTimes(1);
     windowOpenSpy.mockRestore();
   });
 });

--- a/src/components/CardHorizontal/CardHorizontal.tsx
+++ b/src/components/CardHorizontal/CardHorizontal.tsx
@@ -95,6 +95,10 @@ export const CardHorizontal = ({
       window.open(infoUrl, '_blank');
     }
   };
+  const handleButtonClick = (e: React.MouseEvent<HTMLElement>) => {
+    e.stopPropagation();
+    handleClick(e);
+  };
   return (
     <div
       tabIndex={disabled ? -1 : 0}
@@ -174,7 +178,7 @@ export const CardHorizontal = ({
           >
             <Button
               label={infoText}
-              onClick={handleClick}
+              onClick={handleButtonClick}
               disabled={disabled}
               fillWidth
             />


### PR DESCRIPTION
## What changed

- Stop the inner button click from bubbling to the card
- The inner info button no longer triggers the card public `onClick` handler, including when `onClick` is passed through `...props`
- Add tests for onButtonClick and window.open call counts
- Add a patch changeset

## Why

When a CardHorizontal has an info button, clicking it also triggers the card handler. This could call the callback and open the URL twice.

## Checks

- corepack yarn test --run
- corepack yarn typecheck
- corepack yarn format
- corepack yarn lint:code