### PR TITLE
fix(Loaders): use valid 0% keyframe selector for horizontal-circle animations

### DIFF
--- a/.changeset/fix-loaders-invalid-keyframe-selector.md
+++ b/.changeset/fix-loaders-invalid-keyframe-selector.md
@@ -1,0 +1,5 @@
+---
+'@clickhouse/click-ui': patch
+---
+
+Fixed the horizontal-circle loader animations, which used the invalid keyframe selector `0` instead of `0%`, causing the initial keyframe to be dropped by browsers that don't tolerate the unitless selector.

--- a/src/components/Assets/Icons/Loaders.module.css
+++ b/src/components/Assets/Icons/Loaders.module.css
@@ -36,7 +36,7 @@
 }
 
 @keyframes loaders-horizontal-circle-1 {
-  0 {
+  0% {
     r: 0;
   }
 
@@ -54,7 +54,7 @@
 }
 
 @keyframes loaders-horizontal-circle-2 {
-  0 {
+  0% {
     r: 0;
   }
 
@@ -76,7 +76,7 @@
 }
 
 @keyframes loaders-horizontal-circle-3 {
-  0 {
+  0% {
     r: 0;
   }
 


### PR DESCRIPTION
## Why?

While experimenting with CUI, I ran into some warning at build time that seems to be coming from this changed file.

The Error:

```bash
▲ [WARNING] Expected percentage but found "0" [css-syntax-error]

    <stdin>:810:2:
      810 │   0 {
          ╵   ^
```
## How?

- Replace the wrong keyframe percentage value from `0` to `0%`
